### PR TITLE
[SOC_IFC_TB] Initialize mailbox RAM in unittest

### DIFF
--- a/src/soc_ifc/tb/soc_ifc_tb.sv
+++ b/src/soc_ifc/tb/soc_ifc_tb.sv
@@ -292,6 +292,10 @@ module soc_ifc_tb
 
 
   //SRAM for mbox
+  initial begin
+    mbox_ram1.ram = '{default:8'h0};
+  end
+
   caliptra_sram 
   #(
     .DATA_WIDTH(32),


### PR DESCRIPTION
Resolves a regression failure due to detecting X values from the SRAM