### PR TITLE
Lint fix to resolve synthesis issue for SHA512 masked IP

### DIFF
--- a/src/sha512_masked/rtl/sha512_masked_defines_pkg.sv
+++ b/src/sha512_masked/rtl/sha512_masked_defines_pkg.sv
@@ -25,51 +25,51 @@ package sha512_masked_defines_pkg;
   //----------------------------------------------------------------
   // Function definition.
   //----------------------------------------------------------------
-  function masked_reg_t masked_not (input masked_reg_t x);
+  function automatic masked_reg_t masked_not (input masked_reg_t x);
     return {~x.masked, x.random};
   endfunction
 
-  function reg [63:0] masked_and (input masked_reg_t x, y);
+  function automatic reg [63:0] masked_and (input masked_reg_t x, y);
     return ~y.masked & (~y.random & x.random | y.random & x.masked) | y.masked & (y.random & x.random | ~y.random & x.masked); //x & y;
   endfunction
 
-  function masked_reg_t masked_maj (input masked_reg_t a, b, c);
+  function automatic masked_reg_t masked_maj (input masked_reg_t a, b, c);
     return {masked_and(a, b) ^ masked_and(a, c) ^ masked_and(b, c), b.random};
   endfunction
 
-  function masked_reg_t masked_ch (input masked_reg_t e, f, g);
+  function automatic masked_reg_t masked_ch (input masked_reg_t e, f, g);
     return {masked_and(e, f) ^ masked_and(g, masked_not(e)), e.random ^ g.random};
   endfunction
 
-  function reg [63:0] sigma0 (input reg [63:0] x);
+  function automatic reg [63:0] sigma0 (input reg [63:0] x);
     return {x[27 : 0], x[63 : 28]} ^
            {x[33 : 0], x[63 : 34]} ^
            {x[38 : 0], x[63 : 39]};
   endfunction
 
-  function reg [63:0] sigma1 (input reg [63:0] x);
+  function automatic reg [63:0] sigma1 (input reg [63:0] x);
     return {x[13 : 0], x[63 : 14]} ^
            {x[17 : 0], x[63 : 18]} ^
            {x[40 : 0], x[63 : 41]};
   endfunction
 
-  function reg [63:0] ROT1 (input reg [63:0] x);
+  function automatic reg [63:0] ROT1 (input reg [63:0] x);
     return {x[0],       x[63 : 1]} ^ // ROTR1
            {x[7 : 0],   x[63 : 8]} ^ // ROTR8
            {7'b0000000, x[63 : 7]};  // SHR7           
   endfunction
   
-  function reg [63:0] ROT14 (input reg [63:0] x);
+  function automatic reg [63:0] ROT14 (input reg [63:0] x);
     return {x[18 : 0], x[63 : 19]} ^ // ROTR19
            {x[60 : 0], x[63 : 61]} ^ // ROTR61
            {6'b000000, x[63 : 6]};   // SHR6          
   endfunction
   
-  function masked_reg_t masked_sum (input masked_reg_t x, y);
+  function automatic masked_reg_t masked_sum (input masked_reg_t x, y);
     return {(x.masked + y.masked), (x.random + y.random)};
   endfunction
 
-  function masked_reg_t B2A_conv (input masked_reg_t x, logic q); // convert x_masked = x ^ rnd to x_prime = x + rand
+  function automatic masked_reg_t B2A_conv (input masked_reg_t x, logic q); // convert x_masked = x ^ rnd to x_prime = x + rand
     reg [63 : 0] masked_carry;  // masked_carry[j] = c[j] ^ q
     reg [63 : 0] x_prime;
     for (int j = 0; j < 64 ; j++) begin
@@ -85,7 +85,7 @@ package sha512_masked_defines_pkg;
     return {x_prime, x.random};
   endfunction
 
-  function masked_reg_t A2B_conv (input masked_reg_t x, logic q); // convert x_prime = x + rand to x_masked = x ^ rnd
+  function automatic masked_reg_t A2B_conv (input masked_reg_t x, logic q); // convert x_prime = x + rand to x_masked = x ^ rnd
     reg [63 : 0] masked_carry;  // masked_carry[j] = c[j] ^ q
     reg [63 : 0] x_masked;
  


### PR DESCRIPTION
Declare functions in the sha512 masked package as 'automatic' to resolve a synthesis warning