### PR TITLE
Fix usage of RISC-V toolchain

### DIFF
--- a/.github/scripts/gdb_test.sh
+++ b/.github/scripts/gdb_test.sh
@@ -5,6 +5,17 @@
 
 SIM_LOG=`realpath sim.log`
 OPENOCD_LOG=`realpath openocd.log`
+GCC_PREFIX=riscv64-unknown-elf
+
+# Ensure that RISC-V toolchain is installed
+if ! which ${GCC_PREFIX}-gcc >/dev/null; then
+    GCC_PREFIX=riscv32-unknown-elf
+fi
+if ! which ${GCC_PREFIX}-gcc >/dev/null; then
+    echo "RISC-V toolchain not found, please refer to https://github.com/chipsalliance/caliptra-rtl?tab=readme-ov-file#riscv-toolchain-installation for more details."
+    exit 1
+fi
+export GCC_PREFIX
 
 set +e
 

--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -101,7 +101,7 @@ jobs:
         if: steps.riscv_restore.outputs.cache-hit != 'true'
         run: |
           # Building from source takes around 6.65 GB of disk and download size
-          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv64imc-3.0.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz
+          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-131023/riscv32-unknown-elf.gcc-13.2.0.tar.gz
           mkdir /opt/riscv
           tar -xzf toolchain.tar.gz -C /opt/riscv/
 

--- a/.github/workflows/interactive-debugging.yml
+++ b/.github/workflows/interactive-debugging.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Install Risc V Toolchain
         run: |
           # Building from source takes around 6.65 GB of disk and download size
-          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv64imc-3.0.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz
+          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-131023/riscv32-unknown-elf.gcc-13.2.0.tar.gz
           mkdir /opt/riscv
           tar -xzf toolchain.tar.gz -C /opt/riscv/
 
@@ -268,7 +268,7 @@ jobs:
       - name: Install Risc V Toolchain
         run: |
           # Building from source takes around 6.65 GB of disk and download size
-          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv64imc-3.0.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz
+          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-131023/riscv32-unknown-elf.gcc-13.2.0.tar.gz
           mkdir /opt/riscv
           tar -xzf toolchain.tar.gz -C /opt/riscv/
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ GCC:
  - RISCV Toolchain for generating memory initialization files
    - `Version 2023.04.29`
    - `riscv64-unknown-elf-gcc (g) 12.2.0`
+   - `riscv32-unknown-elf-gcc (g) 13.2.0`
  - G++ Used to compile Verilator objects and test firmware
    - `g++ (GCC) 11.2.0`
 
@@ -144,12 +145,12 @@ Verilog file lists are generated via VCS and included in the config directory fo
 ## **Simulation Flow** ##
 
 ### Caliptra Top VCS Steps: ###
