### PR TITLE
Fix for security state multi-driver

### DIFF
--- a/src/integration/tb/caliptra_top_tb.sv
+++ b/src/integration/tb/caliptra_top_tb.sv
@@ -150,11 +150,6 @@ module caliptra_top_tb (
 
     //device lifecycle
     security_state_t security_state;
-`ifdef CALIPTRA_DEBUG_UNLOCKED
-    assign security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: 1'b0}; // DebugUnlocked & Production
-`else
-    assign security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: 1'b1}; // DebugLocked & Production
-`endif
 
     ras_test_ctrl_t ras_test_ctrl;
     logic [63:0] generic_input_wires;


### PR DESCRIPTION
The fix was made in MSFT internal repository, but did not merge correctly into this GitHub repository during a recent sync (git cherry-pick did not recognize the change had been made).

This fix removes the security state driver in caliptra_top_tb so that the driver in caliptra_top_tb_services is the only one.