### PR TITLE
Remove read IDCODE instruction from VeeR JTAG TAP

### DIFF
--- a/src/integration/rtl/caliptra_top.sv
+++ b/src/integration/rtl/caliptra_top.sv
@@ -354,16 +354,12 @@ end
    // RTL instance
    //=========================================================================-
 //FIXME TIE OFFS
-logic [31:0] jtag_id;
 logic [31:0] reset_vector;
 logic [31:0] nmi_vector;
 logic nmi_int;
 logic soft_int;
 logic timer_int;
 
-assign jtag_id[31:28] = 4'b1;
-assign jtag_id[27:12] = '0;
-assign jtag_id[11:1]  = 11'h45;
 assign reset_vector = `RV_RESET_VEC;
 assign soft_int     = 1'b0;
 
@@ -415,7 +411,6 @@ el2_veer_wrapper rvtop (
     .rst_vec                ( reset_vector[31:1]),
     .nmi_int                ( nmi_int       ),
     .nmi_vec                ( nmi_vector[31:1]),
-    .jtag_id                ( jtag_id[31:1]),
 
     .haddr                  ( ic_haddr      ),
     .hburst                 ( ic_hburst     ),

--- a/src/riscv_core/veer_el2/rtl/dmi/dmi_wrapper.v
+++ b/src/riscv_core/veer_el2/rtl/dmi/dmi_wrapper.v
@@ -34,7 +34,6 @@ module dmi_wrapper(
   // Processor Signals
   input              core_rst_n,          // Core reset                  
   input              core_clk,            // Core clock                  
-  input [31:1]       jtag_id,             // JTAG ID
   input [31:0]       rd_data,             // 32 bit Read data from  Processor                       
   output [31:0]      reg_wr_data,         // 32 bit Write data to Processor                      
   output [6:0]       reg_wr_addr,         // 7 bit reg address to Processor                   
@@ -70,7 +69,6 @@ module dmi_wrapper(
    .idle(3'h0),                         // no need to wait to sample data
    .dmi_stat(2'b0),                     // no need to wait or error possible
    .version(4'h1),                      // debug spec 0.13 compliant
-   .jtag_id(jtag_id),
    .dmi_hard_reset(dmi_hard_reset),
    .dmi_reset(dmireset)
 );

--- a/src/riscv_core/veer_el2/rtl/dmi/rvjtag_tap.v
+++ b/src/riscv_core/veer_el2/rtl/dmi/rvjtag_tap.v
@@ -37,13 +37,6 @@ output  reg         dmi_hard_reset,
 
 input   [2:0]       idle,
 input   [1:0]       dmi_stat,
-/*
---  revisionCode        : 4'h0;
---  manufacturersIdCode : 11'h45;
---  deviceIdCode        : 16'h0001;
---  order MSB .. LSB -> [4 bit version or revision] [16 bit part number] [11 bit manufacturer id] [value of 1'b1 in LSB]
-*/
-input   [31:1]      jtag_id,
 input   [3:0]       version
 );
 
@@ -67,7 +60,6 @@ wire pause_ir ;
 wire update_ir ;
 wire capture_ir;
 wire[1:0] dr_en;
-wire devid_sel;
 wire [5:0] abits;
 
 assign abits = AWIDTH[5:0];
@@ -143,7 +135,6 @@ always @ (negedge tck or negedge trst) begin
 end
 
 
-assign devid_sel  = ir == 5'b00001;
 assign dr_en[0]   = ir == 5'b10000;
 assign dr_en[1]   = ir == 5'b10001;
 
@@ -166,9 +157,7 @@ always_comb begin
     shift_dr:   begin
                     case(1)
                     dr_en[1]:   nsr = {tdi, sr[USER_DR_LENGTH-1:1]};
-
-                    dr_en[0],
-                    devid_sel:  nsr = {{USER_DR_LENGTH-32{1'b0}},tdi, sr[31:1]};
+                    dr_en[0]:   nsr = {{USER_DR_LENGTH-32{1'b0}},tdi, sr[31:1]};
                     default:    nsr = {{USER_DR_LENGTH-1{1'b0}},tdi}; // bypass
                     endcase
                 end
@@ -177,7 +166,6 @@ always_comb begin
                     case(1)
                     dr_en[0]:   nsr = {{USER_DR_LENGTH-15{1'b0}}, idle, dmi_stat, abits, version};
                     dr_en[1]:   nsr = {{AWIDTH{1'b0}}, rd_data, rd_status};
-                    devid_sel:  nsr = {{USER_DR_LENGTH-32{1'b0}}, jtag_id, 1'b1};
                     endcase
                 end
     shift_ir:   nsr = {{USER_DR_LENGTH-5{1'b0}},tdi, sr[4:1]};

--- a/src/riscv_core/veer_el2/rtl/el2_veer_wrapper.sv
+++ b/src/riscv_core/veer_el2/rtl/el2_veer_wrapper.sv
@@ -33,7 +33,6 @@ import soc_ifc_pkg::*;
    input logic [31:1]                      rst_vec,
    input logic                             nmi_int,
    input logic [31:1]                      nmi_vec,
-   input logic [31:1]                      jtag_id,
 
 
    output logic [31:0]                     trace_rv_i_insn_ip,
@@ -724,7 +723,6 @@ import soc_ifc_pkg::*;
     // Processor Signals
     .core_rst_n  (dbg_rst_l),       // Debug reset, active low
     .core_clk    (clk),             // Core clock
-    .jtag_id     (jtag_id),         // JTAG ID
     .rd_data     (dmi_reg_rdata_PostQ),   // Read data from  Processor
     .reg_wr_data (dmi_reg_wdata),   // Write data to Processor
     .reg_wr_addr (dmi_reg_addr),    // Write address to Processor

--- a/src/riscv_core/veer_el2/tb/el2_veer_wrapper_tb.sv
+++ b/src/riscv_core/veer_el2/tb/el2_veer_wrapper_tb.sv
@@ -28,7 +28,6 @@ module el2_veer_wrapper_tb ( input bit core_clk );
 
     logic        [31:0]         reset_vector;
     logic        [31:0]         nmi_vector;
-    logic        [31:1]         jtag_id;
 
     logic        [31:0]         ic_haddr        ;
     logic        [2:0]          ic_hburst       ;
@@ -411,9 +410,6 @@ module el2_veer_wrapper_tb ( input bit core_clk );
         abi_reg[30] = "t5";
         abi_reg[31] = "t6";
     // tie offs
-        jtag_id[31:28] = 4'b1;
-        jtag_id[27:12] = '0;
-        jtag_id[11:1]  = 11'h45;
         reset_vector = `RV_RESET_VEC;
         nmi_vector   = 32'hee000000;
         nmi_int   = 0;