-1. Setup tools, add to PATH (ensure riscv64-unknown-elf-gcc is also available)
+1. Setup tools, add to PATH (ensure RISC-V toolchain is also available)
 2. Define all environment variables above
     - For the initial test run after downloading repository, `iccm_lock` is recommended for TESTNAME
     - See [Regression Tests](#Regression-Tests) for information about available tests.
 3. Create a run folder for build outputs (and cd to it)
-4. [OPTIONAL] By default, this run flow will use the riscv64 toolchain to compile test firmware (according to TESTNAME) into program.hex, iccm.hex, dccm.hex, and mailbox.hex. As a first pass, integrators may alternatively use the pre-built hexfiles for convenience (available for [iccm_lock](src/integration/test_suites/iccm_lock) test). To do this, copy [iccm_lock.hex](src/integration/test_suites/iccm_lock/iccm_lock.hex) to the run directory and rename to `program.hex`. [dccm.hex](src/integration/test_suites/iccm_lock/iccm_lock.hex) should also be copied to the run directory, as-is. Use `touch iccm.hex mailbox.hex` to create empty hex files, as these are unnecessary for `iccm_lock` test.
+4. [OPTIONAL] By default, this run flow will use the RISC-V toolchain to compile test firmware (according to TESTNAME) into program.hex, iccm.hex, dccm.hex, and mailbox.hex. As a first pass, integrators may alternatively use the pre-built hexfiles for convenience (available for [iccm_lock](src/integration/test_suites/iccm_lock) test). To do this, copy [iccm_lock.hex](src/integration/test_suites/iccm_lock/iccm_lock.hex) to the run directory and rename to `program.hex`. [dccm.hex](src/integration/test_suites/iccm_lock/iccm_lock.hex) should also be copied to the run directory, as-is. Use `touch iccm.hex mailbox.hex` to create empty hex files, as these are unnecessary for `iccm_lock` test.
 5. Invoke `${CALIPTRA_ROOT}/tools/scripts/Makefile` with target 'program.hex' to produce SRAM initialization files from the firmware found in `src/integration/test_suites/${TESTNAME}`
     - E.g.: `make -f ${CALIPTRA_ROOT}/tools/scripts/Makefile program.hex`
     - NOTE: TESTNAME may also be overridden in the makefile command line invocation, e.g. `make -f ${CALIPTRA_ROOT}/tools/scripts/Makefile TESTNAME=iccm_lock program.hex`
@@ -165,13 +166,13 @@ Verilog file lists are generated via VCS and included in the config directory fo
 8. Simulate project with `caliptra_top_tb` as the top target
 
 ### Caliptra Top Verilator Steps: ###
-1. Setup tools, add to PATH (ensure Verilator, GCC, and riscv64-unknown-elf-gcc are available)
+1. Setup tools, add to PATH (ensure Verilator, GCC, and RISC-V toolchain are available)
 2. Define all environment variables above
     - For the initial test run after downloading repository, `iccm_lock` is recommended for TESTNAME
     - See [Regression Tests](#Regression-Tests) for information about available tests.
 3. Create a run folder for build outputs
     - Recommended to place run folder under `${CALIPTRA_WORKSPACE}/scratch/$USER/verilator/<date>`
-4. [OPTIONAL] By default, this run flow will use the riscv64 toolchain to compile test firmware (according to TESTNAME) into program.hex, iccm.hex, dccm.hex, and mailbox.hex. As a first pass, integrators may alternatively use the pre-built hexfiles for convenience (available for `iccm_lock` test). To do this, copy `iccm_lock.hex` to the run directory and rename to `program.hex`. `dccm.hex` should also be copied to the run directory, as-is. Use `touch iccm.hex mailbox.hex` to create empty hex files, as these are unnecessary for `iccm_lock` test.
+4. [OPTIONAL] By default, this run flow will use the RISC-V toolchain to compile test firmware (according to TESTNAME) into program.hex, iccm.hex, dccm.hex, and mailbox.hex. As a first pass, integrators may alternatively use the pre-built hexfiles for convenience (available for `iccm_lock` test). To do this, copy `iccm_lock.hex` to the run directory and rename to `program.hex`. `dccm.hex` should also be copied to the run directory, as-is. Use `touch iccm.hex mailbox.hex` to create empty hex files, as these are unnecessary for `iccm_lock` test.
 5. Run Caliptra/tools/scripts/Makefile, which provides steps to run a top-level simulation in Verilator
     - Example command:
         `make -C <path/to/run/folder> -f ${CALIPTRA_ROOT}/tools/scripts/Makefile TESTNAME=${TESTNAME} debug=1 verilator`

--- a/src/integration/test_suites/fw_test_rom/fw_test_rom.makefile
+++ b/src/integration/test_suites/fw_test_rom/fw_test_rom.makefile
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-GCC_PREFIX = riscv64-unknown-elf
 BUILD_DIR = $(CURDIR)
 
 # Define test name

--- a/src/integration/test_suites/infinite_loop/dump_and_compare.sh
+++ b/src/integration/test_suites/infinite_loop/dump_and_compare.sh
@@ -16,7 +16,7 @@
 set -ex
 
 # Invoke GDB and dump core registers
-riscv64-unknown-elf-gdb -n --batch -x dump_registers.gdb >gdb.log
+${GCC_PREFIX}-gdb -n --batch -x dump_registers.gdb >gdb.log
 # Parse the log, extract register values. Skip those which change as the
 # program executes since we don't know at which point we tap in.
 cat gdb.log | grep -E '^ra |^sp |^gp |^tp |^t[01256] |^s[0-9]+ |^a[0-9]+ |^\$[0-9]+' >regdump.txt

--- a/src/integration/test_suites/infinite_loop/mem_access.sh
+++ b/src/integration/test_suites/infinite_loop/mem_access.sh
@@ -16,7 +16,7 @@
 set -ex
 
 # Invoke GDB
-riscv64-unknown-elf-gdb -n --batch -x mem_access.gdb >gdb.log
+${GCC_PREFIX}-gdb -n --batch -x mem_access.gdb >gdb.log
 # Parse the log
 cat gdb.log | grep -E '^\$[0-9]+' >out.txt
 

--- a/src/integration/test_suites/infinite_loop/peripheral_access.sh
+++ b/src/integration/test_suites/infinite_loop/peripheral_access.sh
@@ -16,7 +16,7 @@
 set -ex
 
 # Invoke GDB
-riscv64-unknown-elf-gdb -n --batch -x peripheral_access.gdb >gdb.log
+${GCC_PREFIX}-gdb -n --batch -x peripheral_access.gdb >gdb.log
 # Parse the log
 cat gdb.log | grep -E '^\$[0-9]+' >out.txt
 

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -20,9 +20,17 @@ VERILATOR = verilator
 GCC_PREFIX = riscv64-unknown-elf
 BUILD_DIR = $(CURDIR)
 
-rv_gcc_version = $(strip $(shell $(GCC_PREFIX)-gcc --version | head -1 | sed "s/$(GCC_PREFIX)-gcc (\w\+) //"))
+# Ensure that RISC-V toolchain is installed
+ifeq ($(shell which $(GCC_PREFIX)-gcc 2> /dev/null),)
+GCC_PREFIX = riscv32-unknown-elf
+endif
+ifeq ($(shell which $(GCC_PREFIX)-gcc 2> /dev/null),)
+$(error RISC-V toolchain not found, please refer to https://github.com/chipsalliance/caliptra-rtl?tab=readme-ov-file#riscv-toolchain-installation for more details)
+endif
+
+rv_gcc_version = $(strip $(shell $(GCC_PREFIX)-gcc --version | head -1 | sed "s/$(GCC_PREFIX)-gcc (.*) //"))
 $(info rv_gcc_version is $(rv_gcc_version))
-ifeq (12.2.0, $(rv_gcc_version))
+ifeq "12.2.0" "$(word 1, $(sort 12.2.0 $(rv_gcc_version)))"
 ABI = -mabi=ilp32 -march=rv32imc_zicsr_zifencei
 else
 ABI = -mabi=ilp32 -march=rv32imc


### PR DESCRIPTION
This PR introduces few changes:
- switches to the active RISC-V toolchain version in CI,
- ensures in `Makefile` that RISC-V toolchain is installed, it checks for bot 64-bit and 32-bit versions, in that order,
- uses new `march` syntax for `Zifencei` extension in versions higher or equal to 12.2.0 of RISC-V toolchain.

Solves https://github.com/chipsalliance/caliptra-rtl/issues/371.