### PR TITLE
[UVM] Fix regression failure caused by a false negative

### DIFF
--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/soc_ifc/soc_ifc_env_mbox_dlen_invalid_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/soc_ifc/soc_ifc_env_mbox_dlen_invalid_sequence.svh
@@ -45,6 +45,8 @@ class soc_ifc_env_mbox_dlen_invalid_sequence extends soc_ifc_env_mbox_sequence_b
 
   function new(string name = "" );
     super.new(name);
+    this.mbox_sts_exp_error = 1;
+    this.mbox_sts_exp_error_type = EXP_ERR_RSP_DLEN;
   endfunction
 
 endclass


### PR DESCRIPTION
Add code to predict/anticipate an error condition when injecting an invalid DLEN value as an error test sequence. This resolves an error that fires when the (expected) failure status is returned for the command. 