### PR TITLE
remove profile for 1.0

### DIFF
--- a/docs/CaliptraHardwareSpecification.md
+++ b/docs/CaliptraHardwareSpecification.md
@@ -24,7 +24,7 @@ The Boot FSM detects that the SoC is bringing Caliptra out of reset. Part of thi
 
 The following figure shows the initial power-on arc of the Mailbox Boot FSM.
 
-*Figure 2: Mailbox Boot FSM state diagram*
+*Figure 1: Mailbox Boot FSM state diagram*
 
 ![](./images/HW_mbox_boot_fsm.png)
 
@@ -36,7 +36,7 @@ BOOT\_DONE enables Caliptra reset de-assertion through a two flip-flop synchroni
 
 Runtime FW updates write to fw\_update\_reset register to trigger the FW update reset. When this register is written, only the RISC-V core is reset using cptra\_uc\_fw\_rst\_b pin and all AHB slaves are still active. All registers within the slaves and ICCM/DCCM memories are intact after the reset. Since ICCM is locked during runtime, it must be unlocked after the RISC-V reset is asserted. Reset is deasserted synchronously after a programmable number of cycles (currently set to 5 clocks) and normal boot flow updates the ICCM with the new FW from the mailbox SRAM. Reset de-assertion is done through a two flip-flop synchronizer. The boot flow is modified as shown in the following figure.
 
-*Figure 3: Mailbox Boot FSM state diagram for FW update reset*
+*Figure 2: Mailbox Boot FSM state diagram for FW update reset*
 
 ![](./images/mbox_boot_fsm_FW_update_reset.png)
 
