### PR TITLE
Publish HTML docs for 1.1 RTL in addition to main

### DIFF
--- a/.github/workflow_metadata/README.md
+++ b/.github/workflow_metadata/README.md
@@ -19,4 +19,9 @@ pr\_\* objects are used to validate a Pull Request run. This is in support of an
       - Pull Request runs a hash on the branch fileset (including the timestamp), compares with the contents of pr\_hash. If the hash mismatches, the feature branch is considered to have failed the internal workflow
   1. Pull Request is allowed to be merged only once all Actions complete successfully
 
-The Pull Request run ignores updates to documentation files. That is, commits containing only markdown (.md) or image (.png) files are not required to pass the timestamp/hash check.
+The Pull Request run ignores updates to documentation files. That is, commits containing only the following files are not required to pass the timestamp/hash check.
+
+* Markdown (.md)
+* Images (.png)
+* Github Workflows (.github/workflows/**)
+

--- a/.github/workflows/doc-gen.yml
+++ b/.github/workflows/doc-gen.yml
@@ -44,10 +44,52 @@ jobs:
           cp -R src/soc_ifc/docs/caliptra_top_reg_html /tmp/pages-docs/main/external-regs
           find /tmp/pages-docs
 
-      - name: Generate GitHub Pages artifacts
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload artifacts for main
+        uses: actions/upload-artifact@v4
         with:
-          path: /tmp/pages-docs
+          name: pages_main
+          path: /tmp/pages-docs/main
+
+  build-1_1:
+    name: Build v1.1
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "patch_v1.1"
+
+      - name: Install peakrdl
+        run: |
+          python3 -m pip install \
+              systemrdl-compiler==1.27.3 \
+              peakrdl-systemrdl==0.3.0 \
+              peakrdl-regblock==0.21.0 \
+              peakrdl-uvm==2.3.0 \
+              peakrdl-ipxact==3.4.3 \
+              peakrdl-html==2.10.1 \
+              peakrdl-cheader==1.0.0 \
+              peakrdl==1.1.0
+
+      - name: Generate docs for v1.1
+        run: |
+          echo Running script
+          tools/scripts/reg_doc_gen.sh
+
+      - name: Stage documents for v1.1
+        run: |
+          mkdir -p /tmp/pages-docs/v1_1
+          tools/scripts/reg_doc_gen.sh
+          cp -R src/integration/docs/caliptra_reg_html /tmp/pages-docs/v1_1/internal-regs
+          cp -R src/soc_ifc/docs/caliptra_top_reg_html /tmp/pages-docs/v1_1/external-regs
+          find /tmp/pages-docs
+
+      - name: Upload artifacts for v1.1
+        uses: actions/upload-artifact@v4
+        with:
+          name: pages_v1_1
+          path: /tmp/pages-docs/v1_1
 
   deploy:
     name: Deploy
@@ -63,8 +105,25 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-22.04
-      
+
     steps:
+      - name: Download main artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: pages_main
+          path: /tmp/pages-docs/main
+
+      - name: Download v1.1 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: pages_v1_1
+          path: /tmp/pages-docs/v1_1
+
+      - name: Generate GitHub Pages artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: /tmp/pages-docs
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/CaliptraReleaseChecklist.md
+++ b/docs/CaliptraReleaseChecklist.md
@@ -52,3 +52,4 @@ For each release, the following steps are followed to ensure code functionality 
   - Add latest synthesis results to the [CaliptraIntegrationSpecification](./CaliptraIntegrationSpecification.md#netlist-synthesis-data)
   - Update [Release_Notes](../Release_Notes.md)
   - Tag the main branch on GitHub to generate an official release
+  - Generate version-specific registers documentation page in the [Register Documentation Workflow](./.github/workflows/doc-gen.yml)


### PR DESCRIPTION
Currently the docs workflow only publishes documentation for registers at main. To make it easier to look up registers for 1.x, also publish the registers from the patch_v1.1 branch.

This was tested on my fork of this repo. See sample output:

* Workflow run: https://github.com/jhand2/caliptra-rtl/actions/runs/12472498726
* main: https://jhand2.github.io/caliptra-rtl/main/internal-regs/?p=
* 1.1: https://jhand2.github.io/caliptra-rtl/v1_1/internal-regs/?p=