### PR TITLE
Patch v1.0.1: Mailbox Lock resets to 1 with Caliptra ownership

### DIFF
--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -14,11 +14,24 @@ See the License for the specific language governing permissions and<BR>
 limitations under the License.*_<BR>
 
 # **Release Notes** #
-_*Last Update: 2024/01/18*_
+_*Last Update: 2024/01/30*_
 
-## Rev 1p0 ##
+## Rev 1p0 Patch (v1.0.1) ##
 
-### Rev 1p0 release date: 2024/01/18 ###
+### v1.0.1 release date: 2024/01/30 ###
+- Verification
+  - Updated validation firmware images to unlock the mailbox at startup
+  - Fixes for UVM SOC_IFC test sequences to unlock the mailbox and correctly
+    perform transaction checking and scoreboarding
+
+### Bug Fixes ###
+[MBOX] Fix mailbox lock to initialize to 1 out of reset
+
+## Previous Releases ##
+
+### Rev 1p0 ###
+
+#### Rev 1p0 release date: 2024/01/18 ####
 - Caliptra Hardware Specification: Markdown conversion
 - Caliptra Integration specification update with synthesis warnings and jtag tck requirement
 - Caliptra README updates to clarify test cases and running with VCS
@@ -33,10 +46,8 @@ _*Last Update: 2024/01/18*_
   - Remove TODO comments on caliptra_top ports
   - Remove JTAG IDCODE command from RISC-V processor
 
-### Bug Fixes ###
+#### Bug Fixes ####
 [MBOX] Fix ICCM Uncorrectable ECC error driving hw_error_non_fatal bit for LSU reads
-
-## Previous Releases ##
 
 ### Rev 1p0-rc1 ###
 

--- a/src/integration/test_suites/libs/riscv_hw_if/crt0.s
+++ b/src/integration/test_suites/libs/riscv_hw_if/crt0.s
@@ -57,6 +57,11 @@ _start:
     la t0, early_trap_vector
     csrw mtvec, t0
 
+    // Unlock the mailbox (force)
+    li t0, CLP_MBOX_CSR_MBOX_UNLOCK
+    li t1, MBOX_CSR_MBOX_UNLOCK_UNLOCK_MASK
+    sw t1, 0(t0)
+
     // Copy .data from ROM (imem) to DCCM
     la t0, _data_lma_start
     la t1, _data_lma_end

--- a/src/integration/test_suites/smoke_test_sha_accel/smoke_test_sha_accel.s
+++ b/src/integration/test_suites/smoke_test_sha_accel/smoke_test_sha_accel.s
@@ -39,6 +39,11 @@ _start:
     la t0, early_trap_vector
     csrw mtvec, t0
 
+    // Unlock the mailbox (force)
+    li t0, CLP_MBOX_CSR_MBOX_UNLOCK
+    li t1, MBOX_CSR_MBOX_UNLOCK_UNLOCK_MASK
+    sw t1, 0(t0)
+
     // Init. the stack
     la sp, STACK
 

--- a/src/soc_ifc/rtl/mbox_csr.rdl
+++ b/src/soc_ifc/rtl/mbox_csr.rdl
@@ -36,7 +36,7 @@ addrmap mbox_csr {
         desc="Mailbox lock register for mailbox access, reading 0 will set the lock
         [br]Caliptra Access: RO
         [br]SOC Access:      RO";
-        field {rset; sw=r; hw=r; hwclr=true; precedence=hw; swmod=true;} lock=0;
+        field {rset; sw=r; hw=r; hwclr=true; precedence=hw; swmod=true;} lock=1;
     } mbox_lock;
 
     // user register