@@ -193,7 +193,7 @@ For more details regarding the register interface to control the WDT, see the [r
 
 The following figure shows the two timers.
 
-*Figure 4: Caliptra Watchdog Timer*
+*Figure 3: Caliptra Watchdog Timer*
 
 ![](./images/WDT.png)
 
@@ -207,7 +207,7 @@ The Caliptra microcontroller communicates with the mailbox through its internal 
 
 ### AHB-lite interface
 
-AHB-lite is a subset of the full AHB specification. It is primarily used in single master systems. This interface connects VeeR EL2 Core (LSU master) to the slave devices as shown in Figure 1.
+AHB-lite is a subset of the full AHB specification. It is primarily used in single master systems. This interface connects VeeR EL2 Core (LSU master) to the slave devices. See [Caliptra Core](#caliptra-core) for information.
 
 The interface can be customized to support variable address and data widths, and a variable number of slave devices. Each slave device is assigned an address range within the 32-bit address memory map region. The interface includes address decoding logic to route data to the appropriate AHB slave device based on the address specified.
 
@@ -229,7 +229,7 @@ For details, see the [Cryptographic subsystem architecture](#cryptographic-subsy
 
 ## Peripherals subsystem
 
-Caliptra includes QSPI and UART peripherals that are used to facilitate alternative operating modes and debug. In the first generation, Caliptra includes code to enable QSPI in the RTL. Therefore, QSPI must not be enabled. Similarly, the UART interface exists to facilitate firmware debug in an FPGA prototype, but should be disabled in final silicon. SystemVerilog defines used to disable these peripherals are described in the [Caliptra Integration Specification](https://github.com/chipsalliance/caliptra-rtl/blob/main/docs/CaliptraIntegrationSpecification.md). Operation of these peripherals is described in the following sections.
+Caliptra includes QSPI and UART peripherals that are used to facilitate alternative operating modes and debug. In the first generation, Caliptra does not support enabling the QSPI interface. Similarly, the UART interface exists to facilitate firmware debug in an FPGA prototype, but should be disabled in final silicon. SystemVerilog defines used to disable these peripherals are described in the [Caliptra Integration Specification](https://github.com/chipsalliance/caliptra-rtl/blob/main/docs/CaliptraIntegrationSpecification.md). Operation of these peripherals is described in the following sections.
 
 ### QSPI Flash Controller
 
@@ -237,7 +237,7 @@ Caliptra implements a QSPI block that can communicate with 2 QSPI devices. This 
 
 The QSPI block is composed of the spi\_host implementation. For information, see the [SPI\_HOST HWIP Technical Specification](https://opentitan.org/book/hw/ip/spi_host/index.html). The core code (see [spi\_host](https://github.com/lowRISC/opentitan/tree/master/hw/ip/spi_host)) is reused but the interface to the module is changed to AHB-lite and the number of chip select lines supported is increased to 2. The design provides support for Standard SPI, Dual SPI, or Quad SPI commands. The following figure shows the QSPI flash controller.
 
-*Figure 5: QSPI flash controller*
+*Figure 4: QSPI flash controller*
 
 ![](./images/QSPI_flash.png)
 
@@ -249,7 +249,7 @@ The structure of a command depends on the device and the command itself. In the 
 
 A typical SPI command consists of different segments that are combined as shown in the following example. Each segment can configure the length, speed, and direction. As an example, the following SPI read transaction consists of 2 segments.
 
-*Figure 6: SPI read transaction segments*
+*Figure 5: SPI read transaction segments*
 
 ![](./images/SPI_read.png)
 
@@ -269,7 +269,7 @@ QSPI consists of up to four command segments in which the host:
 
 The following example shows the QSPI segments.
 
-*Figure 7: QSPI segments*
+*Figure 6: QSPI segments*
 
 ![](./images/QSPI_segments.png)
 
@@ -304,7 +304,7 @@ CONFIGOPTS.CLKDIV = (400/(2\*100)) -1 = 1
 
 The following figure shows CONFIGOPTS.
 
-*Figure 8: CONFIGOPTS*
+*Figure 7: CONFIGOPTS*
 
 ![](./images/CONFIGOPTS.png)
 
@@ -352,7 +352,7 @@ Caliptra implements a UART block that can communicate with a serial device that 
 
 The UART block is composed of the uart implementation. For information, see the [UART HWIP Technical Specification](https://opentitan.org/book/hw/ip/uart/). The design provides support for a programmable baud rate. The UART block is shown in the following figure.
 
-*Figure 9: UART block*
+*Figure 8: UART block*
 
 ![](./images/UART_block.png)
 
@@ -362,7 +362,7 @@ Transactions flow through the UART block starting with an AHB-lite write to WDAT
 
 The following figure shows the transmit data on the serial lane, starting with the START bit, which is indicated by a high to low transition, followed by the 8 bits of data.
 
-*Figure 10: Serial transmission frame*
+*Figure 9: Serial transmission frame*
 
 ![](./images/serial_transmission.png)
 
@@ -483,7 +483,7 @@ The following applies to the clock gating feature:
 
 The following figure shows the timing information for clock gating.
 
-*Figure 11: Clock gating timing*
+*Figure 10: Clock gating timing*
 
 ![](./images/clock_gating_timing.png)
 
@@ -497,19 +497,19 @@ The block is instantiated based on a design parameter chosen at integration time
 
 The following figure shows the integrated TRNG block.
 
-*Figure 12: Integrated TRNG block*
+*Figure 11: Integrated TRNG block*
 
 ![](./images/integrated_TRNG.png)
 
 The following figure shows the CSRNG block.
 
-*Figure 13: CSRNG block*
+*Figure 12: CSRNG block*
 
 ![](./images/CSRNG_block.png)
 
 The following figure shows the entropy source block.
 
-*Figure 14: Entropy source block*
+*Figure 13: Entropy source block*
 
 ![](./images/entropy_source_block.png)
 
@@ -573,7 +573,7 @@ These are the top level signals defined in caliptra\_top.
 
 The following figure shows the top level signals defined in caliptra\_top.
 
-*Figure 15: caliptra\_top signals*
+*Figure 14: caliptra\_top signals*
 
 ![](./images/caliptra_top_signals.png)
 
@@ -594,7 +594,7 @@ The following table provides descriptions of the entropy source signals.
 
 The following figure shows the entropy source signals.
 
-*Figure 16: Entropy source signals*
+*Figure 15: Entropy source signals*
 
 ![](./images/entropy_source_signals.png)
 
@@ -652,7 +652,7 @@ Caliptra’s JTAG/TAP should be implemented as a TAP EP. JTAG is open if the deb
 
 Note: If the debug security state switches to debug mode anytime, the security assets and keys are still flushed even though JTAG is not open.
 
-*Figure 17: JTAG implementation*
+*Figure 16: JTAG implementation*
 
 ![](./images/JTAG_implementation.png)
 
@@ -673,7 +673,7 @@ The architecture of Caliptra cryptographic subsystem includes the following comp
 
 The high-level architecture of Caliptra cryptographic subsystem is shown in the following figure.
 
-*Figure 18: Caliptra cryptographic subsystem*
+*Figure 17: Caliptra cryptographic subsystem*
 
 ![](./images/crypto_subsystem.png)
 
@@ -698,7 +698,7 @@ The message should be padded before feeding to the hash core. The input message 
 
 The total size should be equal to 128 bits short of a multiple of 1024 since the goal is to have the formatted message size as a multiple of 1024 bits (N x 1024). The following figure shows the SHA512 input formatting.
 
-*Figure 19: SHA512 input formatting*
+*Figure 18: SHA512 input formatting*
 
 ![](./images/SHA512_input.png)
 
@@ -710,7 +710,7 @@ The SHA512 core performs 80 iterative operations to process the hash value of th
 
 The SHA512 architecture has the finite-state machine as shown in the following figure.
 
-*Figure 20: SHA512 FSM*
+*Figure 19: SHA512 FSM*
 
 ![](./images/SHA512_fsm.png)
 
@@ -739,7 +739,7 @@ The SHA512 address map is shown here: [sha512\_reg — clp Reference (chipsallia
 
 The following pseudocode demonstrates how the SHA512 interface can be implemented.
 
-*Figure 21: SHA512 pseudocode*
+*Figure 20: SHA512 pseudocode*
 
 ![](./images/SHA512_pseudo.png)
 
@@ -817,7 +817,7 @@ The total size should be equal to 64 bits, short of a multiple of 512 because th
 
 The following figure shows SHA256 input formatting.
 
-*Figure 22: SHA256 input formatting*
+*Figure 21: SHA256 input formatting*
 
 ![](./images/SHA256_input.png)
 
@@ -829,7 +829,7 @@ The SHA256 core performs 64 iterative operations to process the hash value of th
 
 The SHA256 architecture has the finite-state machine as shown in the following figure.
 
-*Figure 23: SHA256 FSM*
+*Figure 22: SHA256 FSM*
 
 ![](./images/SHA256_fsm.png)
 
@@ -858,7 +858,7 @@ The SHA256 address map is shown here: [sha256\_reg — clp Reference (chipsallia
 
 The following pseudocode demonstrates how the SHA256 interface can be implemented.
 
-*Figure 24: SHA256 pseudocode*
+*Figure 23: SHA256 pseudocode*
 
 ![](./images/SHA256_pseudo.png)
 
@@ -922,25 +922,25 @@ The message should be padded before feeding to the HMAC core. Internally, the i\
 
 The total size should be equal to 128 bits, short of a multiple of 1024 because the goal is to have the formatted message size as a multiple of 1024 bits (N x 1024).
 
-*Figure 25: HMAC input formatting*
+*Figure 24: HMAC input formatting*
 
 ![](./images/HMAC_input.png)
 
 The following figures show examples of input formatting for different message lengths.
 
-*Figure 26: Message length of 1023 bits*
+*Figure 25: Message length of 1023 bits*
 
 ![](./images/msg_1023.png)
 
 When the message is 1023 bits long, padding is given in the next block along with message size.
 
-*Figure 27: 1 bit padding*
+*Figure 26: 1 bit padding*
 
 ![](./images/1_bit.png)
 
 When the message size is 895 bits, a padding of ‘1’ is also considered valid, followed by the message size.
 
-*Figure 28: Multi block message*
+*Figure 27: Multi block message*
 
 ![](./images/msg_multi_block.png)
 
@@ -951,7 +951,7 @@ Messages with a length greater than 1024 bits are broken down into N 1024-bit bl
 
 The HMAC core performs the sha2-384 function to process the hash value of the given message. The algorithm processes each block of the 1024 bits from the message, using the result from the previous block. This data flow is shown in the following figure.
 
-*Figure 29: HMAC-SHA-384-192 data flow*
+*Figure 28: HMAC-SHA-384-192 data flow*
 
 ![](./images/HMAC_SHA_384_192.png)
 
@@ -959,7 +959,7 @@ The HMAC core performs the sha2-384 function to process the hash value of the gi
 
 The HMAC architecture has the finite-state machine as shown in the following figure.
 
-*Figure 30: HMAC FSM*
+*Figure 29: HMAC FSM*
 
 ![](./images/HMAC_FSM.png)
 
@@ -989,7 +989,7 @@ The HMAC address map is shown here: [hmac\_reg — clp Reference (chipsalliance.
 
 The following pseudocode demonstrates how the HMAC interface can be implemented.
 
-*Figure 31: HMAC pseudocode*
+*Figure 30: HMAC pseudocode*
 
 ![](./images/HMAC_pseudo.png)
 
@@ -1109,7 +1109,7 @@ The hardware implementation supports deterministic ECDSA, 384 Bits (Prime Field)
 
 Secp384r1 parameters are shown in the following figure.
 
-*Figure 32: Secp384r1 parameters*
+*Figure 31: Secp384r1 parameters*
 
 ![](./images/secp384r1_params.png)
 
@@ -1117,7 +1117,7 @@ Secp384r1 parameters are shown in the following figure.
 
 The ECDSA consists of three operations, shown in the following figure.
 
-*Figure 33: ECDSA operations*
+*Figure 32: ECDSA operations*
 
 ![](./images/ECDSA_ops.png)
 
@@ -1152,7 +1152,7 @@ The signature (r, s) can be verified by Verify(pubKey ,h ,r, s) considering the 
 
 The ECC top-level architecture is shown in the following figure.
 
-*Figure 34: ECDSA architecture*
+*Figure 33: ECDSA architecture*
 
 ![](./images/ECDSA_arch.png)
 
@@ -1190,19 +1190,19 @@ The following pseudocode blocks demonstrate example implementations for KeyGen, 
 
 #### KeyGen
 
-*Figure 35: KeyGen pseudocode*
+*Figure 34: KeyGen pseudocode*
 
 ![](./images/keygen_pseudo.png)
 
 #### Signing
 
-*Figure 36: Signing pseudocode*
+*Figure 35: Signing pseudocode*
 
 ![](./images/signing_pseudo.png)
 
 #### Verifying
 
-*Figure 37: Verifying pseudocode*
+*Figure 36: Verifying pseudocode*
 
 ![](./images/verify_pseudo.png)
 
@@ -1268,7 +1268,7 @@ The state machine of HMAC\_DRBG utilization is shown in the following figure, in
 2. KEYGEN PRIVKEY: Running HMAC\_DRBG with seed and nonce to generate the privkey in KEYGEN operation.
 3. SIGNING NONCE: Running HMAC\_DRBG based on RFC6979 in SIGNING operation with privkey and hashed\_msg.
 
-*Figure 38: HMAC\_DRBG utilization*
+*Figure 37: HMAC\_DRBG utilization*
 
 ![](./images/HMAC_DRBG_util.png)
 
@@ -1284,7 +1284,7 @@ In SCA random generator state:
 
 The data flow of the HMAC\_DRBG operation in keygen operation mode is shown in the following figure.
 
-*Figure 39: HMAC\_DRBG data flow*
+*Figure 38: HMAC\_DRBG data flow*
 
 ![](./images/HMAC_DRBG_data.png)
 
@@ -1294,7 +1294,7 @@ Test vector leakage assessment (TVLA) provides a robust test using a 𝑡-test. 
 
 In practice, observing a t-value greater than a specific threshold (mainly 4.5) indicates the presence of leakage. However, in ECC, due to its latency, around 5 million samples are required to be captured. This latency leads to many false positives and the TVLA threshold can be considered a higher value than 4.5. Based on the following figure from “Side-Channel Analysis and Countermeasure Design for Implementation of Curve448 on Cortex-M4” by Bisheh-Niasar et. al., the threshold can be considered equal to 7 in our case.
 
-*Figure 40: TVLA threshold as a function of the number of samples per trace*
+*Figure 39: TVLA threshold as a function of the number of samples per trace*
 
 ![](./images/TVLA_threshold.png)
 
@@ -1303,13 +1303,13 @@ In practice, observing a t-value greater than a specific threshold (mainly 4.5) 
 
 The TVLA results for performing privkey-dependent leakage detection using 20,000 traces is shown in the following figure. Based on this figure, there is no leakage in ECC signing by changing the privkey after 20,000 operations.
 
-*Figure 41: privkey-dependent leakage detection using TVLA for ECC signing after 20,000 traces*
+*Figure 40: privkey-dependent leakage detection using TVLA for ECC signing after 20,000 traces*
 
 ![](./images/TVLA_privekey.png)
 
 The TVLA results for performing message-dependent leakage detection using 64,000 traces is shown in the following figure. Based on this figure, there is no leakage in ECC signing by changing the message after 64,000 operations.
 
-*Figure 42: Message-dependent leakage detection using TVLA for ECC signing after 64,000 traces*
+*Figure 41: Message-dependent leakage detection using TVLA for ECC signing after 64,000 traces*
 
 ![](./images/TVLA_msg_dependent.png)
 

--- a/docs/CaliptraHardwareSpecification.md
+++ b/docs/CaliptraHardwareSpecification.md
@@ -16,11 +16,7 @@ This document provides definitions and requirements for a Caliptra cryptographic
 
 # Caliptra Core
 
-The following figure shows the Caliptra Core.
-
-*Figure 1: Caliptra Block Diagram*
-
-![](./images/Caliptra_HW_diagram.png)
+For information on the Caliptra Core, see the [High level architecture](https://chipsalliance.github.io/Caliptra/doc/Caliptra.html#high-level-architecture) section of [Caliptra: A Datacenter System on a Chip (SoC) Root of Trust (RoT)](https://chipsalliance.github.io/Caliptra/doc/Caliptra.html).
 
 ## Boot FSM
 
@@ -233,7 +229,7 @@ For details, see the [Cryptographic subsystem architecture](#cryptographic-subsy
 
 ## Peripherals subsystem
 
-Caliptra includes QSPI and UART peripherals that are used to facilitate alternative operating modes and debug. In the first generation, Caliptra includes code to enable QSPI in the RTL, but does not support the BMI profile. Therefore, QSPI must not be enabled. Similarly, the UART interface exists to facilitate firmware debug in an FPGA prototype, but should be disabled in final silicon. SystemVerilog defines used to disable these peripherals are described in the [Caliptra Integration Specification](https://github.com/chipsalliance/caliptra-rtl/blob/main/docs/CaliptraIntegrationSpecification.md). Operation of these peripherals is described in the following sections.
+Caliptra includes QSPI and UART peripherals that are used to facilitate alternative operating modes and debug. In the first generation, Caliptra includes code to enable QSPI in the RTL. Therefore, QSPI must not be enabled. Similarly, the UART interface exists to facilitate firmware debug in an FPGA prototype, but should be disabled in final silicon. SystemVerilog defines used to disable these peripherals are described in the [Caliptra Integration Specification](https://github.com/chipsalliance/caliptra-rtl/blob/main/docs/CaliptraIntegrationSpecification.md). Operation of these peripherals is described in the following sections.
 
 ### QSPI Flash Controller
 

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -34,15 +34,7 @@ The blocks described in this document are either obtained from open-source GitHu
 
 # Caliptra Core
 
-The following figure shows the Caliptra Core.
-
-*Figure 1: Caliptra block diagram*
-
-![](./images/Caliptra_HW_diagram.png)
-
-## Boot Media Dependent (passive) vs Boot Media Integrated (active) profile
-
-In the BMD profile, QSPI and I3C IO peripherals are disabled using integration-time defines passed to the hardware, which are also exposed to ROM. Peripheral IOs can be tied off appropriately for the BMD profile at SoC integration time. For more information on the BMD vs. BMI profile differences, see the boot flows in [Caliptra profiles](https://chipsalliance.github.io/Caliptra/doc/Caliptra.html#caliptra-profiles). Only the BMD profile is supported for the first generation release of Caliptra.
+For information on the Caliptra Core, see the [High level architecture](https://chipsalliance.github.io/Caliptra/doc/Caliptra.html#high-level-architecture) section of [Caliptra: A Datacenter System on a Chip (SoC) Root of Trust (RoT)](https://chipsalliance.github.io/Caliptra/doc/Caliptra.html).
 
 # SoC interface definition
 

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -27,7 +27,7 @@ The blocks described in this document are either obtained from open-source GitHu
 | IP/Block | GitHub URL | Documentation | Link |
 | :--------- | :--------- | :--------- |:--------- |
 | Cores-VeeR | [GitHub - chipsalliance/Cores-VeeR-EL2](https://github.com/chipsalliance/Cores-VeeR-EL2) | VeeR EL2 Programmer’s Reference Manual | [chipsalliance/Cores-VeeR-EL2 · GitHubPDF](http://cores-swerv-el2/RISC-V_SweRV_EL2_PRM.pdf%20at%20master%20%C2%B7) |
-| AHB Lite Bus | [aignacio/ahb_lite_bus: AHB Bus lite v3.0 (github.com)](https://github.com/aignacio/ahb_lite_bus) | AHB Lite Protocol<br> [Figure 2: SoC interface block diagram](#soc-interface-definition) | [ahb_lite_bus/docs at master · aignacio/ahb_lite_bus (github.com)](https://github.com/aignacio/ahb_lite_bus/tree/master/docs)<br> [ahb_lite_bus/diagram_ahb_bus.png at master · aignacio/ahb_lite_bus (github.com)](https://github.com/aignacio/ahb_lite_bus/blob/master/diagram_ahb_bus.png) |
+| AHB Lite Bus | [aignacio/ahb_lite_bus: AHB Bus lite v3.0 (github.com)](https://github.com/aignacio/ahb_lite_bus) | AHB Lite Protocol<br> [Figure 1: SoC interface block diagram](#soc-interface-definition) | [ahb_lite_bus/docs at master · aignacio/ahb_lite_bus (github.com)](https://github.com/aignacio/ahb_lite_bus/tree/master/docs)<br> [ahb_lite_bus/diagram_ahb_bus.png at master · aignacio/ahb_lite_bus (github.com)](https://github.com/aignacio/ahb_lite_bus/blob/master/diagram_ahb_bus.png) |
 | SHA 256 | [secworks/sha256: Hardware implementation of the SHA-256 cryptographic hash function (github.com)](https://github.com/secworks/sha256) | | |
 | SHA 512 | | | |
 | SPI Controller | <https://github.com/pulp-platform/axi_spi_master> | | |
@@ -40,7 +40,7 @@ For information on the Caliptra Core, see the [High level architecture](https://
 
 The following figure shows the SoC interface definition.
 
-*Figure 2: SoC Interface Block Diagram*
+*Figure 1: SoC Interface Block Diagram*
 
 ![](./images/Caliptra_soc_interface_block.png)
 
@@ -188,7 +188,7 @@ Although fuse values (and the fuse done register) persist across a warm reset, S
 
 The following figure shows the reset rules and timing for cold boot flows.
 
-*Figure 3: Reset rules and timing diagram*
+*Figure 2: Reset rules and timing diagram*
 
 ![](./images/Caliptra_reset_timing.png)
 
@@ -263,7 +263,7 @@ Caliptra in turn also uses the mailbox to pass information back to the SoC. The 
 
 The Boot FSM detects that the SoC is bringing Caliptra out of reset. Part of this flow involves signaling to the SoC that Caliptra is ready for fuses. After fuses are populated and the SoC indicates that it is done downloading fuses, Caliptra can wake up the rest of the IP by deasserting the internal reset. The following figure shows the boot FSM state.
 
-*Figure 4: Mailbox Boot FSM state diagram*
+*Figure 3: Mailbox Boot FSM state diagram*
 
 ![](./images/Caliptra_mbox_boot_FSM.png)
 
@@ -310,7 +310,7 @@ Mailboxes are generic data-passing structures with a specific protocol that defi
 
 Once LOCK is granted, the mailbox is locked until that device has concluded its operation. Caliptra has access to an internal mechanism to terminate a lock early or release the lock if the device does not proceed to use it or to recover from deadlock scenarios. The following figure shows the sender protocol flow.
 
-*Figure 5: Sender protocol flow chart*
+*Figure 4: Sender protocol flow chart*
 
 ![](./images/Caliptra_mbox-sender.png)
 
@@ -333,7 +333,7 @@ Caliptra will not initiate any mailbox commands that require a response from the
 
 The following figure shows the receiver protocol flow.
 
-*Figure 6: Receiver protocol flowchart*
+*Figure 5: Receiver protocol flowchart*
 
 ![](./images/Caliptra_mbox_receiver.png)
 
@@ -505,7 +505,7 @@ Table 4 indicates the signals contained in the memory interface. Direction is re
 
 The following figure shows the SRAM interface timing.
 
-*Figure 7: SRAM interface timing*
+*Figure 6: SRAM interface timing*
 
 ![](./images/Caliptra_SRAM_interface_timing.png)
 
@@ -534,7 +534,7 @@ This example is applicable to scenarios where an integrator may need control of 
 
 Note that the example assumes that data and ECC codes are in non-deterministic bit-position in the exposed SRAM interface bus. Accordingly, redundant correction coding is shown in the integrator level logic (i.e., integrator\_ecc(calitpra\_data, caliptra\_ecc)). If the Caliptra data and ECC are deterministically separable at the Caliptra interface, the integrator would have discretion to store the ECC codes directly and calculate integrator ECC codes for the data alone.
 
-*Figure 8: Example machine check reliability implementation*
+*Figure 7: Example machine check reliability implementation*
 
 ![](./images/Caliptra_machine_reliability.png)
 
@@ -663,7 +663,7 @@ In an unconstrained environment, several CDC violations are anticipated. CDC ana
 
 The following code snippet and schematic diagram illustrate JTAG originating CDC violations.
 
-*Figure 9: Schematic diagram and code snippet showing JTAG-originating CDC violations*
+*Figure 8: Schematic diagram and code snippet showing JTAG-originating CDC violations*
 
 ![](./images/Caliptra_CDC_JTAG_code_snippet.png)
 


### PR DESCRIPTION
Removes references to outdated HW diagram, adds links to current diagram in main spec, and removes phrase that refers to supporting BMI profile. Aligns with [PR 154](https://github.com/chipsalliance/Caliptra/pull/154) in main spec