### PR TITLE
CI for regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,21 @@ on:
 
 jobs:
 
-  Test:
+  verilator:
+    name: Build Verilator
     runs-on: ubuntu-latest
     env:
       CCACHE_DIR: "/opt/caliptra-rtl/.cache/"
+      DEBIAN_FRONTEND: "noninteractive"
 
     steps:
-      - name: Install utils
+      - name: Install prerequisities
         run: |
           sudo apt -qqy update && sudo apt -qqy --no-install-recommends install \
             git autoconf automake autotools-dev curl python3 python3-pip \
             libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex \
             texinfo gperf libtool patchutils bc zlib1g zlib1g-dev libexpat-dev \
-            ninja-build ccache libfl2 libfl-dev gcc-riscv64-unknown-elf
+            ninja-build ccache libfl2 libfl-dev
 
       - name: Create Cache Timestamp
         id: cache_timestamp
@@ -45,7 +47,63 @@ jobs:
             make -j `nproc`
             make install
           popd
- 
+          cd /opt && tar -czvf verilator.tar.gz verilator/
+
+      - name: Store Verilator binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: verilator
+          path: /opt/*.tar.gz
+
+  tests:
+    name: L0 regression tests
+    runs-on: ubuntu-latest
+    needs: verilator
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - name: smoke_test_veer
+          - name: smoke_test_mbox
+          - name: smoke_test_sha512
+          - name: smoke_test_sha256
+          - name: smoke_test_sha_accel
+          - name: smoke_test_ecc
+          - name: smoke_test_hmac
+          - name: smoke_test_kv
+          - name: smoke_test_sram_ecc
+          - name: smoke_test_kv_uds_reset
+          - name: smoke_test_kv_securitystate
+          - name: smoke_test_kv_ecc_flow
+          - name: smoke_test_kv_hmac_flow
+          - name: smoke_test_kv_sha512_flow
+          - name: memCpy_ROM_to_dccm
+          - name: memCpy_dccm_to_iccm
+          - name: hello_world_iccm
+          - name: iccm_lock
+          - name: c_intr_handler
+          - name: kv_pcr_hash_extend
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+
+    steps:
+      - name: Install utils
+        run: |
+          sudo apt -qqy update && sudo apt -qqy --no-install-recommends install \
+            git python3 python3-pip build-essential ninja-build ccache \
+            gcc-riscv64-unknown-elf
+
+      - name: Download verilator binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: verilator
+          path: /opt
+
+      - name: Unpack verilator binaries
+        run: |
+          cd /opt && tar -zxvf verilator.tar.gz 
+
       - name: Setup repository
         uses: actions/checkout@v2
         with:
@@ -60,4 +118,6 @@ jobs:
         run: |
           export PATH=/opt/verilator/bin:$PATH
           export WORKSPACE=$GITHUB_WORKSPACE
-          python3 Caliptra/tools/scripts/run_verilator_l0_regression.py
+          make -f Caliptra/tools/scripts/Makefile \
+               TESTNAME=${{ matrix.test.name }} \
+               verilator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
 
   Test:
     runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: "/opt/caliptra-rtl/.cache/"
 
     steps:
       - name: Install utils
@@ -17,7 +19,21 @@ jobs:
             libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex \
             texinfo gperf libtool patchutils bc zlib1g zlib1g-dev libexpat-dev \
             ninja-build ccache libfl2 libfl-dev gcc-riscv64-unknown-elf
-          pip install pyyaml
+
+      - name: Create Cache Timestamp
+        id: cache_timestamp
+        uses: nanzm/get-time-action@v1.1
+        with:
+          format: 'YYYY-MM-DD-HH-mm-ss'
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        timeout-minutes: 3
+        continue-on-error: true
+        with:
+          path: "/opt/caliptra-rtl/.cache/"
+          key: cache_${{ steps.cache_timestamp.outputs.time }}
+          restore-keys: cache_
 
       - name: Build Verilator
         run: |
@@ -35,6 +51,10 @@ jobs:
         with:
           submodules: recursive
           path: Caliptra
+
+      - name: Install Python dependencies
+        run: |
+          cd Caliptra && pip install -r requirements.txt
 
       - name: Run L0 smoke test regression suite
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: L0 smoke test regression suite
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install utils
+        run: |
+          sudo apt -qqy update && sudo apt -qqy --no-install-recommends install \
+            git autoconf automake autotools-dev curl python3 python3-pip \
+            libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex \
+            texinfo gperf libtool patchutils bc zlib1g zlib1g-dev libexpat-dev \
+            ninja-build ccache libfl2 libfl-dev gcc-riscv64-unknown-elf
+          pip install pyyaml
+
+      - name: Build Verilator
+        run: |
+          git clone https://github.com/verilator/verilator
+          pushd verilator
+            git checkout v5.002
+            autoconf
+            ./configure --prefix=/opt/verilator
+            make -j `nproc`
+            make install
+          popd
+ 
+      - name: Setup repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          path: Caliptra
+
+      - name: Run L0 smoke test regression suite
+        run: |
+          export PATH=/opt/verilator/bin:$PATH
+          export WORKSPACE=$GITHUB_WORKSPACE
+          python3 Caliptra/tools/scripts/run_verilator_l0_regression.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/picolibc"]
+	path = third_party/picolibc
+	url = https://github.com/picolibc/picolibc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+meson

--- a/src/integration/test_suites/libs/picolibc/Makefile
+++ b/src/integration/test_suites/libs/picolibc/Makefile
@@ -19,13 +19,15 @@ strip = '$(GCC_PREFIX)-strip'
 
 [host_machine]
 system     = 'unknown'
-cpu_family = 'riscv'
+cpu_family = 'riscv64'
 cpu        = 'riscv'
 endian     = 'little'
 
-[built-in options]
-c_args      = [ $(foreach flag,$(filter-out $(DEPFLAGS) -flto,$(CFLAGS)),'$(flag)',) ]
-c_link_args = [ $(foreach flag,$(filter-out -flto,$(LDFLAGS)),'$(flag)',) ]
+[properties]
+# this uses shorter but slower function entry code
+c_args = [ '-msave-restore' ]
+# default multilib is 64 bit
+c_args_ = [ '-mcmodel=medany' ]
 endef
 
 export CROSSFILE
@@ -39,7 +41,8 @@ $(BUILD_PATH)/cross.txt: | $(BUILD_PATH)
 $(BUILD_PATH)/libc.a: $(BUILD_PATH)/cross.txt | $(BUILD_PATH)
 
 	cd $(PICOLIBC_PATH) && meson $(BUILD_PATH) \
-		-Dmultilib=false \
+		-Dmultilib=true \
+		-Dmultilib-list=rv32imac/ilp32 \
 		-Dpicocrt=false \
 		-Datomic-ungetc=false \
 		-Dthread-local-storage=false \
@@ -50,8 +53,11 @@ $(BUILD_PATH)/libc.a: $(BUILD_PATH)/cross.txt | $(BUILD_PATH)
 		--cross-file $(BUILD_PATH)/cross.txt
 
 	cd $(BUILD_PATH) && meson compile
-	cp $(BUILD_PATH)/newlib/libc.a $@
+	cp $(BUILD_PATH)/newlib/librv32imac_ilp32/*.a $(BUILD_PATH)/
 
 all: $(BUILD_PATH)/libc.a | $(BUILD_PATH)
 
-.PHONY: all
+clean:
+	rm -rf $(BUILD_PATH)
+
+.PHONY: all clean

--- a/src/integration/test_suites/libs/picolibc/Makefile
+++ b/src/integration/test_suites/libs/picolibc/Makefile
@@ -1,0 +1,57 @@
+GCC_PREFIX    ?= riscv64-unknown-elf
+MAKEFILE_PATH  = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+PICOLIBC_PATH  = $(abspath $(MAKEFILE_PATH)/../../../../../third_party/picolibc)
+BUILD_PATH     = $(PICOLIBC_PATH)/build
+
+ifeq ($(CCACHE), )
+	MESON_CROSS_CC = '$(GCC_PREFIX)-gcc'
+else
+	MESON_CROSS_CC = ['$(CCACHE)', '$(GCC_PREFIX)-gcc']
+endif
+
+define CROSSFILE
+[binaries]
+c     = $(MESON_CROSS_CC)
+ar    = '$(GCC_PREFIX)-gcc-ar'
+as    = '$(GCC_PREFIX)-as'
+nm    = '$(GCC_PREFIX)-gcc-nm'
+strip = '$(GCC_PREFIX)-strip'
+
+[host_machine]
+system     = 'unknown'
+cpu_family = 'riscv'
+cpu        = 'riscv'
+endian     = 'little'
+
+[built-in options]
+c_args      = [ $(foreach flag,$(filter-out $(DEPFLAGS) -flto,$(CFLAGS)),'$(flag)',) ]
+c_link_args = [ $(foreach flag,$(filter-out -flto,$(LDFLAGS)),'$(flag)',) ]
+endef
+
+export CROSSFILE
+
+$(BUILD_PATH):
+	mkdir -p $@
+
+$(BUILD_PATH)/cross.txt: | $(BUILD_PATH)
+	@echo "$$CROSSFILE" > $@
+
+$(BUILD_PATH)/libc.a: $(BUILD_PATH)/cross.txt | $(BUILD_PATH)
+
+	cd $(PICOLIBC_PATH) && meson $(BUILD_PATH) \
+		-Dmultilib=false \
+		-Dpicocrt=false \
+		-Datomic-ungetc=false \
+		-Dthread-local-storage=false \
+		-Dio-long-long=true \
+		-Dformat-default=integer \
+		-Dincludedir=picolibc/$(GCC_PREFIX)/include \
+		-Dlibdir=picolibc/$(GCC_PREFIX)/lib \
+		--cross-file $(BUILD_PATH)/cross.txt
+
+	cd $(BUILD_PATH) && meson compile
+	cp $(BUILD_PATH)/newlib/libc.a $@
+
+all: $(BUILD_PATH)/libc.a | $(BUILD_PATH)
+
+.PHONY: all

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -20,17 +20,16 @@ ABI = -mabi=ilp32 -march=rv32imac
 VERILATOR = verilator
 GCC_PREFIX = riscv64-unknown-elf
 BUILD_DIR = $(CURDIR)
-WORKSPACE = $(shell echo ${PWD\/caliptra-rtl*/\/caliptra-rtl}) 
 
 # Define test name
 TESTNAME ?= iccm_lock
