### PR TITLE
[UVM] Fix for a regression failure caused by cycle-inaccurate FSM prediction logic in TB

### DIFF
--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_execute_execute.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_execute_execute.svh
@@ -40,7 +40,6 @@ class soc_ifc_reg_delay_job_mbox_csr_mbox_execute_execute extends soc_ifc_reg_de
             rm.mbox_status.mbox_fsm_ps.predict(state_nxt, .kind(UVM_PREDICT_READ), .path(UVM_PREDICT), .map(map));
             case (state_nxt) inside
                 MBOX_IDLE: begin
-                    rm.mbox_fn_state_sigs = '{mbox_idle: 1'b1, default: 1'b0};
                     rm.mbox_status.status.predict(CMD_BUSY, .kind(UVM_PREDICT_READ), .path(UVM_PREDICT), .map(map));
                     rm.mbox_status.soc_has_lock.predict(1'b0, .kind(UVM_PREDICT_READ), .path(UVM_PREDICT), .map(map));
                     `uvm_info("SOC_IFC_REG_DELAY_JOB", $sformatf("post_predict called through map [%p] on mbox_execute results in state transition. Functional state tracker: [%p] mbox_fsm_ps transition [%p]", map.get_name(), rm.mbox_fn_state_sigs, state_nxt), UVM_FULL)
@@ -56,6 +55,7 @@ class soc_ifc_reg_delay_job_mbox_csr_mbox_execute_execute extends soc_ifc_reg_de
                         if (rm.mbox_lock.is_busy()) begin
                             rm.mbox_lock.Xset_busyX(0);
                             rm.mbox_lock.lock.predict(0);
+                            rm.mbox_fn_state_sigs = '{mbox_idle: 1'b1, default: 1'b0};
                             rm.mbox_lock.Xset_busyX(1);
                         end
                         else begin
@@ -76,6 +76,7 @@ class soc_ifc_reg_delay_job_mbox_csr_mbox_execute_execute extends soc_ifc_reg_de
                     end
                     else begin
                         rm.mbox_lock.lock.predict(0);
+                        rm.mbox_fn_state_sigs = '{mbox_idle: 1'b1, default: 1'b0};
                     end
                 end
                 MBOX_EXECUTE_SOC: begin

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_unlock_unlock.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_cbs_mbox_csr_mbox_unlock_unlock.svh
@@ -25,7 +25,6 @@ class soc_ifc_reg_delay_job_mbox_csr_mbox_unlock_unlock extends soc_ifc_reg_dela
         rm.mbox_status.status.predict(CMD_BUSY, .kind(UVM_PREDICT_READ), .path(UVM_PREDICT), .map(map));
         rm.mbox_status.mbox_fsm_ps.predict(MBOX_IDLE, .kind(UVM_PREDICT_READ), .path(UVM_PREDICT), .map(map));
         rm.mbox_status.soc_has_lock.predict(1'b0, .kind(UVM_PREDICT_READ), .path(UVM_PREDICT), .map(map));
-        rm.mbox_fn_state_sigs = '{mbox_idle: 1'b1, default: 1'b0};
         rm.mbox_unlock.unlock.predict(1'b0);
         if (rm.mbox_lock.is_busy()) begin
             `uvm_info("SOC_IFC_REG_DELAY_JOB", "Delay job for mbox_unlock attempted to clear mbox_lock, but hit access collision! Flagging clear event in reg-model for mbox_lock callback to handle", UVM_LOW)
@@ -39,6 +38,7 @@ class soc_ifc_reg_delay_job_mbox_csr_mbox_unlock_unlock extends soc_ifc_reg_dela
             if (rm.mbox_lock.is_busy()) begin
                 rm.mbox_lock.Xset_busyX(0);
                 rm.mbox_lock.lock.predict(0);
+                rm.mbox_fn_state_sigs = '{mbox_idle: 1'b1, default: 1'b0};
                 rm.mbox_lock.Xset_busyX(1);
             end
             else begin
@@ -59,6 +59,7 @@ class soc_ifc_reg_delay_job_mbox_csr_mbox_unlock_unlock extends soc_ifc_reg_dela
         end
         else begin
             rm.mbox_lock.lock.predict(0);
+            rm.mbox_fn_state_sigs = '{mbox_idle: 1'b1, default: 1'b0};
         end
     endtask
 endclass

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/src/soc_ifc_predictor.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/src/soc_ifc_predictor.svh
@@ -737,6 +737,7 @@ class soc_ifc_predictor #(
                     // Complete any scheduled predictions to 0 (due to other delay jobs)
                     if (p_soc_ifc_rm.mbox_csr_rm.mbox_lock_clr_miss.is_on()) begin
                         p_soc_ifc_rm.mbox_csr_rm.mbox_lock.lock.predict(0);
+                        p_soc_ifc_rm.mbox_csr_rm.mbox_fn_state_sigs = '{mbox_idle: 1'b1, default: 1'b0};
                         `uvm_info("PRED_AHB", "Completed mbox_lock deassert prediction (scheduled by mbox_execute) since mbox_lock reg prediction is disabled, due to failed AHB transfer", UVM_MEDIUM)
                         p_soc_ifc_rm.mbox_csr_rm.mbox_lock_clr_miss.reset(0);
                     end


### PR DESCRIPTION
Resolves an issue where mbox_lock is accessed simultaneously by SoC and by Caliptra FW and UVM predictor fails to accurately track FSM transitions.