### PR TITLE
Update VeeR-EL2 codebase

### DIFF
--- a/src/integration/rtl/caliptra_top.sv
+++ b/src/integration/rtl/caliptra_top.sv
@@ -505,6 +505,7 @@ el2_veer_wrapper rvtop (
     .soft_int               (soft_int),
     .core_id                ('0),
     .scan_mode              ( cptra_scan_mode_Latched ), // To enable scan mode
+    .scan_rst_l             ( 1'b1 ),
     .mbist_mode             ( 1'b0 )        // to enable mbist
 
 );

--- a/src/riscv_core/veer_el2/rtl/el2_veer.sv
+++ b/src/riscv_core/veer_el2/rtl/el2_veer.sv
@@ -32,7 +32,7 @@ import el2_pkg::*;
    input logic [31:1]           rst_vec,
    input logic                  nmi_int,
    input logic [31:1]           nmi_vec,
-   output logic                 core_rst_l,   // This is "rst_l | dbg_rst_l"
+   output logic                 core_rst_l,   // This is "rst_l & (scan_rst_l | scan_mode)"
 
    output logic                 active_l2clk,
    output logic                 free_l2clk,
@@ -380,7 +380,8 @@ import el2_pkg::*;
    input logic [pt.PIC_TOTAL_INT:1]           extintsrc_req,
    input logic                   timer_int,
    input logic                   soft_int,
-   input logic                   scan_mode
+   input logic                   scan_mode,
+   input logic                   scan_rst_l
 );
 
 
@@ -856,7 +857,7 @@ import el2_pkg::*;
 
    // -----------------   DEBUG END -----------------------------
 
-   assign core_rst_l = rst_l & (dbg_core_rst_l | scan_mode);
+   assign core_rst_l = rst_l & (scan_rst_l | scan_mode);
    // fetch
    el2_ifu #(.pt(pt)) ifu (
                             .clk(active_l2clk),

--- a/src/riscv_core/veer_el2/rtl/el2_veer_wrapper.sv
+++ b/src/riscv_core/veer_el2/rtl/el2_veer_wrapper.sv
@@ -335,6 +335,7 @@ import soc_ifc_pkg::*;
    input logic                             i_cpu_run_req, // Async restart req to CPU
    output logic                            o_cpu_run_ack, // Core response to run req
    input logic                             scan_mode,     // To enable scan mode
+   input logic                             scan_rst_l,
    input logic                             mbist_mode     // to enable mbist
 );
 

--- a/src/riscv_core/veer_el2/rtl/lib/beh_lib.sv
+++ b/src/riscv_core/veer_el2/rtl/lib/beh_lib.sv
@@ -291,7 +291,7 @@ endmodule
 // special power flop for predict packet
 // format: { LEFT, RIGHT==31 }
 // LEFT # of bits will be done with rvdffe; RIGHT is enabled by LEFT[LSB] & en
-module rvdffppe #( parameter WIDTH=32 )
+module rvdffppe #( parameter integer WIDTH = 39 )
    (
      input  logic [WIDTH-1:0] din,
      input  logic             clk,
@@ -301,13 +301,13 @@ module rvdffppe #( parameter WIDTH=32 )
      output logic [WIDTH-1:0] dout
      );
 
-   localparam RIGHT = 31;
-   localparam LEFT = WIDTH - RIGHT;
+   localparam integer RIGHT = 31;
+   localparam integer LEFT  = WIDTH - RIGHT;
 
-   localparam LMSB = WIDTH-1;
-   localparam LLSB = LMSB-LEFT+1;
-   localparam RMSB = LLSB-1;
-   localparam RLSB = LLSB-RIGHT;
+   localparam integer LMSB  = WIDTH-1;
+   localparam integer LLSB  = LMSB-LEFT+1;
+   localparam integer RMSB  = LLSB-1;
+   localparam integer RLSB  = LLSB-RIGHT;
 
 
 `ifndef RV_PHYSICAL
@@ -748,7 +748,7 @@ module rvecc_decode_64  (
 
  endmodule // rvecc_decode_64
 
-
+`ifndef TECH_SPECIFIC_EC_RV_ICG
 module `TEC_RV_ICG
   (
    input logic SE, EN, CK,
@@ -773,6 +773,7 @@ module `TEC_RV_ICG
    assign Q = CK & en_ff;
 
 endmodule
+`endif
 
 `ifndef RV_FPGA_OPTIMIZE
 module rvclkhdr
@@ -786,7 +787,11 @@ module rvclkhdr
    logic   SE;
    assign       SE = 0;
 
+`ifdef TECH_SPECIFIC_EC_RV_ICG
+   `USER_EC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+`else
    `TEC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+`endif
 
 endmodule // rvclkhdr
 `endif
@@ -805,7 +810,11 @@ module rvoclkhdr
 `ifdef RV_FPGA_OPTIMIZE
    assign l1clk = clk;
 `else
-   `TEC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+   `ifdef TECH_SPECIFIC_EC_RV_ICG
+      `USER_EC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+   `else
+      `TEC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+    `endif
 `endif
 
 endmodule

--- a/src/riscv_core/veer_el2/tb/dasm.svi
+++ b/src/riscv_core/veer_el2/tb/dasm.svi
@@ -23,7 +23,7 @@
 bit[31:0] [31:0] gpr[`RV_NUM_THREADS];
 
 // main DASM function
