### PR TITLE
Fix typos from regression test lists

### DIFF
--- a/src/integration/stimulus/L0_regression.yml
+++ b/src/integration/stimulus/L0_regression.yml
@@ -12,7 +12,7 @@ contents:
         - ../test_suites/smoke_test_mbox_cg/smoke_test_mbox_cg.yml
         - ../test_suites/smoke_test_sha512/smoke_test_sha512.yml
         - ../test_suites/smoke_test_sha256/smoke_test_sha256.yml
-        - ../test_suites/smoke_test_sha256_wntz_rand/smoke_test_sha256_wntz.yml
+        - ../test_suites/smoke_test_sha256_wntz/smoke_test_sha256_wntz.yml
         - ../test_suites/smoke_test_sha256_wntz_rand/smoke_test_sha256_wntz_rand.yml
         - ../test_suites/smoke_test_sha_accel/smoke_test_sha_accel.yml
         - ../test_suites/memCpy_ROM_to_dccm/memCpy_ROM_to_dccm.yml

--- a/src/integration/stimulus/testsuites/caliptra_top_nightly_directed_regression.yml
+++ b/src/integration/stimulus/testsuites/caliptra_top_nightly_directed_regression.yml
@@ -5,11 +5,11 @@ contents:
   - tests:
       tags: ["directed", "nightly", "firmware"]
       paths:
-        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_doe/fw_test_doe.yml
-        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_ecc384/fw_test_ecc384.yml
-        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_hmac384/fw_test_hmac384.yml
-        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_sha256/fw_test_sha256.yml
-        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_sha384/fw_test_sha384.yml
+        #- ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_doe/fw_test_doe.yml
+        #- ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_ecc384/fw_test_ecc384.yml
+        #- ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_hmac384/fw_test_hmac384.yml
+        #- ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_sha256/fw_test_sha256.yml
+        #- ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_sha384/fw_test_sha384.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_lms24/fw_test_lms24.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_lms32/fw_test_lms32.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_datavault_mini/smoke_test_datavault_mini.yml

--- a/src/integration/stimulus/testsuites/caliptra_top_nightly_directed_regression.yml
+++ b/src/integration/stimulus/testsuites/caliptra_top_nightly_directed_regression.yml
@@ -5,11 +5,11 @@ contents:
   - tests:
       tags: ["directed", "nightly", "firmware"]
       paths:
-        - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_doe/fw_test_doe.yml
-        - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_ecc384/fw_test_ecc384.yml
-        - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_hmac384/fw_test_hmac384.yml
-        - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_sha256/fw_test_sha256.yml
-        - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_sha384/fw_test_sha384.yml
+        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_doe/fw_test_doe.yml
+        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_ecc384/fw_test_ecc384.yml
+        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_hmac384/fw_test_hmac384.yml
+        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_sha256/fw_test_sha256.yml
+        - ${MSFT_REPO_ROOT}/src/integration/test_suites/fw_test_sha384/fw_test_sha384.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_lms24/fw_test_lms24.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/fw_test_lms32/fw_test_lms32.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_datavault_mini/smoke_test_datavault_mini.yml


### PR DESCRIPTION
Update paths to fw_test files in nightly directed regression and disable those tests as they are obsolete.
Fix a typo in the L0 regression test list that was introduced alongside new tests for 1.1 features (Winternitz accelerator)