### PR TITLE
UVM: Fix some failing scenarios

### DIFF
--- a/src/hmac/uvmf_2022/uvmf_template_output/project_benches/HMAC/tb/testbench/hdl_top.sv
+++ b/src/hmac/uvmf_2022/uvmf_template_output/project_benches/HMAC/tb/testbench/hdl_top.sv
@@ -25,6 +25,7 @@ module hdl_top;
 
 import HMAC_parameters_pkg::*;
 import uvmf_base_pkg_hdl::*;
+import kv_defines_pkg::*;
 
   // pragma attribute hdl_top partition_module_xrtl                                            
 // pragma uvmf custom clock_generator begin
@@ -43,10 +44,15 @@ import uvmf_base_pkg_hdl::*;
 
 // pragma uvmf custom reset_generator begin
   bit rst;
+  bit cptra_pwrgood;
   // Instantiate a rst driver
   // tbx clkgen
   initial begin
     rst = 0; 
+    cptra_pwrgood = 0;
+    @(negedge clk)
+    @(posedge clk)
+    cptra_pwrgood = 1;
     #200ns;
     rst =  1; 
   end
@@ -83,12 +89,21 @@ import uvmf_base_pkg_hdl::*;
   //verilog_dut         dut_verilog(   .clk(clk), .rst(rst), .in_signal(vhdl_to_verilog_signal), .out_signal(verilog_to_vhdl_signal));
   //vhdl_dut            dut_vhdl   (   .clk(clk), .rst(rst), .in_signal(verilog_to_vhdl_signal), .out_signal(vhdl_to_verilog_signal));
  
