### PR TITLE
[UVM] Implement mailbox sanitize feature in val fw to suppress regression failure

### DIFF
--- a/src/integration/test_suites/caliptra_rt/caliptra_rt.c
+++ b/src/integration/test_suites/caliptra_rt/caliptra_rt.c
@@ -519,6 +519,10 @@ void caliptra_rt() {
                         CLEAR_INTR_FLAG_SAFELY(cptra_intr_rcv.soc_ifc_error, ~SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK)
                         VPRINTF(LOW, "Clearing FW soc_ifc_error intr bit (ECC unc) after servicing\n");
                         soc_ifc_set_mbox_status_field(CMD_FAILURE);
+                        // TODO Remove the mailbox sanitization op in Gen2 validation framework.
+                        //      In Gen2, Caliptra Mailbox code should be modified to avoid spurious
+                        //      SRAM prefetches that make this sanitization necessary after a double-bit
+                        //      ECC error
                         if (soc_ifc_sanitize_mbox_n_bytes(dlen_received >= (MBOX_DIR_SPAN) ? MBOX_DIR_SPAN : dlen_received, 0xfff) != 0) {
                             SEND_STDOUT_CTRL(0x1);
                             while(1);
@@ -570,6 +574,10 @@ void caliptra_rt() {
                         CLEAR_INTR_FLAG_SAFELY(cptra_intr_rcv.soc_ifc_error, ~SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK)
                         VPRINTF(LOW, "Clearing FW soc_ifc_error intr bit (ECC unc) after servicing\n");
                         soc_ifc_set_mbox_status_field(CMD_FAILURE);
+                        // TODO Remove the mailbox sanitization op in Gen2 validation framework.
+                        //      In Gen2, Caliptra Mailbox code should be modified to avoid spurious
+                        //      SRAM prefetches that make this sanitization necessary after a double-bit
+                        //      ECC error
                         if (soc_ifc_sanitize_mbox_n_bytes(dlen_received >= (MBOX_DIR_SPAN) ? MBOX_DIR_SPAN : dlen_received, 0xfff) != 0) {
                             SEND_STDOUT_CTRL(0x1);
                             while(1);

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
@@ -112,9 +112,11 @@ inline void soc_ifc_set_iccm_lock() {
     lsu_write_32((CLP_SOC_IFC_REG_INTERNAL_ICCM_LOCK), SOC_IFC_REG_INTERNAL_ICCM_LOCK_LOCK_MASK);
 }
 // Mailbox command flows
+uint8_t soc_ifc_mbox_acquire_lock(uint32_t attempt_count);
 mbox_op_s soc_ifc_read_mbox_cmd();
 void soc_ifc_mbox_fw_flow(mbox_op_s op);
 void soc_ifc_fw_update(mbox_op_s op);
+uint8_t soc_ifc_sanitize_mbox_n_bytes(uint32_t byte_count, uint32_t attempt_count);
 
 // SHA Accelerator Functions
 void soc_ifc_sha_accel_acquire_lock();

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/soc_ifc/soc_ifc_env_mbox_sram_double_bit_flip_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/soc_ifc/soc_ifc_env_mbox_sram_double_bit_flip_sequence.svh
@@ -110,7 +110,7 @@ endclass
 
 //==========================================
 // Task:        mbox_teardown
-// Description: At end-of-sequence, injuect some stalls to allow
+// Description: At end-of-sequence, inject some stalls to allow
 //              uC to acquire lock and sanitize the mailbox
 //==========================================
 task soc_ifc_env_mbox_sram_double_bit_flip_sequence::mbox_teardown();

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/soc_ifc/soc_ifc_env_mbox_sram_double_bit_flip_sequence.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/sequences/mbox/soc_ifc/soc_ifc_env_mbox_sram_double_bit_flip_sequence.svh
@@ -40,6 +40,8 @@ class soc_ifc_env_mbox_sram_double_bit_flip_sequence extends soc_ifc_env_mbox_se
 
   `uvm_object_utils( soc_ifc_env_mbox_sram_double_bit_flip_sequence )
 
+  extern virtual task mbox_teardown();
+
   // Constrain command to undefined opcode
   constraint mbox_cmd_undef_c { !(mbox_op_rand.cmd.cmd_s inside {defined_cmds}); }
 
@@ -105,3 +107,13 @@ class soc_ifc_env_mbox_sram_double_bit_flip_sequence extends soc_ifc_env_mbox_se
   endtask
 
 endclass
+
+//==========================================
+// Task:        mbox_teardown
+// Description: At end-of-sequence, injuect some stalls to allow
+//              uC to acquire lock and sanitize the mailbox
+//==========================================
+task soc_ifc_env_mbox_sram_double_bit_flip_sequence::mbox_teardown();
+    do_rand_delay(1, DLY_MEDIUM);
+    super.mbox_teardown();
+endtask


### PR DESCRIPTION
Implement a firmware feature (for the validation code used in UVM tests) to sanitize the mailbox after detecting double-bit ECC error, to mirror the workaround required in 1.1 Firmware as per https://github.com/chipsalliance/caliptra-rtl/issues/399.

This is a temporary solution that should be removed for 2.0, as the mailbox should be modified to avoid spurious data prefetches.