### PR TITLE
CI: use risc-v gcc 12.1.0

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -18,7 +18,7 @@ env:
   SCCACHE_GHA_CACHE_TO: sccache-verilator-10000
   SCCACHE_GHA_CACHE_FROM: sccache-verilator-
   # Change this to a new random value if you suspect the cache is corrupted
-  SCCACHE_C_CUSTOM_CACHE_BUSTER: f3e6951f0c1d
+  SCCACHE_C_CUSTOM_CACHE_BUSTER: f3e6951f0c1e
 
 jobs:
   build_tools:
@@ -101,9 +101,8 @@ jobs:
         if: steps.riscv_restore.outputs.cache-hit != 'true'
         run: |
           # Building from source takes around 6.65 GB of disk and download size
-          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-131023/riscv32-unknown-elf.gcc-13.2.0.tar.gz
-          mkdir /opt/riscv
-          tar -xzf toolchain.tar.gz -C /opt/riscv/
+          wget -O toolchain.tar.gz https://github.com/chipsalliance/caliptra-tools/releases/download/gcc-v12.1.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz
+          tar -xzf toolchain.tar.gz -C /opt/
 
       - name: Save riscv dir
         uses: actions/cache/save@v3

--- a/.github/workflows/interactive-debugging.yml
+++ b/.github/workflows/interactive-debugging.yml
@@ -22,7 +22,7 @@ jobs:
       SCCACHE_GHA_CACHE_TO: sccache-verilator-10000
       SCCACHE_GHA_CACHE_FROM: sccache-verilator-
       # Change this to a new random value if you suspect the cache is corrupted
-      SCCACHE_C_CUSTOM_CACHE_BUSTER: f3e6951f0c1d
+      SCCACHE_C_CUSTOM_CACHE_BUSTER: f3e6951f0c1e
 
     steps:
       - name: Restore sccache binary
@@ -185,9 +185,8 @@ jobs:
       - name: Install Risc V Toolchain
         run: |
           # Building from source takes around 6.65 GB of disk and download size
-          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-131023/riscv32-unknown-elf.gcc-13.2.0.tar.gz
-          mkdir /opt/riscv
-          tar -xzf toolchain.tar.gz -C /opt/riscv/
+          wget -O toolchain.tar.gz https://github.com/chipsalliance/caliptra-tools/releases/download/gcc-v12.1.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz
+          tar -xzf toolchain.tar.gz -C /opt/
 
       - name: Install dependencies
         run: |
@@ -268,9 +267,8 @@ jobs:
       - name: Install Risc V Toolchain
         run: |
           # Building from source takes around 6.65 GB of disk and download size
-          wget -O toolchain.tar.gz https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-131023/riscv32-unknown-elf.gcc-13.2.0.tar.gz
-          mkdir /opt/riscv
-          tar -xzf toolchain.tar.gz -C /opt/riscv/
+          wget -O toolchain.tar.gz https://github.com/chipsalliance/caliptra-tools/releases/download/gcc-v12.1.0/riscv64-unknown-elf.gcc-12.1.0.tar.gz
+          tar -xzf toolchain.tar.gz -C /opt/
 
       - name: Download Verilator binaries
         uses: actions/download-artifact@v3

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ GCC:
  - RISCV Toolchain for generating memory initialization files
    - `Version 2023.04.29`
    - `riscv64-unknown-elf-gcc (g) 12.2.0`
-   - `riscv32-unknown-elf-gcc (g) 13.2.0`
  - G++ Used to compile Verilator objects and test firmware
    - `g++ (GCC) 11.2.0`
 

--- a/src/integration/test_suites/fw_test_rom/fw_test_rom.makefile
+++ b/src/integration/test_suites/fw_test_rom/fw_test_rom.makefile
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+GCC_PREFIX = riscv64-unknown-elf
 BUILD_DIR = $(CURDIR)
 
 # Define test name

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -22,9 +22,6 @@ BUILD_DIR = $(CURDIR)
 
 # Ensure that RISC-V toolchain is installed
 ifeq ($(shell which $(GCC_PREFIX)-gcc 2> /dev/null),)
-GCC_PREFIX = riscv32-unknown-elf
-endif
-ifeq ($(shell which $(GCC_PREFIX)-gcc 2> /dev/null),)
 $(error RISC-V toolchain not found, please refer to https://github.com/chipsalliance/caliptra-rtl?tab=readme-ov-file#riscv-toolchain-installation for more details)
 endif
 


### PR DESCRIPTION
This PR restores RISC-V toolchain to the version used before #377. The toolchain is hosted in the https://github.com/chipsalliance/caliptra-tools repository