@@ -448,7 +444,6 @@ el2_veer_wrapper rvtop (
     .rst_vec                ( reset_vector[31:1]),
     .nmi_int                ( nmi_int       ),
     .nmi_vec                ( nmi_vector[31:1]),
-    .jtag_id                ( jtag_id[31:1]),
 
 `ifdef RV_BUILD_AHB_LITE
     .haddr                  ( ic_haddr      ),

--- a/tools/scripts/openocd/target/veer-el2-rst.cfg
+++ b/tools/scripts/openocd/target/veer-el2-rst.cfg
@@ -4,13 +4,7 @@ if { [info exists CHIPNAME] } {
    set  _CHIPNAME riscv
 }
 
-if { [info exists CPUTAPID ] } {
-   set _CPUTAPID $CPUTAPID
-} else {
-   set _CPUTAPID 0x1000008b
-}
-
-jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID
+jtag newtap $_CHIPNAME tap -irlen 5
 set _TARGETNAME $_CHIPNAME.tap
 target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME -rtos hwthread
 

--- a/tools/scripts/openocd/target/veer-el2.cfg
+++ b/tools/scripts/openocd/target/veer-el2.cfg
@@ -4,13 +4,7 @@ if { [info exists CHIPNAME] } {
    set  _CHIPNAME riscv
 }
 
-if { [info exists CPUTAPID ] } {
-   set _CPUTAPID $CPUTAPID
-} else {
-   set _CPUTAPID 0x1000008b
-}
-
-jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID
+jtag newtap $_CHIPNAME tap -irlen 5
 set _TARGETNAME $_CHIPNAME.tap
 target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME -rtos hwthread
 


### PR DESCRIPTION
This PR removes support for read IDCODE instruction from the TAP. This addresses https://github.com/chipsalliance/caliptra-rtl/issues/289 where Caliptra is to be connected to a system JTAG as a submodule. 