-TEST_DIR = $(WORKSPACE)/src/integration/test_suites/$(TESTNAME)
-HEX_DIR = $(WORKSPACE)/src/integration/test_suites/hex
-INCLUDES_DIR = $(WORKSPACE)/src/integration/test_suites/includes
-TBDIR = $(WORKSPACE)/src/integration/tb
-RISCV_HW_IF_DIR = $(WORKSPACE)/src/integration/test_suites/libs/riscv_hw_if
-ISR_DIR    = $(WORKSPACE)/src/integration/test_suites/libs/caliptra_isr
-PRINTF_DIR = $(WORKSPACE)/src/integration/test_suites/libs/printf
+TEST_DIR = $(WORKSPACE)/Caliptra/src/integration/test_suites/$(TESTNAME)
+HEX_DIR = $(WORKSPACE)/Caliptra/src/integration/test_suites/hex
+INCLUDES_DIR = $(WORKSPACE)/Caliptra/src/integration/test_suites/includes
+TBDIR = $(WORKSPACE)/Caliptra/src/integration/tb
+RISCV_HW_IF_DIR = $(WORKSPACE)/Caliptra/src/integration/test_suites/libs/riscv_hw_if
+ISR_DIR    = $(WORKSPACE)/Caliptra/src/integration/test_suites/libs/caliptra_isr
+PRINTF_DIR = $(WORKSPACE)/Caliptra/src/integration/test_suites/libs/printf
 
 # Determine test directory
 #ifneq (,$(wildcard $(TBDIR)/tests/$(TEST)))
