### PR TITLE
User/dev/kupadhyayula/lms init fixes

### DIFF
--- a/src/integration/test_suites/libs/caliptra_isr/caliptra_isr.c
+++ b/src/integration/test_suites/libs/caliptra_isr/caliptra_isr.c
@@ -299,7 +299,8 @@ void init_interrupts(void) {
 
     // SHA256
     // TODO error interrupt enables
-    sha256_reg[SHA256_REG_INTR_BLOCK_RF_ERROR_INTR_EN_R /sizeof(uint32_t)] = SHA256_REG_INTR_BLOCK_RF_ERROR_INTR_EN_R_ERROR0_EN_MASK;
+    sha256_reg[SHA256_REG_INTR_BLOCK_RF_ERROR_INTR_EN_R /sizeof(uint32_t)] = SHA256_REG_INTR_BLOCK_RF_ERROR_INTR_EN_R_ERROR0_EN_MASK |
+                                                                             SHA256_REG_INTR_BLOCK_RF_ERROR_INTR_EN_R_ERROR1_EN_MASK;
     sha256_reg[SHA256_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R /sizeof(uint32_t)] = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R_NOTIF_CMD_DONE_EN_MASK;
     sha256_reg[SHA256_REG_INTR_BLOCK_RF_GLOBAL_INTR_EN_R/sizeof(uint32_t)] = SHA256_REG_INTR_BLOCK_RF_GLOBAL_INTR_EN_R_ERROR_EN_MASK |
                                                                              SHA256_REG_INTR_BLOCK_RF_GLOBAL_INTR_EN_R_NOTIF_EN_MASK;

--- a/src/integration/test_suites/smoke_test_sha256_wntz/caliptra_isr.h
+++ b/src/integration/test_suites/smoke_test_sha256_wntz/caliptra_isr.h
@@ -142,6 +142,12 @@ inline void service_sha256_error_intr() {
         *reg = SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR0_STS_MASK;
         cptra_intr_rcv.sha256_error |= SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR0_STS_MASK;
     }
+
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR1_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR1_STS_MASK;
+        cptra_intr_rcv.sha256_error |= SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR1_STS_MASK;
+    }
 }
 inline void service_sha256_notif_intr() {
     uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);

--- a/src/integration/test_suites/smoke_test_sha256_wntz_rand/caliptra_isr.h
+++ b/src/integration/test_suites/smoke_test_sha256_wntz_rand/caliptra_isr.h
@@ -142,6 +142,12 @@ inline void service_sha256_error_intr() {
         *reg = SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR0_STS_MASK;
         cptra_intr_rcv.sha256_error |= SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR0_STS_MASK;
     }
+
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR1_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR1_STS_MASK;
+        cptra_intr_rcv.sha256_error |= SHA256_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR1_STS_MASK;
+    }
 }
 inline void service_sha256_notif_intr() {
     uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);

--- a/src/sha256/rtl/sha256.sv
+++ b/src/sha256/rtl/sha256.sv
@@ -118,12 +118,13 @@ module sha256
   logic             wntz_n_mode, wntz_n_mode_reg;
   logic [3:0]       wntz_w, wntz_w_reg;
   logic             wntz_w_invalid, wntz_mode_invalid, wntz_j_invalid;
+  logic             invalid_sha_op;
   logic             core_init, core_next, core_mode;
   logic             wntz_init;
   logic             wntz_init_reg;
   logic             wntz_1st_blk, wntz_blk_done;
   logic [7:0]       wntz_iter, wntz_iter_reg;
-  logic [191: 0]    wntz_prefix;
+  logic [175: 0]    wntz_prefix;
 
   typedef enum logic [2:0] {WNTZ_IDLE, WNTZ_1ST, WNTZ_OTHERS} wntz_fsm_t;
   wntz_fsm_t        wntz_fsm, wntz_fsm_next;
@@ -189,12 +190,13 @@ module sha256
                   );
 
   //----------------------------------------------------------------
-  assign wntz_busy     = (wntz_fsm != WNTZ_IDLE);
-  assign wntz_1st_blk  = (wntz_fsm == WNTZ_1ST);
-  assign wntz_blk_done = core_digest_valid & ~core_digest_valid_reg;
-  assign wntz_w_invalid = wntz_busy & !(wntz_w_reg inside {'h1, 'h2, 'h4, 'h8});
-  assign wntz_mode_invalid = wntz_busy & !mode_reg;
-  assign wntz_j_invalid = wntz_mode && (wntz_j_init > wntz_iter);
+  assign wntz_busy          = (wntz_fsm != WNTZ_IDLE);
+  assign wntz_1st_blk       = (wntz_fsm == WNTZ_1ST);
+  assign wntz_blk_done      = core_digest_valid & ~core_digest_valid_reg;
+  assign wntz_w_invalid     = wntz_busy & !(wntz_w_reg inside {'h1, 'h2, 'h4, 'h8});
+  assign wntz_mode_invalid  = wntz_busy & !mode_reg;
+  assign wntz_j_invalid     = wntz_mode && (wntz_j_init > wntz_iter);
+  assign invalid_sha_op     = init_reg && next_reg; //Trigger an error when init and next are high in the same cycle
 
   always_comb begin
     unique casez(wntz_w)
@@ -215,7 +217,7 @@ module sha256
     case (wntz_fsm)
       WNTZ_IDLE: 
         begin 
-          if (wntz_mode && init_reg && (wntz_j_init <= wntz_iter)) begin
+          if (wntz_mode && init_reg && ready_reg && (wntz_j_init <= wntz_iter)) begin
             wntz_fsm_next = WNTZ_1ST;
             wntz_enable = 1'b1;
           end else
@@ -263,10 +265,11 @@ module sha256
 
   always @ (posedge clk or negedge reset_n) begin
       if (!reset_n) begin
-        wntz_j_reg <= '0;
-        wntz_prefix <= '0;
+        wntz_j_reg      <= '0;
+        wntz_prefix     <= '0;
         wntz_n_mode_reg <= '0;
-        wntz_w_reg <= '0;
+        wntz_w_reg      <= '0;
+        wntz_iter_reg   <= '0;
       end else begin
         if (wntz_enable) begin
           wntz_j_reg <= wntz_j_init;
@@ -419,7 +422,7 @@ module sha256
     assign hwif_in.error_reset_b = cptra_pwrgood;
     assign hwif_in.intr_block_rf.notif_internal_intr_r.notif_cmd_done_sts.hwset = core_digest_valid & ~digest_valid_reg;
     assign hwif_in.intr_block_rf.error_internal_intr_r.error0_sts.hwset = wntz_w_invalid | wntz_mode_invalid | wntz_j_invalid;
-    assign hwif_in.intr_block_rf.error_internal_intr_r.error1_sts.hwset = 1'b0; // TODO
+    assign hwif_in.intr_block_rf.error_internal_intr_r.error1_sts.hwset = invalid_sha_op;
     assign hwif_in.intr_block_rf.error_internal_intr_r.error2_sts.hwset = 1'b0; // TODO
     assign hwif_in.intr_block_rf.error_internal_intr_r.error3_sts.hwset = 1'b0; // TODO
 


### PR DESCRIPTION
1. Update wntz_prefix bus width to 176 bits
2. Block wntz_fsm from advancing from IDLE to 1st state when ready_reg is low
3. Reset wntz_iter_reg to 0
4. Add error condition when init_reg and next_reg are high in the same cycle