-function string dasm(input[31:0] opcode, input[31:0] pc, input[4:0] regn, input[31:0] regv, input tid=0);
+function static string dasm(input[31:0] opcode, input[31:0] pc, input[4:0] regn, input[31:0] regv, input tid=0);
     dasm = (opcode[1:0] == 2'b11) ? dasm32(opcode, pc, tid) : dasm16(opcode, pc, tid);
     if(regn) gpr[tid][regn] = regv;
 endfunction
@@ -31,7 +31,7 @@ endfunction
 
 ///////////////// 16 bits instructions ///////////////////////
 
-function string dasm16( input[31:0] opcode, input[31:0] pc, input tid=0);
+function static string dasm16( input[31:0] opcode, input[31:0] pc, input tid=0);
     case(opcode[1:0])
     0: return dasm16_0(opcode, tid);
     1: return dasm16_1(opcode, pc);
@@ -40,7 +40,7 @@ function string dasm16( input[31:0] opcode, input[31:0] pc, input tid=0);
     return $sformatf(".short 0x%h", opcode[15:0]);
 endfunction
 
-function string dasm16_0( input[31:0] opcode, tid);
+function static string dasm16_0( input[31:0] opcode, tid);
     case(opcode[15:13])
     3'b000: return dasm16_ciw(opcode);
     3'b001: return {"c.fld  ", dasm16_cl(opcode, tid)};
@@ -53,7 +53,7 @@ function string dasm16_0( input[31:0] opcode, tid);
     return $sformatf(".short  0x%h", opcode[15:0]);
 endfunction
 
-function string dasm16_ciw( input[31:0] opcode);
+function static string dasm16_ciw( input[31:0] opcode);
 int imm;
     imm=0;
     if(opcode[15:0] == 0) return ".short  0";
@@ -61,7 +61,7 @@ int imm;
     return $sformatf("c.addi4spn %s,0x%0h", abi_reg[opcode[4:2]+8], imm);
 endfunction
 
-function string dasm16_cl( input[31:0] opcode, input tid=0);
+function static string dasm16_cl( input[31:0] opcode, input tid=0);
 int imm;
     imm=0;
     imm[5:3] = opcode[12:10];
@@ -70,7 +70,7 @@ int imm;
     return $sformatf(" %s,%0d(%s) [%h]", abi_reg[opcode[4:2]+8], imm, abi_reg[opcode[9:7]+8], gpr[tid][opcode[9:7]+8]+imm);
 endfunction
 
-function string dasm16_1( input[31:0] opcode, input[31:0] pc);
+function static string dasm16_1( input[31:0] opcode, input[31:0] pc);
     case(opcode[15:13])
     3'b000: return opcode[11:7]==0 ? "c.nop" : {"c.addi  ",dasm16_ci(opcode)};
     3'b001: return {"c.jal   ", dasm16_cj(opcode, pc)};
@@ -83,7 +83,7 @@ function string dasm16_1( input[31:0] opcode, input[31:0] pc);
     endcase
 endfunction
 
-function string dasm16_ci( input[31:0] opcode);
+function static string dasm16_ci( input[31:0] opcode);
 int imm;
     imm=0;
     imm[4:0] = opcode[6:2];
@@ -91,7 +91,7 @@ int imm;
     return $sformatf("%s,%0d", abi_reg[opcode[11:7]], imm);
 endfunction
 
-function string dasm16_cj( input[31:0] opcode, input[31:0] pc);
+function static string dasm16_cj( input[31:0] opcode, input[31:0] pc);
 bit[31:0] imm;
     imm=0;
     {imm[11],imm[4],imm[9:8],imm[10],imm[6], imm[7],imm[3:1], imm[5]} = opcode[12:2];
@@ -99,7 +99,7 @@ bit[31:0] imm;
     return $sformatf("0x%0h", imm+pc);
 endfunction
 
-function string dasm16_cb( input[31:0] opcode, input[31:0] pc);
+function static string dasm16_cb( input[31:0] opcode, input[31:0] pc);
 bit[31:0] imm;
     imm=0;
     {imm[8],imm[4:3]} = opcode[12:10];
@@ -108,7 +108,7 @@ bit[31:0] imm;
     return $sformatf("%s,0x%0h",abi_reg[opcode[9:7]+8], imm+pc);
 endfunction
 
-function string dasm16_cr( input[31:0] opcode);
+function static string dasm16_cr( input[31:0] opcode);
 bit[31:0] imm;
 
     imm = 0;
@@ -128,7 +128,7 @@ bit[31:0] imm;
     endcase
 endfunction
 
-function string dasm16_1_3( input[31:0] opcode);
+function static string dasm16_1_3( input[31:0] opcode);
 int imm;
 
     imm=0;
@@ -145,7 +145,7 @@ int imm;
     end
 endfunction
 
-function string dasm16_2( input[31:0] opcode, input tid=0);
+function static string dasm16_2( input[31:0] opcode, input tid=0);
     case(opcode[15:13])
     3'b000: return {"c.slli  ", dasm16_ci(opcode)};
     3'b001: return {"c.fldsp ", dasm16_cls(opcode,1,tid)};
@@ -167,7 +167,7 @@ function string dasm16_2( input[31:0] opcode, input tid=0);
 endfunction
 
 
-function string dasm16_cls( input[31:0] opcode, input sh1=0, tid=0);
+function static string dasm16_cls( input[31:0] opcode, input sh1=0, tid=0);
 bit[31:0] imm;
     imm=0;
     if(sh1) {imm[4:3],imm[8:6]} = opcode[6:2];
@@ -176,7 +176,7 @@ bit[31:0] imm;
     return $sformatf("%s,0x%0h [%h]", abi_reg[opcode[11:7]], imm, gpr[tid][2]+imm);
 endfunction
 
-function string dasm16_css( input[31:0] opcode, input sh1=0, tid=0);
+function static string dasm16_css( input[31:0] opcode, input sh1=0, tid=0);
 bit[31:0] imm;
     imm=0;
     if(sh1) {imm[5:3],imm[8:6]} = opcode[12:7];
@@ -186,7 +186,7 @@ endfunction
 
 ///////////////// 32 bit instructions ///////////////////////
 
-function string dasm32( input[31:0] opcode, input[31:0] pc, input tid=0);
+function static string dasm32( input[31:0] opcode, input[31:0] pc, input tid=0);
     case(opcode[6:0])
     7'b0110111: return {"lui     ", dasm32_u(opcode)};
     7'b0010111: return {"auipc   ", dasm32_u(opcode)};
@@ -205,14 +205,14 @@ function string dasm32( input[31:0] opcode, input[31:0] pc, input tid=0);
     return $sformatf(".long   0x%h", opcode);
 endfunction
 
-function string dasm32_u( input[31:0] opcode);
+function static string dasm32_u( input[31:0] opcode);
 bit[31:0] imm;
     imm=0;
     imm[31:12] = opcode[31:12];
     return $sformatf("%s,0x%0h", abi_reg[opcode[11:7]], imm);
 endfunction
 
-function string dasm32_j( input[31:0] opcode, input[31:0] pc);
+function static string dasm32_j( input[31:0] opcode, input[31:0] pc);
 int imm;
     imm=0;
     {imm[20], imm[10:1], imm[11], imm[19:12]} = opcode[31:12];
@@ -220,7 +220,7 @@ int imm;
     return $sformatf("%s,0x%0h",abi_reg[opcode[11:7]], imm+pc);
 endfunction
 
-function string dasm32_jr( input[31:0] opcode, input[31:0] pc);
+function static string dasm32_jr( input[31:0] opcode, input[31:0] pc);
 int imm;
     imm=0;
     imm[11:1] = opcode[31:19];
@@ -228,7 +228,7 @@ int imm;
     return $sformatf("%s,%s,0x%0h",abi_reg[opcode[11:7]], abi_reg[opcode[19:15]], imm+pc);
 endfunction
 
-function string dasm32_b( input[31:0] opcode, input[31:0] pc);
+function static string dasm32_b( input[31:0] opcode, input[31:0] pc);
 int imm;
 string mn;
     imm=0;
@@ -247,7 +247,7 @@ string mn;
     return $sformatf("%s%s,%s,0x%0h", mn, abi_reg[opcode[19:15]], abi_reg[opcode[24:20]], imm+pc);
 endfunction
 
-function string dasm32_l( input[31:0] opcode, input tid=0);
+function static string dasm32_l( input[31:0] opcode, input tid=0);
 int imm;
 string mn;
     imm=0;
@@ -264,7 +264,7 @@ string mn;
     return $sformatf("%s%s,%0d(%s) [%h]", mn, abi_reg[opcode[11:7]], imm, abi_reg[opcode[19:15]], imm+gpr[tid][opcode[19:15]]);
 endfunction
 
-function string dasm32_s( input[31:0] opcode, input tid=0);
+function static string dasm32_s( input[31:0] opcode, input tid=0);
 int imm;
 string mn;
     imm=0;
@@ -280,7 +280,7 @@ string mn;
     return $sformatf("%s%s,%0d(%s) [%h]", mn, abi_reg[opcode[24:20]], imm, abi_reg[opcode[19:15]], imm+gpr[tid][opcode[19:15]]);
 endfunction
 
-function string dasm32_ai( input[31:0] opcode);
+function static string dasm32_ai( input[31:0] opcode);
 int imm;
 string mn;
     imm=0;
@@ -299,13 +299,13 @@ endcase
 return $sformatf("%s%s,%s,%0d", mn, abi_reg[opcode[11:7]], abi_reg[opcode[19:15]], imm);
 endfunction
 
-function string dasm32_si( input[31:0] opcode);
+function static string dasm32_si( input[31:0] opcode);
 int imm;
 string mn;
     imm = opcode[24:20];
     case(opcode[14:12])
     1: mn = "slli";
-    5: mn = opcode[30] ? "srli": "srai";
+    5: mn = opcode[30] ? "srai": "srli";
     endcase
 
     return $sformatf("%s    %s,%s,%0d", mn, abi_reg[opcode[11:7]], abi_reg[opcode[19:15]], imm);
@@ -313,7 +313,7 @@ endfunction
 
 
 
-function string dasm32_ar( input[31:0] opcode);
+function static string dasm32_ar( input[31:0] opcode);
 string mn;
     if(opcode[25])
         case(opcode[14:12])
@@ -340,11 +340,11 @@ string mn;
     return $sformatf("%s%s,%s,%s", mn, abi_reg[opcode[11:7]], abi_reg[opcode[19:15]], abi_reg[opcode[24:20]]);
 endfunction
 
-function string dasm32_fence( input[31:0] opcode);
+function static string dasm32_fence( input[31:0] opcode);
     return  opcode[12] ? ".i" : "";
 endfunction
 
-function string dasm32_e(input[31:0] opcode);
+function static string dasm32_e(input[31:0] opcode);
     if(opcode[31:7] == 0) return "ecall";
     else if({opcode[31:21],opcode [19:7]} == 0) return "ebreak";
     else
@@ -360,7 +360,7 @@ function string dasm32_e(input[31:0] opcode);
 endfunction
 
 
-function string dasm32_csr(input[31:0] opcode, input im=0);
+function static string dasm32_csr(input[31:0] opcode, input im=0);
 bit[11:0] csr;
     csr = opcode[31:20];
     if(im) begin
@@ -373,7 +373,7 @@ bit[11:0] csr;
 endfunction
 
 //atomics
-function string dasm32_a(input[31:0] opcode, input tid=0);
+function static string dasm32_a(input[31:0] opcode, input tid=0);
     case(opcode[31:27])
     'b00010: return $sformatf("lr.w    %s,(%s) [%h]",    abi_reg[opcode[11:7]],                         abi_reg[opcode[19:15]], gpr[tid][opcode[19:15]]);
     'b00011: return $sformatf("sc.w    %s,%s,(%s) [%h]", abi_reg[opcode[11:7]], abi_reg[opcode[24:20]], abi_reg[opcode[19:15]], gpr[tid][opcode[19:15]]);
@@ -390,6 +390,6 @@ function string dasm32_a(input[31:0] opcode, input tid=0);
     return $sformatf(".long 0x%h", opcode);
 endfunction
 
-function string dasm32_amo( input[31:0] opcode, input tid=0);
+function static string dasm32_amo( input[31:0] opcode, input tid=0);
     return $sformatf(" %s,%s,(%s) [%h]", abi_reg[opcode[11:7]], abi_reg[opcode[24:20]], abi_reg[opcode[19:15]], gpr[tid][opcode[19:15]]);
 endfunction


### PR DESCRIPTION
This PR updates VeeR-EL2 codebase by bringing in the following changes:

- External scan-chain reset control (https://github.com/chipsalliance/Cores-VeeR-EL2/issues/52, https://github.com/chipsalliance/Cores-VeeR-EL2/pull/61)
- Possibility for injecting custom modules for clock gates (https://github.com/chipsalliance/Cores-VeeR-EL2/issues/50, https://github.com/chipsalliance/Cores-VeeR-EL2/pull/54)
- Correction of default WIDTH parameter for `rvdffppe` (https://github.com/chipsalliance/Cores-VeeR-EL2/issues/73, https://github.com/chipsalliance/Cores-VeeR-EL2/pull/76)
- Fix for swapped mnemonics (https://github.com/chipsalliance/Cores-VeeR-EL2/issues/42, https://github.com/chipsalliance/Cores-VeeR-EL2/pull/77)