### PR TITLE
Exclude some CI tests for Verilator

### DIFF
--- a/.github/scripts/build_tests_matrix.py
+++ b/.github/scripts/build_tests_matrix.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import yaml
 
 def main():
@@ -7,6 +8,10 @@ def main():
     file_name = "src/integration/stimulus/L0_regression.yml"
     with open(file_name, "r") as fp:
         yaml_root = yaml.safe_load(fp)
+
+    # Get excluded test list
+    excluded = os.environ.get("EXCLUDE_TESTS", "")
+    excluded = [s.strip() for s in excluded.strip().split(",")]
 
     # Get test list
     content = yaml_root["contents"][0]
@@ -20,7 +25,9 @@ def main():
 
         for i, part in enumerate(parts):
             if part == "test_suites" and i + 1 < len(parts):
-                test_list.append(parts[i+1])
+                test_name = parts[i+1]
+                if test_name not in excluded:
+                    test_list.append(test_name)
                 break
 
     # Output names

--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -122,6 +122,8 @@ jobs:
     needs: build_tools
     outputs:
       test_names: ${{ steps.output-matrix.outputs.test_names  }}
+    env:
+      EXCLUDE_TESTS: "smoke_test_clk_gating, smoke_test_cg_wdt"
     steps:
       - uses: actions/checkout@v3
       - name: Install deps


### PR DESCRIPTION
This PR adds a mechanism for excluding specific CI tests. The list needs to be passed via the `EXCLUDE_TESTS` env variable to the job that builds CI test matrix. Solves https://github.com/chipsalliance/caliptra-rtl/issues/126

Currently the PR has no effect on the CI as the excluded tests are not yet integrated