+var kv_rd_resp_t [1:0] kv_rd_resp;
+var kv_wr_resp_t       kv_wr_resp;
+initial begin
+    kv_rd_resp[0] = '{default:0};
+    kv_rd_resp[1] = '{default:0};
+    kv_wr_resp    = '{default:0};
+end
+
 hmac_ctrl #(
      .AHB_DATA_WIDTH(32),
      .AHB_ADDR_WIDTH(32)
 ) dut (
-     .clk	          (HMAC_in_agent_bus.clk),
+     .clk           (HMAC_in_agent_bus.clk),
      .reset_n       (HMAC_in_agent_bus.hmac_rst),
+     .cptra_pwrgood (cptra_pwrgood),
      .haddr_i       (HMAC_in_agent_bus.haddr),
      .hwdata_i      (HMAC_in_agent_bus.hwdata),
      .hsel_i        (HMAC_in_agent_bus.hsel),
@@ -101,8 +116,8 @@ hmac_ctrl #(
      .hrdata_o      (HMAC_out_agent_bus.hrdata),
      .kv_read    (),
      .kv_write   (),
-     .kv_rd_resp (),
-     .kv_wr_resp (),
+     .kv_rd_resp (kv_rd_resp),
+     .kv_wr_resp (kv_wr_resp),
      .error_intr (),
      .notif_intr (),
      .debugUnlock_or_scan_mode_switch('0)

--- a/src/integration/test_suites/libs/riscv_hw_if/link.ld
+++ b/src/integration/test_suites/libs/riscv_hw_if/link.ld
@@ -28,7 +28,7 @@ SECTIONS {
   /* Only upper half of DCCM is used for ROM image */
   _data_lma_start = ALIGN(4);
   _data_vma_start = 0x50010000;
-  .data _data_vma_start : AT(_data_lma_start) { *(.*data) *(.rodata*) *(.srodata*) ; . = ALIGN(4);} =0x0000,
+  .data _data_vma_start : AT(_data_lma_start) { *(.*data) *(.*data.*) *(.rodata*) *(.srodata*) ; . = ALIGN(4);} =0x0000,
   _data_lma_end = _data_lma_start + SIZEOF(.data);
   _data_vma_end = _data_vma_start + SIZEOF(.data);
 

--- a/src/integration/test_suites/smoke_test_ras/smoke_test_ras.ld
+++ b/src/integration/test_suites/smoke_test_ras/smoke_test_ras.ld
@@ -45,7 +45,7 @@ SECTIONS {
   . = _bss_vma_end;
   _dccm_lma_start = _bss_vma_end; /* ----\___ SAME */
   _dccm_vma_start = _bss_vma_end; /* ----/         */
-  .dccm _dccm_vma_start : AT(_dccm_lma_start) { *(.*data) *(.rodata*) *(.dccm*) . = ALIGN(4); } =0x0000,
+  .dccm _dccm_vma_start : AT(_dccm_lma_start) { *(.*data) *(.*data.*) *(.rodata*) *(.dccm*) . = ALIGN(4); } =0x0000,
   iccm_code0_start = .;
 
   /* ICCM as VMA */

--- a/src/sha512/uvmf_sha512/uvmf_template_output/project_benches/SHA512/tb/testbench/hdl_top.sv
+++ b/src/sha512/uvmf_sha512/uvmf_template_output/project_benches/SHA512/tb/testbench/hdl_top.sv
@@ -25,6 +25,8 @@ module hdl_top;
 
 import SHA512_parameters_pkg::*;
 import uvmf_base_pkg_hdl::*;
+import kv_defines_pkg::*;
+import pv_defines_pkg::*;
 
   // pragma attribute hdl_top partition_module_xrtl                                            
 // pragma uvmf custom clock_generator begin
@@ -43,10 +45,15 @@ import uvmf_base_pkg_hdl::*;
 
 // pragma uvmf custom reset_generator begin
   bit rst;
+  bit cptra_pwrgood;
   // Instantiate a rst driver
   // tbx clkgen
   initial begin
     rst = 0; 
+    cptra_pwrgood = 0;
+    @(negedge clk)
+    @(posedge clk)
+    cptra_pwrgood = 1;
     #200ns;
     rst =  1; 
   end
@@ -78,6 +85,18 @@ import uvmf_base_pkg_hdl::*;
   // UVMF_CHANGE_ME : Add DUT and connect to signals in _bus interfaces listed above
   // Instantiate your DUT here
   // These DUT's instantiated to show verilog and vhdl instantiation
+
+var kv_rd_resp_t kv_rd_resp;
+var kv_wr_resp_t kv_wr_resp;
+var pv_rd_resp_t pv_rd_resp;
+var pv_wr_resp_t pv_wr_resp;
+initial begin
+    kv_rd_resp = '{default:0};
+    kv_wr_resp = '{default:0};
+    pv_rd_resp = '{default:0};
+    pv_wr_resp = '{default:0};
+end
+
   sha512_ctrl #(
              .AHB_DATA_WIDTH(32),
              .AHB_ADDR_WIDTH(32)
@@ -85,6 +104,7 @@ import uvmf_base_pkg_hdl::*;
             dut (
              .clk(SHA512_in_agent_bus.clk),
              .reset_n(SHA512_in_agent_bus.rst),
+             .cptra_pwrgood(cptra_pwrgood),
 
              .haddr_i(SHA512_in_agent_bus.hadrr),
              .hwdata_i(SHA512_in_agent_bus.hwdata),
@@ -99,12 +119,12 @@ import uvmf_base_pkg_hdl::*;
              .hrdata_o(SHA512_out_agent_bus.hrdata),
              .kv_read   (),
              .kv_write  (),
-             .kv_rd_resp(),
-             .kv_wr_resp(),
+             .kv_rd_resp(kv_rd_resp),
+             .kv_wr_resp(kv_wr_resp),
              .pv_read   (),
              .pv_write  (),
-             .pv_rd_resp(),
-             .pv_wr_resp(),
+             .pv_rd_resp(pv_rd_resp),
+             .pv_wr_resp(pv_wr_resp),
              .pcr_signing_hash(),
              .error_intr(),
              .notif_intr(),


### PR DESCRIPTION
Recent addition of assertions to check for X values on register interfaces revealed some issues with HMAC/SHA512 UVM testbenches. Fix those issues by driving undriven signals with 0 - until an improved solution is available.
Fix an issue with validation firmware linker script - it was excluding both sections `sdata` and `data.datavault`, which causes some issues sims (detected this while doing Caliptra SEED work, but applicable to main also). 