### PR TITLE
Add RTL file list to be modified by integrators

### DIFF
--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -653,6 +653,22 @@ The following table describes SoC integration requirements.
 | ecc_montgomerymultiplier  | Netlist for always_ff block does not contain flip flop                                    | 274, 326 |Output width is smaller than internal signals, synthesis optimizes away the extra internal flops with no loads|
 | Multiple modules          | Signed to unsigned conversion occurs                                                      |          ||
 
+## Integrator RTL replacement requirements
+
+The following files implement functionality that may be process specific, and should be replaced by integrators using components from their fabrication vendor library.
+
+*Table 19: Caliptra integrator custom RTL file list*
+
+| Module                                    | Description                                                                                |
+| :---------------------------------------- | :----------------------------------------------------------------------------------------- |
+| [caliptra_icg](src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.       |
+| [beh_lib](src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace with technology specific clock gater.       |
+| [config_defines](src/integration/rtl/config_defines.svh)                         | Enable Caliptra internal TRNG (if applicable)       |
+| [caliptra_prim_flop_2sync](src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.         |
+| [dmi_jtag_to_core_sync](src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v) | Replace with technology specific sync cell.         |
+| [caliptra_2ff_sync](src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.         |
+
+
 # CDC analysis and constraints
 
 Clock Domain Crossing (CDC) analysis is performed on the Caliptra core IP. The following are the results and recommended constraints for Caliptra integrators using standard CDC analysis EDA tools.
@@ -707,7 +723,7 @@ The area is expressed in units of square microns.
 
 The target foundry technology node is an industry standard, moderately advanced technology node as of 2023 September.
 
-*Table 19: Netlist synthesis data*
+*Table 20: Netlist synthesis data*
 
 | **IP Name**      | **Date**  | **Path Group**       | **Target Freq** | **QoR WNS** | **QoR Achieveable Freq** |
 | :--------- | :--------- | :--------- | :--------- | :--------- | :--------- |
@@ -870,7 +886,7 @@ Fatal: The 'default' or 'others' must be last case in a case statement
 
 The following terminology is used in this document.
 
-*Table 20: Terminology*
+*Table 21: Terminology*
 
 
 | Abbreviation | Description                                                                                      |

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -655,18 +655,18 @@ The following table describes SoC integration requirements.
 
 ## Integrator RTL replacement requirements
 
-The following files implement functionality that may be process specific, and should be replaced by integrators using components from their fabrication vendor library.
+The following files implement functionality that may be process specific, and should be replaced by integrators using components from the cell library of their fabrication vendor.
 
 *Table 19: Caliptra integrator custom RTL file list*
 
 | Module                                    | Description                                                                                |
 | :---------------------------------------- | :----------------------------------------------------------------------------------------- |
-| [caliptra_icg](src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.       |
-| [beh_lib](src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace with technology specific clock gater.       |
-| [config_defines](src/integration/rtl/config_defines.svh)                         | Enable Caliptra internal TRNG (if applicable)       |
-| [caliptra_prim_flop_2sync](src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.         |
-| [dmi_jtag_to_core_sync](src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v) | Replace with technology specific sync cell.         |
-| [caliptra_2ff_sync](src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.         |
+| [caliptra_icg](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.       |
+| [beh_lib](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace with technology specific clock gater.       |
+| [config_defines](../src/integration/rtl/config_defines.svh)                         | Enable Caliptra internal TRNG (if applicable)       |
+| [caliptra_prim_flop_2sync](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.         |
+| [dmi_jtag_to_core_sync](../src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v) | Replace with technology specific sync cell.         |
+| [caliptra_2ff_sync](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.         |
 
 
 # CDC analysis and constraints

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -657,7 +657,7 @@ The following table describes SoC integration requirements.
 
 ## Integrator RTL modification requirements
 
-Several files contain code that may be specific to an integrator's implementation and should be overridden. This overridable code is either configuration parameters with integrator-specific values or modules that implement process specific functionality. Code in these files should be modified or replaced by integrators using components from the cell library of their fabrication vendor. The following table describes recommended modifications for each file.
+Several files contain code that may be specific to an integrator's implementation and should be overridden. This overridable code is either configuration parameters with integrator-specific values or modules that implement process-specific functionality. Code in these files should be modified or replaced by integrators using components from the cell library of their fabrication vendor. The following table describes recommended modifications for each file.
 
 *Table 19: Caliptra integrator custom RTL file list*
 

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -65,9 +65,9 @@ The following table describes integration parameters.
 | CALIPTRA_INTERNAL_TRNG  | config_defines.svh | Defining this enables the internal TRNG source. |
 | CALIPTRA_INTERNAL_UART  | config_defines.svh | Defining this enables the internal UART.        |
 | CALIPTRA_INTERNAL_QSPI  | config_defines.svh | Defining this enables the internal QSPI.        |
-| USER_ICG                | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that is used in [clk_gate.sv](../src/libs/rtl/clk_gate.sv). USER_ICG replaces the clock gating module CALIPTRA_ICG defined in [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_ICG. |
+| USER_ICG                | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that is used in [clk_gate.sv](../src/libs/rtl/clk_gate.sv). USER_ICG replaces the clock gating module, CALIPTRA_ICG, defined in [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_ICG. |
 | TECH_SPECIFIC_ICG       | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the USER_ICG macro) to be used in place of the native Caliptra clock gate module. |
-| USER_EC_RV_ICG          | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that is used in the RISC-V core. USER_EC_RV_ICG replaces the clock gating module TEC_RV_ICG defined in [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_EC_RV_ICG. |
+| USER_EC_RV_ICG          | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that is used in the RISC-V core. USER_EC_RV_ICG replaces the clock gating module, TEC_RV_ICG, defined in [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_EC_RV_ICG. |
 | TECH_SPECIFIC_EC_RV_ICG | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the USER_EC_RV_ICG macro) to be used in place of the native RISC-V core clock gate module. |
 
 ## Interface

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -65,8 +65,8 @@ The following table describes integration parameters.
 | CALIPTRA_INTERNAL_TRNG  | config_defines.svh | Defining this enables the internal TRNG source. |
 | CALIPTRA_INTERNAL_UART  | config_defines.svh | Defining this enables the internal UART.        |
 | CALIPTRA_INTERNAL_QSPI  | config_defines.svh | Defining this enables the internal QSPI.        |
-| USER_ICG                | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that will be used in [clk_gate.sv](../src/libs/rtl/clk_gate.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_ICG |
-| TECH_SPECIFIC_ICG       | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the macro USER_ICG) to be used in place of the native Caliptra clock gate module |
+| USER_ICG                | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that will be used in [clk_gate.sv](../src/libs/rtl/clk_gate.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_ICG. |
+| TECH_SPECIFIC_ICG       | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the macro USER_ICG) to be used in place of the native Caliptra clock gate module. |
 
 ## Interface
 
@@ -663,12 +663,12 @@ The following files implement functionality that may be process specific, and sh
 
 | Module                                                                                 | Description                                                            |
 | :------------------------------------------------------------------------------------- | :--------------------------------------------------------------------- |
-| [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable)<br>
-                                                                                           Declare name of custom clock gate module by defining USER_ICG<br>
-                                                                                           Enable custom clock gate by defining TECH_SPECIFIC_ICG                 |
-| [soc_ifc_pkg.sv](../src/soc_ifc/rtl/soc_ifc_pkg.sv)                                    | Define PAUSER default behavior and (if applicable) override values. See [Integration Parameters](#integration-parameters)  |
+| [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable).<br>
+                                                                                           Declare name of custom clock gate module by defining USER_ICG.<br>
+                                                                                           Enable custom clock gate by defining TECH_SPECIFIC_ICG.                |
+| [soc_ifc_pkg.sv](../src/soc_ifc/rtl/soc_ifc_pkg.sv)                                    | Define PAUSER default behavior and (if applicable) override values. See [Integration Parameters](#integration-parameters). |
 | [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.<br>
-                                                                                           Modifying this file is not necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_ICG |
+                                                                                           Modifying this file is not necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_ICG. |
 | [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology specific clock gater.       |
 | [caliptra_prim_flop_2sync.sv](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.                            |
 | [caliptra_2ff_sync.sv](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.                            |

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -659,14 +659,15 @@ The following files implement functionality that may be process specific, and sh
 
 *Table 19: Caliptra integrator custom RTL file list*
 
-| Module                                    | Description                                                                                |
-| :---------------------------------------- | :----------------------------------------------------------------------------------------- |
-| [caliptra_icg](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.       |
-| [beh_lib](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace with technology specific clock gater.       |
-| [config_defines](../src/integration/rtl/config_defines.svh)                         | Enable Caliptra internal TRNG (if applicable)       |
-| [caliptra_prim_flop_2sync](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.         |
-| [dmi_jtag_to_core_sync](../src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v) | Replace with technology specific sync cell.         |
-| [caliptra_2ff_sync](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.         |
+| Module                                                                                 | Description                                                            |
+| :------------------------------------------------------------------------------------- | :--------------------------------------------------------------------- |
+| [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.                          |
+| [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology specific clock gater.       |
+| [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable)                          |
+| [caliptra_prim_flop_2sync.sv](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.                            |
+| [dmi_jtag_to_core_sync.v](../src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v)  | Replace with technology specific sync cell.                            |
+| [caliptra_2ff_sync.sv](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.                            |
+| [soc_ifc_pkg.sv](../src/soc_ifc/rtl/soc_ifc_pkg.sv)                                    | Define PAUSER default behavior and (if applicable) override values. See [Integration Parameters](#integration-parameters)  |
 
 
 # CDC analysis and constraints

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -655,7 +655,7 @@ The following table describes SoC integration requirements.
 | ecc_montgomerymultiplier  | Netlist for always_ff block does not contain flip flop                                    | 274, 326 |Output width is smaller than internal signals, synthesis optimizes away the extra internal flops with no loads|
 | Multiple modules          | Signed to unsigned conversion occurs                                                      |          ||
 
-## Integrator RTL replacement requirements
+## Integrator RTL modification requirements
 
 The following files implement functionality that may be process specific, and should be replaced by integrators using components from the cell library of their fabrication vendor.
 

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -67,6 +67,8 @@ The following table describes integration parameters.
 | CALIPTRA_INTERNAL_QSPI  | config_defines.svh | Defining this enables the internal QSPI.        |
 | USER_ICG                | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that will be used in [clk_gate.sv](../src/libs/rtl/clk_gate.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_ICG. |
 | TECH_SPECIFIC_ICG       | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the macro USER_ICG) to be used in place of the native Caliptra clock gate module. |
+| USER_EC_RV_ICG          | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that will be used in the RISC-V core. This replaces the clock gating module TEC_RV_ICG defined in [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_EC_RV_ICG. |
+| TECH_SPECIFIC_EC_RV_ICG | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the macro USER_EC_RV_ICG) to be used in place of the native RISC-V core clock gate module. |
 
 ## Interface
 
@@ -666,7 +668,7 @@ Several files contain code that may be specific to an integrator's implementatio
 | [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable).<br>Declare name of custom clock gate module by defining USER_ICG.<br>Enable custom clock gate by defining TECH_SPECIFIC_ICG.                |
 | [soc_ifc_pkg.sv](../src/soc_ifc/rtl/soc_ifc_pkg.sv)                                    | Define PAUSER default behavior and (if applicable) override values. See [Integration Parameters](#integration-parameters). |
 | [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology-specific clock gater.<br>Modifying this file is not necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_ICG. |
-| [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology-specific clock gater.       |
+| [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology-specific clock gater.<br>Modifying this file may not be necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_EC_RV_ICG. |
 | [caliptra_prim_flop_2sync.sv](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology-specific sync cell.                            |
 | [caliptra_2ff_sync.sv](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology-specific sync cell.                            |
 | [dmi_jtag_to_core_sync.v](../src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v)  | Replace with technology-specific sync cell.                            |

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -657,19 +657,19 @@ The following table describes SoC integration requirements.
 
 ## Integrator RTL modification requirements
 
-The following files implement functionality that may be process specific, and should be replaced by integrators using components from the cell library of their fabrication vendor.
+Several files contain code that may be specific to an integrator's implementation and should be overridden. This overridable code is either configuration parameters with integrator-specific values or modules that implement process specific functionality. Code in these files should be modified or replaced by integrators using components from the cell library of their fabrication vendor. The following table describes recommended modifications for each file.
 
 *Table 19: Caliptra integrator custom RTL file list*
 
-| Module                                                                                 | Description                                                            |
+| File                                                                                   | Description                                                            |
 | :------------------------------------------------------------------------------------- | :--------------------------------------------------------------------- |
 | [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable).<br>Declare name of custom clock gate module by defining USER_ICG.<br>Enable custom clock gate by defining TECH_SPECIFIC_ICG.                |
 | [soc_ifc_pkg.sv](../src/soc_ifc/rtl/soc_ifc_pkg.sv)                                    | Define PAUSER default behavior and (if applicable) override values. See [Integration Parameters](#integration-parameters). |
-| [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.<br>Modifying this file is not necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_ICG. |
-| [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology specific clock gater.       |
-| [caliptra_prim_flop_2sync.sv](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.                            |
-| [caliptra_2ff_sync.sv](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.                            |
-| [dmi_jtag_to_core_sync.v](../src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v)  | Replace with technology specific sync cell.                            |
+| [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology-specific clock gater.<br>Modifying this file is not necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_ICG. |
+| [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology-specific clock gater.       |
+| [caliptra_prim_flop_2sync.sv](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology-specific sync cell.                            |
+| [caliptra_2ff_sync.sv](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology-specific sync cell.                            |
+| [dmi_jtag_to_core_sync.v](../src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v)  | Replace with technology-specific sync cell.                            |
 
 
 # CDC analysis and constraints

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -663,12 +663,9 @@ The following files implement functionality that may be process specific, and sh
 
 | Module                                                                                 | Description                                                            |
 | :------------------------------------------------------------------------------------- | :--------------------------------------------------------------------- |
-| [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable).<br>
-                                                                                           Declare name of custom clock gate module by defining USER_ICG.<br>
-                                                                                           Enable custom clock gate by defining TECH_SPECIFIC_ICG.                |
+| [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable).<br>Declare name of custom clock gate module by defining USER_ICG.<br>Enable custom clock gate by defining TECH_SPECIFIC_ICG.                |
 | [soc_ifc_pkg.sv](../src/soc_ifc/rtl/soc_ifc_pkg.sv)                                    | Define PAUSER default behavior and (if applicable) override values. See [Integration Parameters](#integration-parameters). |
-| [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.<br>
-                                                                                           Modifying this file is not necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_ICG. |
+| [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.<br>Modifying this file is not necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_ICG. |
 | [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology specific clock gater.       |
 | [caliptra_prim_flop_2sync.sv](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.                            |
 | [caliptra_2ff_sync.sv](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.                            |

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -65,6 +65,8 @@ The following table describes integration parameters.
 | CALIPTRA_INTERNAL_TRNG  | config_defines.svh | Defining this enables the internal TRNG source. |
 | CALIPTRA_INTERNAL_UART  | config_defines.svh | Defining this enables the internal UART.        |
 | CALIPTRA_INTERNAL_QSPI  | config_defines.svh | Defining this enables the internal QSPI.        |
+| USER_ICG                | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that will be used in [clk_gate.sv](../src/libs/rtl/clk_gate.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_ICG |
+| TECH_SPECIFIC_ICG       | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the macro USER_ICG) to be used in place of the native Caliptra clock gate module |
 
 ## Interface
 
@@ -661,13 +663,16 @@ The following files implement functionality that may be process specific, and sh
 
 | Module                                                                                 | Description                                                            |
 | :------------------------------------------------------------------------------------- | :--------------------------------------------------------------------- |
-| [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.                          |
-| [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology specific clock gater.       |
-| [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable)                          |
-| [caliptra_prim_flop_2sync.sv](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.                            |
-| [dmi_jtag_to_core_sync.v](../src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v)  | Replace with technology specific sync cell.                            |
-| [caliptra_2ff_sync.sv](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.                            |
+| [config_defines.svh](../src/integration/rtl/config_defines.svh)                        | Enable Caliptra internal TRNG (if applicable)<br>
+                                                                                           Declare name of custom clock gate module by defining USER_ICG<br>
+                                                                                           Enable custom clock gate by defining TECH_SPECIFIC_ICG                 |
 | [soc_ifc_pkg.sv](../src/soc_ifc/rtl/soc_ifc_pkg.sv)                                    | Define PAUSER default behavior and (if applicable) override values. See [Integration Parameters](#integration-parameters)  |
+| [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv)                                     | Replace with technology specific clock gater.<br>
+                                                                                           Modifying this file is not necessary if integrators override the clock gate module that is used by setting TECH_SPECIFIC_ICG |
+| [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv)                            | Replace rvclkhdr/rvoclkhdr with technology specific clock gater.       |
+| [caliptra_prim_flop_2sync.sv](../src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv)    | Replace with technology specific sync cell.                            |
+| [caliptra_2ff_sync.sv](../src/libs/rtl/caliptra_2ff_sync.sv)                           | Replace with technology specific sync cell.                            |
+| [dmi_jtag_to_core_sync.v](../src/riscv_core/veer_el2/rtl/dmi/dmi_jtag_to_core_sync.v)  | Replace with technology specific sync cell.                            |
 
 
 # CDC analysis and constraints

--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -65,10 +65,10 @@ The following table describes integration parameters.
 | CALIPTRA_INTERNAL_TRNG  | config_defines.svh | Defining this enables the internal TRNG source. |
 | CALIPTRA_INTERNAL_UART  | config_defines.svh | Defining this enables the internal UART.        |
 | CALIPTRA_INTERNAL_QSPI  | config_defines.svh | Defining this enables the internal QSPI.        |
-| USER_ICG                | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that will be used in [clk_gate.sv](../src/libs/rtl/clk_gate.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_ICG. |
-| TECH_SPECIFIC_ICG       | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the macro USER_ICG) to be used in place of the native Caliptra clock gate module. |
-| USER_EC_RV_ICG          | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that will be used in the RISC-V core. This replaces the clock gating module TEC_RV_ICG defined in [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_EC_RV_ICG. |
-| TECH_SPECIFIC_EC_RV_ICG | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the macro USER_EC_RV_ICG) to be used in place of the native RISC-V core clock gate module. |
+| USER_ICG                | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that is used in [clk_gate.sv](../src/libs/rtl/clk_gate.sv). USER_ICG replaces the clock gating module CALIPTRA_ICG defined in [caliptra_icg.sv](../src/libs/rtl/caliptra_icg.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_ICG. |
+| TECH_SPECIFIC_ICG       | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the USER_ICG macro) to be used in place of the native Caliptra clock gate module. |
+| USER_EC_RV_ICG          | config_defines.svh | If added by an integrator, provides the name of the custom clock gating module that is used in the RISC-V core. USER_EC_RV_ICG replaces the clock gating module TEC_RV_ICG defined in [beh_lib.sv](../src/riscv_core/veer_el2/rtl/lib/beh_lib.sv). This substitution is only performed if integrators also define TECH_SPECIFIC_EC_RV_ICG. |
+| TECH_SPECIFIC_EC_RV_ICG | config_defines.svh | Defining this causes the custom, integrator-defined clock gate module (indicated by the USER_EC_RV_ICG macro) to be used in place of the native RISC-V core clock gate module. |
 
 ## Interface
 


### PR DESCRIPTION
This PR addresses #358 by adding a table to the Integration spec that describes which RTL modifications integrators are expected to make.
Several other issues in the caliptra-rtl repository also discuss concerns over ambiguous synchronizer requirements and implementation:
* #218
* #315
* #333
* #366

This update may become obsolete and require further spec updates once https://github.com/chipsalliance/Cores-VeeR-EL2/pull/56 has been finalized and merged back into the caliptra-rtl repository.

Resolves #333
Resolves #358