@@ -46,10 +45,10 @@ COMP_LIB_NAMES := aes \
 		  sha256 \
 		  sha512 \
 		  soc_ifc
-COMP_LIBS := $(foreach name, $(COMP_LIB_NAMES), $(WORKSPACE)/src/integration/test_suites/libs/$(name))
+COMP_LIBS := $(foreach name, $(COMP_LIB_NAMES), $(WORKSPACE)/Caliptra/src/integration/test_suites/libs/$(name))
 HEADER_FILES := $(INCLUDES_DIR)/caliptra_defines.h \
 		$(INCLUDES_DIR)/defines.h \
-		$(WORKSPACE)/src/integration/rtl/caliptra_reg.h  \
+		$(WORKSPACE)/Caliptra/src/integration/rtl/caliptra_reg.h  \
 		$(RISCV_HW_IF_DIR)/riscv_hw_if.h \
 		$(wildcard $(TEST_DIR)/*.h) \
 		$(PRINTF_DIR)/printf.h \

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -210,7 +210,7 @@ else
 # Build program.hex from source (test_suites)
 program.hex: $(OFILE_CRT) $(OFILES) $(LINK)
 	@echo Building $(TESTNAME)
-	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map -lc -T$(LINK) -o $(TESTNAME).exe $(OFILE_CRT) $(OFILES) -nostartfiles -nostdlib -L$(PICOLIBC_DIR)/build $(TEST_LIBS)
+	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map -T$(LINK) -o $(TESTNAME).exe $(OFILE_CRT) $(OFILES) -nostartfiles -nostdlib -fno-builtin -L$(PICOLIBC_DIR)/build -lc $(TEST_LIBS)
 	-$(GCC_PREFIX)-objcopy -O verilog -R .data_iccm0 -R .data_iccm1 -R .data_iccm2 -R .iccm -R .dccm -R .eh_frame --pad-to 0x8000 --no-change-warnings $(TESTNAME).exe program.hex
 	-$(GCC_PREFIX)-objcopy -O verilog -j .data_iccm0 -j .data_iccm1 -j .data_iccm2 -j .dccm \
 			      --change-section-lma .data_iccm0-0x50000000 \
@@ -230,7 +230,7 @@ program.hex: $(OFILE_CRT) $(OFILES) $(LINK)
 # Entire image will be loaded into the mailbox, so it must fit the 128KiB memory
 %.hex: $(OFILES) $(LINK)
 	@echo Building $(TESTNAME)
-	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map -lc -T$(LINK) -o $(TESTNAME).exe $(OFILES) -nostartfiles -nostdlib -L$(PICOLIBC_DIR)/build  $(TEST_LIBS)
+	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map,--verbose -T$(LINK) -o $(TESTNAME).exe $(OFILES) -nostartfiles -nostdlib -fno-builtin -L$(PICOLIBC_DIR)/build -lc $(TEST_LIBS)
 	-$(GCC_PREFIX)-objcopy -O verilog -R .eh_frame --pad-to 0x20000 --no-change-warnings $(TESTNAME).exe $@
 	$(GCC_PREFIX)-objdump -S  $(TESTNAME).exe > $(TESTNAME).dis
 	$(GCC_PREFIX)-size        $(TESTNAME).exe | tee $(TESTNAME).size
@@ -238,12 +238,12 @@ program.hex: $(OFILE_CRT) $(OFILES) $(LINK)
 
 %.o : %.s $(HEADER_FILES)
 	cp $(HEADER_FILES) $(BUILD_DIR)
-	$(GCC_PREFIX)-cpp $(includes) -I$(TEST_DIR) -nostdlib $<  > $*.cpp.s
+	$(GCC_PREFIX)-cpp $(includes) -I$(TEST_DIR) -nostdlib -fno-builtin $<  > $*.cpp.s
 	$(GCC_PREFIX)-as $(ABI) $*.cpp.s -o $@
 
 %.o : %.c $(HEADER_FILES)
 	cp $(HEADER_FILES) $(BUILD_DIR)
-	$(GCC_PREFIX)-gcc $(includes) $(TEST_CFLAGS) -I$(PICOLIBC_DIR)/newlib/libc/include -I$(PICOLIBC_DIR)/build -DCOMPILER_FLAGS="\"$(TEST_CFLAGS)\"" $(ABI) -nostdlib -c $< -o $@
+	$(GCC_PREFIX)-gcc $(includes) $(TEST_CFLAGS) -I$(PICOLIBC_DIR)/newlib/libc/include -I$(PICOLIBC_DIR)/build -DCOMPILER_FLAGS="\"$(TEST_CFLAGS)\"" $(ABI) -nostdlib -fno-builtin -c $< -o $@
 
 endif
 

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -21,6 +21,8 @@ VERILATOR = verilator
 GCC_PREFIX = riscv64-unknown-elf
 BUILD_DIR = $(CURDIR)
 
+PICOLIBC_DIR = $(WORKSPACE)/Caliptra/third_party/picolibc
+
 # Define test name
 TESTNAME ?= iccm_lock
 TEST_DIR = $(WORKSPACE)/Caliptra/src/integration/test_suites/$(TESTNAME)
@@ -169,7 +171,10 @@ verilator-build: $(TBFILES) $(INCLUDES_DIR)/defines.h test_caliptra_top_tb.cpp
 
 ############ TEST Simulation ###############################
 
-verilator: program.hex verilator-build
+picolibc:
+	$(MAKE) -f $(WORKSPACE)/Caliptra/src/integration/test_suites/libs/picolibc/Makefile all
+
+verilator: picolibc program.hex verilator-build
 	./obj_dir/Vcaliptra_top_tb
 
 ############ TEST build ###############################
@@ -205,7 +210,7 @@ else
 # Build program.hex from source (test_suites)
 program.hex: $(OFILE_CRT) $(OFILES) $(LINK)
 	@echo Building $(TESTNAME)
-	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map -lgcc -T$(LINK) -o $(TESTNAME).exe $(OFILE_CRT) $(OFILES) -nostartfiles  $(TEST_LIBS)
+	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map -lc -T$(LINK) -o $(TESTNAME).exe $(OFILE_CRT) $(OFILES) -nostartfiles -nostdlib -L$(PICOLIBC_DIR)/build $(TEST_LIBS)
 	-$(GCC_PREFIX)-objcopy -O verilog -R .data_iccm0 -R .data_iccm1 -R .data_iccm2 -R .iccm -R .dccm -R .eh_frame --pad-to 0x8000 --no-change-warnings $(TESTNAME).exe program.hex
 	-$(GCC_PREFIX)-objcopy -O verilog -j .data_iccm0 -j .data_iccm1 -j .data_iccm2 -j .dccm \
 			      --change-section-lma .data_iccm0-0x50000000 \
@@ -225,7 +230,7 @@ program.hex: $(OFILE_CRT) $(OFILES) $(LINK)
 # Entire image will be loaded into the mailbox, so it must fit the 128KiB memory
 %.hex: $(OFILES) $(LINK)
 	@echo Building $(TESTNAME)
-	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map -lgcc -T$(LINK) -o $(TESTNAME).exe $(OFILES) -nostartfiles  $(TEST_LIBS)
+	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map -lc -T$(LINK) -o $(TESTNAME).exe $(OFILES) -nostartfiles -nostdlib -L$(PICOLIBC_DIR)/build  $(TEST_LIBS)
 	-$(GCC_PREFIX)-objcopy -O verilog -R .eh_frame --pad-to 0x20000 --no-change-warnings $(TESTNAME).exe $@
 	$(GCC_PREFIX)-objdump -S  $(TESTNAME).exe > $(TESTNAME).dis
 	$(GCC_PREFIX)-size        $(TESTNAME).exe | tee $(TESTNAME).size
@@ -233,12 +238,12 @@ program.hex: $(OFILE_CRT) $(OFILES) $(LINK)
 
 %.o : %.s $(HEADER_FILES)
 	cp $(HEADER_FILES) $(BUILD_DIR)
-	$(GCC_PREFIX)-cpp $(includes) -I$(TEST_DIR)  $<  > $*.cpp.s
+	$(GCC_PREFIX)-cpp $(includes) -I$(TEST_DIR) -nostdlib $<  > $*.cpp.s
 	$(GCC_PREFIX)-as $(ABI) $*.cpp.s -o $@
 
 %.o : %.c $(HEADER_FILES)
 	cp $(HEADER_FILES) $(BUILD_DIR)
-	$(GCC_PREFIX)-gcc $(includes) $(TEST_CFLAGS) -DCOMPILER_FLAGS="\"$(TEST_CFLAGS)\"" $(ABI) -nostdlib -c $< -o $@
+	$(GCC_PREFIX)-gcc $(includes) $(TEST_CFLAGS) -I$(PICOLIBC_DIR)/newlib/libc/include -I$(PICOLIBC_DIR)/build -DCOMPILER_FLAGS="\"$(TEST_CFLAGS)\"" $(ABI) -nostdlib -c $< -o $@
 
 endif
 


### PR DESCRIPTION
This PR adds a CI for the regression tests suite.

The CI first builds Verilator and then invokes all the regression tests in parallel.

The RISC-V toolchain for the tests' firmware is installed from a package. The C library has been replaced with `picolibc`. This is because the toolchain comes without `libc` and building it would be unnecessarily time consuming.