--- a/src/soc_ifc/rtl/mbox_csr.rdl
+++ b/src/soc_ifc/rtl/mbox_csr.rdl
@@ -33,7 +33,11 @@ addrmap mbox_csr {
     // clear comes from mailbox control
     reg {
         name="Mailbox Lock";
-        desc="Mailbox lock register for mailbox access, reading 0 will set the lock
+        desc="Mailbox lock register for mailbox access, reading 0 will set the lock.
+        [br]Lock has a reset value of 1 (soc_has_lock resets to 0) indicating
+            Caliptra initially owns the lock. Caliptra microcontroller may perform
+            direct-mode accesses to the mailbox memory, but must unlock and
+            reacquire the lock before it is able to send any mailbox commands.
         [br]Caliptra Access: RO
         [br]SOC Access:      RO";
         field {rset; sw=r; hw=r; hwclr=true; precedence=hw; swmod=true;} lock=1;

--- a/src/soc_ifc/rtl/mbox_csr.sv
+++ b/src/soc_ifc/rtl/mbox_csr.sv
@@ -263,7 +263,7 @@ module mbox_csr (
     end
     always_ff @(posedge clk or negedge hwif_in.cptra_rst_b) begin
         if(~hwif_in.cptra_rst_b) begin
-            field_storage.mbox_lock.lock.value <= 'h0;
+            field_storage.mbox_lock.lock.value <= 'h1;
         end else if(field_combo.mbox_lock.lock.load_next) begin
             field_storage.mbox_lock.lock.value <= field_combo.mbox_lock.lock.next;
         end

--- a/src/soc_ifc/rtl/mbox_csr_uvm.sv
+++ b/src/soc_ifc/rtl/mbox_csr_uvm.sv
@@ -25,7 +25,7 @@ package mbox_csr_uvm;
 
         virtual function void build();
             this.lock = new("lock");
-            this.lock.configure(this, 1, 0, "RS", 1, 'h0, 1, 1, 0);
+            this.lock.configure(this, 1, 0, "RS", 1, 'h1, 1, 1, 0);
             if (has_coverage(UVM_CVR_REG_BITS)) begin
                 foreach(lock_bit_cg[bt]) lock_bit_cg[bt] = new();
             end

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/project_benches/soc_ifc/tb/sequences/src/soc_ifc_cmdline_test_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/project_benches/soc_ifc/tb/sequences/src/soc_ifc_cmdline_test_sequence.svh
@@ -37,6 +37,7 @@ class soc_ifc_cmdline_test_sequence extends soc_ifc_bench_sequence_base;
   rand soc_ifc_env_bringup_sequence_t soc_ifc_env_bringup_seq;
   rand soc_ifc_env_cptra_rst_wait_sequence_t soc_ifc_env_cptra_rst_wait_seq;
   rand soc_ifc_env_cptra_init_interrupts_sequence_t soc_ifc_env_cptra_init_interrupts_seq;
+  rand soc_ifc_env_cptra_mbox_unlock_sequence_t soc_ifc_env_cptra_mbox_unlock_seq;
 
   function new(string name = "" );
     super.new(name);
@@ -55,6 +56,7 @@ class soc_ifc_cmdline_test_sequence extends soc_ifc_bench_sequence_base;
     soc_ifc_env_cptra_rst_wait_seq = soc_ifc_env_cptra_rst_wait_sequence_t::type_id::create("soc_ifc_env_cptra_rst_wait_seq");
 
     soc_ifc_env_cptra_init_interrupts_seq = soc_ifc_env_cptra_init_interrupts_sequence_t::type_id::create("soc_ifc_env_cptra_init_interrupts_seq");
+    soc_ifc_env_cptra_mbox_unlock_seq     = soc_ifc_env_cptra_mbox_unlock_sequence_t::type_id::create("soc_ifc_env_cptra_mbox_unlock_seq");
 
     soc_ifc_ctrl_agent_random_seq      = soc_ifc_ctrl_agent_random_seq_t::type_id::create("soc_ifc_ctrl_agent_random_seq");
     cptra_ctrl_agent_random_seq        = cptra_ctrl_agent_random_seq_t::type_id::create("cptra_ctrl_agent_random_seq");
@@ -66,6 +68,7 @@ class soc_ifc_cmdline_test_sequence extends soc_ifc_bench_sequence_base;
     soc_ifc_env_bringup_seq.soc_ifc_status_agent_rsp_seq = soc_ifc_status_agent_responder_seq;
     soc_ifc_env_cptra_rst_wait_seq.cptra_status_agent_rsp_seq = cptra_status_agent_responder_seq;
     soc_ifc_env_cptra_init_interrupts_seq.cptra_status_agent_rsp_seq = cptra_status_agent_responder_seq;
+    soc_ifc_env_cptra_mbox_unlock_seq.cptra_status_agent_rsp_seq = cptra_status_agent_responder_seq;
 
     reg_model.reset();
     // Start RESPONDER sequences here
@@ -93,8 +96,29 @@ class soc_ifc_cmdline_test_sequence extends soc_ifc_bench_sequence_base;
     // Always initialize interrupts
     // TODO - if we make this random, we can test both interrupt-driven and
     // polling behavior
+    soc_ifc_env_cptra_rst_wait_seq = soc_ifc_env_cptra_rst_wait_sequence_t::type_id::create("soc_ifc_env_cptra_rst_wait_uc_seq");
+    soc_ifc_env_cptra_rst_wait_seq.cptra_status_agent_rsp_seq = cptra_status_agent_responder_seq;
+    soc_ifc_env_cptra_rst_wait_seq.wait_for_noncore_rst_assert   = 1'b0;
+    soc_ifc_env_cptra_rst_wait_seq.wait_for_core_rst_assert      = 1'b0;
+    soc_ifc_env_cptra_rst_wait_seq.wait_for_noncore_rst_deassert = 1'b0;
+    soc_ifc_env_cptra_rst_wait_seq.wait_for_core_rst_deassert    = 1'b1;
+    // Wait for Caliptra uC (Core) reset to be deasserted by SOC_IFC
+    soc_ifc_env_cptra_rst_wait_seq.start(top_configuration.vsqr);
+    `uvm_info("SOC_IFC_CMDLINE_TEST", "SOC_IFC observed uC reset deassertion", UVM_LOW)
     soc_ifc_env_cptra_init_interrupts_seq.start(top_configuration.vsqr);
     `uvm_info("SOC_IFC_CMDLINE_TEST", "Completed interrupt init", UVM_MEDIUM)
+
+    // Delaying before unlocking mailbox roughly simulates the delay before
+    // the ROM can get around to doing the unlock
+    fork
+        begin: DELAY_THEN_MBOX_UNLOCK
+            int unsigned dly;
+            std::randomize(dly) with {dly > 0 ; dly < 256;};
+            soc_ifc_ctrl_agent_config.wait_for_num_clocks(dly);
+            soc_ifc_env_cptra_mbox_unlock_seq.start(top_configuration.vsqr);
+            `uvm_info("SOC_IFC_CMDLINE_TEST", "Completed mailbox unlock", UVM_MEDIUM)
+        end
+    join_none
 
     // Run cmdline provided env sequences
     clp = uvm_cmdline_processor::get_inst();

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/project_benches/soc_ifc/tb/sequences/src/soc_ifc_rand_test_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/project_benches/soc_ifc/tb/sequences/src/soc_ifc_rand_test_sequence.svh
@@ -262,7 +262,7 @@ class soc_ifc_rand_test_sequence extends soc_ifc_bench_sequence_base;
         end
     join
 
-//    fork
+    fork
         // Delaying before unlocking mailbox roughly simulates the delay before
         // the ROM can get around to doing the unlock
         begin: DELAY_THEN_MBOX_UNLOCK
@@ -370,7 +370,7 @@ class soc_ifc_rand_test_sequence extends soc_ifc_bench_sequence_base;
                 end
             endcase
         end
-//    join
+    join
 
     // UVMF_CHANGE_ME : Extend the simulation XXX number of clocks after 
     // the last sequence to allow for the last sequence item to flow 

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_lock_lock.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_lock_lock.svh
@@ -92,10 +92,21 @@ class soc_ifc_reg_cbs_mbox_csr_mbox_lock_lock extends soc_ifc_reg_cbs_mbox_csr;
         if (map.get_name() == this.AHB_map_name) begin
             case (kind) inside
                 UVM_PREDICT_READ: begin
+                    // Reading mbox_lock when it is already locked has no effect, but indicates
+                    // a TB error if the state machine tracker is IDLE
+                    if (value & previous) begin
+                        // Check why lock is set and report
+                        if (rm.mbox_fn_state_sigs.mbox_idle && rm.mbox_locked_from_reset) begin
+                            rm.mbox_locked_from_reset = 0;
+                            `uvm_info("SOC_IFC_REG_CBS", $sformatf("Read from mbox_lock on map [%s] with value [%x] and previous [%x] is expected in state [%p] due to lock being reset to 1", map.get_name(), value, previous, rm.mbox_fn_state_sigs), UVM_LOW)
+                        end
+                        else if (rm.mbox_fn_state_sigs.mbox_idle) begin
+                            `uvm_error("SOC_IFC_REG_CBS", $sformatf("Read from mbox_lock on map [%s] with value [%x] and previous [%x] is unexpected in state [%p]!", map.get_name(), value, previous, rm.mbox_fn_state_sigs))
+                        end
+                    end
                     // Rising edge on RS
-                    // Reading mbox_lock when it is already locked has no effect, so
-                    // only calculate predictions on acquiring lock
-                    if (value & ~previous) begin
+                    // Calculate predictions on acquiring lock
+                    else if (value & ~previous) begin
                         if (rm.mbox_fn_state_sigs.mbox_idle) begin
                             delay_job.state_nxt = MBOX_RDY_FOR_CMD;
                             delay_jobs.push_back(delay_job);
@@ -130,10 +141,16 @@ class soc_ifc_reg_cbs_mbox_csr_mbox_lock_lock extends soc_ifc_reg_cbs_mbox_csr;
                     // Reading mbox_lock when it is already locked (by uC)
                     // triggers a notification interrupt to the uC in Caliptra
                     if (value & previous) begin
-                        if (rm.mbox_fn_state_sigs.mbox_idle) begin
+                        // Check why lock is set and report
+                        if (rm.mbox_fn_state_sigs.mbox_idle && rm.mbox_locked_from_reset) begin
+                            rm.mbox_locked_from_reset = 0;
+                            `uvm_info("SOC_IFC_REG_CBS", $sformatf("Read from mbox_lock on map [%s] with value [%x] and previous [%x] is expected in state [%p] due to lock being reset to 1", map.get_name(), value, previous, rm.mbox_fn_state_sigs), UVM_LOW)
+                        end
+                        else if (rm.mbox_fn_state_sigs.mbox_idle) begin
                             `uvm_error("SOC_IFC_REG_CBS", $sformatf("Read from mbox_lock on map [%s] with value [%x] and previous [%x] is unexpected in state [%p]!", map.get_name(), value, previous, rm.mbox_fn_state_sigs))
                         end
-                        else if (!rm.mbox_status.soc_has_lock.get_mirrored_value()) begin
+                        // Flag the interrupt
+                        if (!rm.mbox_status.soc_has_lock.get_mirrored_value()) begin
                             `uvm_info("SOC_IFC_REG_CBS", $sformatf("Read from mbox_lock on map [%s] with value [%x] and previous [%x] in state [%p] triggers a notification interrupt for soc_req_lock!", map.get_name(), value, previous, rm.mbox_fn_state_sigs), UVM_HIGH)
                             rm.get_parent().get_block_by_name("soc_ifc_reg_rm").get_block_by_name("intr_block_rf_ext").get_field_by_name("notif_soc_req_lock_sts").predict(1'b1, -1, UVM_PREDICT_READ, UVM_PREDICT, rm.get_parent().get_map_by_name(this.AHB_map_name)); /* AHB-access only, use AHB map*/
                         end

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_lock_lock.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_lock_lock.svh
@@ -97,7 +97,6 @@ class soc_ifc_reg_cbs_mbox_csr_mbox_lock_lock extends soc_ifc_reg_cbs_mbox_csr;
                     if (value & previous) begin
                         // Check why lock is set and report
                         if (rm.mbox_fn_state_sigs.mbox_idle && rm.mbox_locked_from_reset) begin
-                            rm.mbox_locked_from_reset = 0;
                             `uvm_info("SOC_IFC_REG_CBS", $sformatf("Read from mbox_lock on map [%s] with value [%x] and previous [%x] is expected in state [%p] due to lock being reset to 1", map.get_name(), value, previous, rm.mbox_fn_state_sigs), UVM_LOW)
                         end
                         else if (rm.mbox_fn_state_sigs.mbox_idle) begin
@@ -143,7 +142,6 @@ class soc_ifc_reg_cbs_mbox_csr_mbox_lock_lock extends soc_ifc_reg_cbs_mbox_csr;
                     if (value & previous) begin
                         // Check why lock is set and report
                         if (rm.mbox_fn_state_sigs.mbox_idle && rm.mbox_locked_from_reset) begin
-                            rm.mbox_locked_from_reset = 0;
                             `uvm_info("SOC_IFC_REG_CBS", $sformatf("Read from mbox_lock on map [%s] with value [%x] and previous [%x] is expected in state [%p] due to lock being reset to 1", map.get_name(), value, previous, rm.mbox_fn_state_sigs), UVM_LOW)
                         end
                         else if (rm.mbox_fn_state_sigs.mbox_idle) begin

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_unlock_unlock.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_unlock_unlock.svh
@@ -39,6 +39,7 @@ class soc_ifc_reg_delay_job_mbox_csr_mbox_unlock_unlock extends soc_ifc_reg_dela
             if (rm.mbox_lock.is_busy()) begin
                 rm.mbox_lock.Xset_busyX(0);
                 rm.mbox_lock.lock.predict(0);
+                rm.mbox_locked_from_reset = 0;
                 rm.mbox_lock.Xset_busyX(1);
             end
             else begin
@@ -59,6 +60,7 @@ class soc_ifc_reg_delay_job_mbox_csr_mbox_unlock_unlock extends soc_ifc_reg_dela
         end
         else begin
             rm.mbox_lock.lock.predict(0);
+            rm.mbox_locked_from_reset = 0;
         end
     endtask
 endclass

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_model_top_pkg.sv
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_model_top_pkg.sv
@@ -416,6 +416,8 @@ package soc_ifc_reg_model_top_pkg;
         uvm_reg_data_t mbox_data_q [$];
         uvm_reg_data_t mbox_resp_q [$];
 
+        bit mbox_locked_from_reset;
+
         extern virtual function void reset(string kind = "HARD");
         function new(string name = "mbox_csr_ext");
             super.new(name);
@@ -423,6 +425,7 @@ package soc_ifc_reg_model_top_pkg;
             mbox_lock_clr_miss = new("mbox_lock_clr_miss");
             mbox_datain_to_dataout_predict = new("mbox_datain_to_dataout_predict");
             mbox_datain_sem = new(1);
+            mbox_locked_from_reset = 1;
         endfunction : new
 
         // FIXME Manually maintaining a list here of registers that are configured
@@ -486,6 +489,8 @@ package soc_ifc_reg_model_top_pkg;
             // Mailbox State Changes
             // TODO what to do for FW update?
             mbox_fn_state_sigs = '{mbox_idle: 1'b1, default: 1'b0};
+
+            mbox_locked_from_reset = 1;
         end
 
     endfunction

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/bringup/cptra/soc_ifc_env_cptra_init_interrupts_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/bringup/cptra/soc_ifc_env_cptra_init_interrupts_sequence.svh
@@ -46,7 +46,7 @@ class soc_ifc_env_cptra_init_interrupts_sequence extends soc_ifc_env_sequence_ba
     reg_model = configuration.soc_ifc_rm;
 
     if (cptra_status_agent_rsp_seq == null)
-        `uvm_fatal("CPTRA_INIT_INTR", "SOC_IFC ENV caliptra reset wait sequence expected a handle to the cptra status agent responder sequence (from bench-level sequence) but got null!")
+        `uvm_fatal("CPTRA_INIT_INTR", "SOC_IFC ENV caliptra interrupt init sequence expected a handle to the cptra status agent responder sequence (from bench-level sequence) but got null!")
     fork
         forever begin
             @(cptra_status_agent_rsp_seq.new_rsp) sts_rsp_count++;
@@ -56,6 +56,8 @@ class soc_ifc_env_cptra_init_interrupts_sequence extends soc_ifc_env_sequence_ba
     // Clear debug locked interrupt 
     data = (uvm_reg_data_t'(1) << reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_debug_locked_sts.get_lsb_pos());
     reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.write(reg_sts, data, UVM_FRONTDOOR, reg_model.soc_ifc_AHB_map, this);
+    if (reg_sts != UVM_IS_OK)
+        `uvm_error("CPTRA_INIT_INTR", $sformatf("Register access failed (%s)", "notif_internal_intr_r"))
 
     // Interrupt Enable (Global)
     data = (uvm_reg_data_t'(1) << reg_model.soc_ifc_reg_rm.intr_block_rf_ext.global_intr_en_r.error_en.get_lsb_pos()) |

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/bringup/cptra/soc_ifc_env_cptra_mbox_unlock_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/bringup/cptra/soc_ifc_env_cptra_mbox_unlock_sequence.svh
@@ -1,0 +1,63 @@
+//----------------------------------------------------------------------
+// Created with uvmf_gen version 2022.3
+//----------------------------------------------------------------------
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// pragma uvmf custom header begin
+// pragma uvmf custom header end
+//----------------------------------------------------------------------
+//----------------------------------------------------------------------
+//
+// DESCRIPTION: Sequence to initialize Caliptra SOC_IFC interrupts
+//
+//----------------------------------------------------------------------
+//----------------------------------------------------------------------
+//
+class soc_ifc_env_cptra_mbox_unlock_sequence extends soc_ifc_env_sequence_base #(.CONFIG_T(soc_ifc_env_configuration_t));
+
+
+  `uvm_object_utils( soc_ifc_env_cptra_mbox_unlock_sequence );
+
+
+  uvm_status_e reg_sts;
+
+  function new(string name = "" );
+    super.new(name);
+
+  endfunction
+
+  virtual task body();
+
+    uvm_reg_data_t data;
+    int sts_rsp_count = 0;
+    reg_model = configuration.soc_ifc_rm;
+
+    if (cptra_status_agent_rsp_seq == null)
+        `uvm_fatal("CPTRA_MBOX_UNLOCK", "SOC_IFC ENV caliptra mailbox unlock sequence expected a handle to the cptra status agent responder sequence (from bench-level sequence) but got null!")
+    fork
+        forever begin
+            @(cptra_status_agent_rsp_seq.new_rsp) sts_rsp_count++;
+        end
+    join_none
+
+    // Write to mbox_unlock
+    data = uvm_reg_data_t'(1) << reg_model.mbox_csr_rm.mbox_unlock.unlock.get_lsb_pos();
+    reg_model.mbox_csr_rm.mbox_unlock.write(reg_sts, data, UVM_FRONTDOOR, reg_model.soc_ifc_AHB_map, this);
+    if (reg_sts != UVM_IS_OK)
+        `uvm_error("CPTRA_MBOX_UNLOCK", $sformatf("Register access failed (%s)", "mbox_unlock"))
+
+  endtask
+
+endclass

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_handler_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_handler_sequence.svh
@@ -244,6 +244,19 @@ task soc_ifc_env_cptra_mbox_handler_sequence::mbox_wait_for_command(output op_st
         if (ntf_rsp_count != 0 && !cptra_status_agent_rsp_seq.rsp.soc_ifc_notif_intr_pending) begin
             ntf_rsp_count = 0;
         end
+        else if (ntf_rsp_count != 0) begin
+            op_active = 1;
+            reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.read(reg_sts, data, UVM_FRONTDOOR, reg_model.soc_ifc_AHB_map, this);
+            report_reg_sts(reg_sts, "notif_internal_intr_r");
+            op_active = 0;
+            if (!data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] && 
+                (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] ||
+                 data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_soc_req_lock_sts.get_lsb_pos()] ||
+                 data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_gen_in_toggle_sts.get_lsb_pos()])) begin
+                `uvm_info("CPTRA_MBOX_HANDLER", $sformatf("After receiving notification interrupt, ignoring set bits 0x%x as notif_cmd_avail_sts is not set!", data), UVM_LOW)
+                ntf_rsp_count = 0;
+            end
+        end
     end
     ntf_rsp_count = 0;
     op_active = 1;

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_handler_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_handler_sequence.svh
@@ -237,9 +237,10 @@ endtask
 //==========================================
 task soc_ifc_env_cptra_mbox_handler_sequence::mbox_wait_for_command(output op_sts_e op_sts);
     uvm_reg_data_t data;
+    bit ntf_is_cmd_avail = 0;
     op_sts = CPTRA_TIMEOUT;
     // Wait for notification interrupt indicating command is available
-    while (ntf_rsp_count == 0) begin
+    while (!ntf_is_cmd_avail) begin
         configuration.soc_ifc_ctrl_agent_config.wait_for_num_clocks(1);
         if (ntf_rsp_count != 0 && !cptra_status_agent_rsp_seq.rsp.soc_ifc_notif_intr_pending) begin
             ntf_rsp_count = 0;
@@ -249,22 +250,24 @@ task soc_ifc_env_cptra_mbox_handler_sequence::mbox_wait_for_command(output op_st
             reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.read(reg_sts, data, UVM_FRONTDOOR, reg_model.soc_ifc_AHB_map, this);
             report_reg_sts(reg_sts, "notif_internal_intr_r");
             op_active = 0;
-            if (!data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] && 
-                (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_soc_req_lock_sts.get_lsb_pos()] ||
-                 data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_gen_in_toggle_sts.get_lsb_pos()])) begin
+            if (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()]) begin
+                ntf_is_cmd_avail = 1;
+                ntf_rsp_count = 0;
+            end
+            else if (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_soc_req_lock_sts.get_lsb_pos()] ||
+                     data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_gen_in_toggle_sts.get_lsb_pos()]) begin
                 `uvm_info("CPTRA_MBOX_HANDLER", $sformatf("After receiving notification interrupt, ignoring set bits 0x%x as notif_cmd_avail_sts is not set!", data), UVM_LOW)
                 ntf_rsp_count = 0;
             end
+            else begin
+                `uvm_error("CPTRA_MBOX_HANDLER", "After receiving notification interrupt, notif_cmd_avail_sts is not set!")
+            end
         end
     end
-    ntf_rsp_count = 0;
     op_active = 1;
     // Clear interrupt
     reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.read(reg_sts, data, UVM_FRONTDOOR, reg_model.soc_ifc_AHB_map, this);
     report_reg_sts(reg_sts, "notif_internal_intr_r");
-    if (!data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()]) begin
-        `uvm_error("CPTRA_MBOX_HANDLER", "After receiving notification interrupt, notif_cmd_avail_sts is not set!")
-    end
     data &= uvm_reg_data_t'(1) << reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos();
     reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.write(reg_sts, data, UVM_FRONTDOOR, reg_model.soc_ifc_AHB_map, this);
     report_reg_sts(reg_sts, "notif_internal_intr_r");

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_handler_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_handler_sequence.svh
@@ -250,8 +250,7 @@ task soc_ifc_env_cptra_mbox_handler_sequence::mbox_wait_for_command(output op_st
             report_reg_sts(reg_sts, "notif_internal_intr_r");
             op_active = 0;
             if (!data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] && 
-                (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] ||
-                 data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_soc_req_lock_sts.get_lsb_pos()] ||
+                (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_soc_req_lock_sts.get_lsb_pos()] ||
                  data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_gen_in_toggle_sts.get_lsb_pos()])) begin
                 `uvm_info("CPTRA_MBOX_HANDLER", $sformatf("After receiving notification interrupt, ignoring set bits 0x%x as notif_cmd_avail_sts is not set!", data), UVM_LOW)
                 ntf_rsp_count = 0;

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_interference_handler_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_interference_handler_sequence.svh
@@ -98,8 +98,7 @@ task soc_ifc_env_cptra_mbox_interference_handler_sequence::mbox_wait_for_command
             reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.read(reg_sts, data, UVM_FRONTDOOR, reg_model.soc_ifc_AHB_map, this);
             report_reg_sts(reg_sts, "notif_internal_intr_r");
             if (!data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] && 
-                (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] ||
-                 data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_soc_req_lock_sts.get_lsb_pos()] ||
+                (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_soc_req_lock_sts.get_lsb_pos()] ||
                  data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_gen_in_toggle_sts.get_lsb_pos()])) begin
                 `uvm_info("CPTRA_MBOX_HANDLER", $sformatf("After receiving notification interrupt, ignoring set bits 0x%x as notif_cmd_avail_sts is not set!", data), UVM_LOW)
                 ntf_rsp_count = 0;

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_interference_handler_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/cptra/soc_ifc_env_cptra_mbox_interference_handler_sequence.svh
@@ -94,6 +94,17 @@ task soc_ifc_env_cptra_mbox_interference_handler_sequence::mbox_wait_for_command
         if (ntf_rsp_count != 0 && !cptra_status_agent_rsp_seq.rsp.soc_ifc_notif_intr_pending) begin
             ntf_rsp_count = 0;
         end
+        else if (ntf_rsp_count != 0) begin
+            reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.read(reg_sts, data, UVM_FRONTDOOR, reg_model.soc_ifc_AHB_map, this);
+            report_reg_sts(reg_sts, "notif_internal_intr_r");
+            if (!data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] && 
+                (data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_cmd_avail_sts.get_lsb_pos()] ||
+                 data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_soc_req_lock_sts.get_lsb_pos()] ||
+                 data[reg_model.soc_ifc_reg_rm.intr_block_rf_ext.notif_internal_intr_r.notif_gen_in_toggle_sts.get_lsb_pos()])) begin
+                `uvm_info("CPTRA_MBOX_HANDLER", $sformatf("After receiving notification interrupt, ignoring set bits 0x%x as notif_cmd_avail_sts is not set!", data), UVM_LOW)
+                ntf_rsp_count = 0;
+            end
+        end
     end
     ntf_rsp_count = 0;
     // Clear interrupt

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/soc_ifc/soc_ifc_env_mbox_rand_medium_interference_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/soc_ifc/soc_ifc_env_mbox_rand_medium_interference_sequence.svh
@@ -70,7 +70,7 @@ task soc_ifc_env_mbox_rand_medium_interference_sequence::mbox_poll_status();
                 if(!this.randomize(RnW, reg_select, data, cycles) with {RnW == APB3_TRANS_READ;
                                                                         reg_select < regs.size();
                                                                         cycles inside {[1:200]}; }) begin
-                    `uvm_error("MBOX_SEQ", "Failed to randomize memory APB transfer in mbox_wait_for_command")
+                    `uvm_error("MBOX_SEQ", "Failed to randomize memory APB transfer in mbox_poll_status")
                 end
                 else begin
                     `uvm_info("MBOX_SEQ", $sformatf("Doing random APB access of type %p to %s, which has is_busy(): %d", RnW, regs[reg_select].get_name(), regs[reg_select].is_busy()), UVM_DEBUG)

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/soc_ifc_env_pkg.sv
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/soc_ifc_env_pkg.sv
@@ -230,6 +230,8 @@ package soc_ifc_env_pkg;
   typedef soc_ifc_env_cptra_rst_wait_sequence soc_ifc_env_cptra_rst_wait_sequence_t;
   `include "sequences/bringup/cptra/soc_ifc_env_cptra_init_interrupts_sequence.svh"
   typedef soc_ifc_env_cptra_init_interrupts_sequence soc_ifc_env_cptra_init_interrupts_sequence_t;
+  `include "sequences/bringup/cptra/soc_ifc_env_cptra_mbox_unlock_sequence.svh"
+  typedef soc_ifc_env_cptra_mbox_unlock_sequence soc_ifc_env_cptra_mbox_unlock_sequence_t;
   `include "sequences/bringup/soc_ifc_env_top_reset_warm_sequence.svh"
   typedef soc_ifc_env_top_reset_warm_sequence soc_ifc_env_top_reset_warm_sequence_t;
   `include "sequences/bringup/soc_ifc_env_top_reset_cold_sequence.svh"


### PR DESCRIPTION
This patch honors the behavior defined in the [Caliptra specification](https://github.com/chipsalliance/Caliptra/blob/main/doc/Caliptra.md#caliptra-fw-push-flow), which stipulates that ROM is responsible for enabling the Mailbox to receive commands out of reset.

This allows ROM to initialize the Mailbox SRAM, which resolves issue #399, prior to enabling the Mailbox to receive data.