### PR TITLE
Update Verilator to 5.002

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -19,7 +19,7 @@ jobs:
       SCCACHE_VERSION: 0.3.3
       RISCV_VERSION: v12.1.0
       # TODO: To update to 5.006, clean up lint errors
-      VERILATOR_VERSION: v4.228
+      VERILATOR_VERSION: v5.002
       PKG_CONFIG_PATH: /opt/verilator/share/pkgconfig
       SCCACHE_GHA_CACHE_TO: sccache-verilator-10000
       SCCACHE_GHA_CACHE_FROM: sccache-verilator-


### PR DESCRIPTION
The QSPI flash model used requires the --timing flag