### PR TITLE
[RTL] AXI Sub Arb fix. Add recovery inf synchros. Export trace signals. Move SS dbg unlock reg to pwrgood.

### DIFF
--- a/docs/CaliptraIntegrationSpecification.md
+++ b/docs/CaliptraIntegrationSpecification.md
@@ -183,7 +183,18 @@ The table below details the interface required for each SRAM. Driver direction i
 | jtag_trst_n | 1 | Input | Asynchronous assertion<br>Synchronous deassertion to jtag_tck | |
 | jtag_tdo | 1 | Output | Synchronous to jtag_tck | |
 
-*Table 10: Subsystem Straps and Control*
+*Table 10: RISC-V Trace interface*
+| Signal name | Width | Driver | Synchronous (as viewed from Caliptra’s boundary) | Description |
+| :--------- | :--------- | :--------- | :--------- | :--------- |
+| trace_rv_i_insn_ip      | 32 | Output | Synchronous to clk | |
+| trace_rv_i_address_ip   | 32 | Output | Synchronous to clk | |
+| trace_rv_i_valid_ip     |  1 | Output | Synchronous to clk | |
+| trace_rv_i_exception_ip |  1 | Output | Synchronous to clk | |
+| trace_rv_i_ecause_ip    |  5 | Output | Synchronous to clk | |
+| trace_rv_i_interrupt_ip |  1 | Output | Synchronous to clk | |
+| trace_rv_i_tval_ip      | 32 | Output | Synchronous to clk | |
+
+*Table 11: Subsystem Straps and Control*
 
 | Signal name | Width      | Driver     | Synchronous (as viewed from Caliptra’s boundary) | Description |
 | :---------- | :--------- | :--------- | :----------------------------------------------- | :--------- |
@@ -206,7 +217,7 @@ The table below details the interface required for each SRAM. Driver direction i
 | recovery_data_avail                                       | 1   | Input       | Synchronous to clk | | 
 | recovery_image_activated                                  | 1   | Input       | Synchronous to clk | | 
 
-*Table 11: Security and miscellaneous*
+*Table 12: Security and miscellaneous*
 
 | Signal name | Width | Driver  | Synchronous (as viewed from Caliptra’s boundary) | Description |
 | :--------- | :--------- | :--------- | :--------- | :--------- |
@@ -325,13 +336,13 @@ The interface signals generic\_input\_wires, generic\_output\_wires, and strap\_
 
 While these late binding interface pins are generic in nature until assigned a function, integrators must not define non-standard use cases for these pins. Defining standard use cases ensures that the security posture of Caliptra in the final implementation is not degraded relative to the consortium design intent. Bits in generic\_input\_wires and strap\_ss\_strap\_generic\_N that don't have a function defined in Caliptra must be tied to a 0-value. These undefined input bits shall not be connected to any flip flops (which would allow run-time transitions on the value).
 
-Each wire connects to a register in the SoC Interface register bank through which communication to the internal microprocessor may be facilitated. Each of the generic wire signals is 64 bits in size. The size of the generic strap is indicated in Table 10.
+Each wire connects to a register in the SoC Interface register bank through which communication to the internal microprocessor may be facilitated. Each of the generic wire signals is 64 bits in size. The size of the generic strap is indicated in Table 11.
 
 Activity on any bit of the generic\_input\_wires triggers a notification interrupt to the microcontroller indicating a bit toggle.
 
 The following table describes the allocation of functionality on generic\_input\_wires. All bits not listed in this table must be tied to 0.
 
-*Table 12: generic\_input\_wires function binding*
+*Table 13: generic\_input\_wires function binding*
 
 | Bit  | Name               | Description                                         |
 | :--------- | :--------- | :--------- |
@@ -449,7 +460,7 @@ It is strongly recommended that these AXI_USER registers are either set at integ
 
 Caliptra provides 5 programmable registers that SoC can set at boot time to limit access to the mailbox peripheral. The default AXI_USER set by the integration parameter CPTRA\_DEF\_MBOX\_VALID\_AXI\_USER is valid at all times. CPTRA\_MBOX\_VALID\_AXI\_USER registers become valid once the corresponding lock bit CPTRA\_MBOX\_AXI\_USER\_LOCK is set.
 
-*Table 13: AXI\_USER register definition*
+*Table 14: AXI\_USER register definition*
 
 | Register                               | Description |
 | :--------- | :--------- |
@@ -460,7 +471,7 @@ Caliptra provides 5 programmable registers that SoC can set at boot time to limi
 
 Another option for limiting access to the mailbox peripheral are the integration time parameters that override the programmable AXI_USER registers. At integration time, the CPTRA\_SET\_MBOX\_AXI\_USER\_INTEG parameters can be set to 1 which enables the corresponding CPTRA\_MBOX\_VALID\_AXI\_USER parameters to override the programmable register.
 
-*Table 14: AXI_USER Parameter definition*
+*Table 15: AXI_USER Parameter definition*
 
 | Parameter                          | Description                                                                                                                            |
 | :--------- | :--------- |
@@ -498,7 +509,7 @@ After a mailbox protocol violation is flagged, it is reported to the system in s
 
 The following table describes AXI transactions that cause the Mailbox FSM to enter the ERROR state, given that the register “mbox\_user” contains the value of the AXI USER that was used to originally acquire the mailbox lock.
 
-*Table 15: Mailbox protocol error trigger conditions*
+*Table 16: Mailbox protocol error trigger conditions*
 
 | FSM state         | SoC HAS LOCK | AXI USER eq mbox_user | Error state trigger condition                                                        |
 | :--------- | :--------- | :--------- | :--------- |
@@ -594,7 +605,7 @@ The following memories are exported:
 * Instruction Closely-Coupled Memory (ICCM)
 * Data Closely Coupled Memory (DCCM)
 
-Table 8 indicates the signals contained in the memory interface. Direction is relative to the exported memory wrapper that is instantiated outside of the Caliptra subsystem (that is, from the testbench perspective).
+Table 7 indicates the signals contained in the memory interface. Direction is relative to the exported memory wrapper that is instantiated outside of the Caliptra subsystem (that is, from the testbench perspective).
 
 ## SRAM timing behavior
 * [Writes] Input wren signal is asserted simultaneously with input data and address. Input data is stored at the input address 1 clock cycle later.
@@ -611,7 +622,7 @@ The following figure shows the SRAM interface timing.
 
 Parameterization for ICCM/DCCM memories is derived from the configuration of the VeeR RISC-V core that has been selected for Caliptra integration. Parameters defined in the VeeR core determine signal dimensions at the Caliptra top-level interface and drive requirements for SRAM layout. For details about interface parameterization, see the [Interface](#interface) section. The following configuration options from the RISC-V Core dictate this behavior:
 
-*Table 16: SRAM parameterization*
+*Table 17: SRAM parameterization*
 
 | Parameter       | Value | Description |
 | :--------- | :--------- | :--------- |
@@ -690,7 +701,7 @@ The following table describes SoC integration requirements.
 
 For additional information, see [Caliptra assets and threats](https://github.com/chipsalliance/Caliptra/blob/main/doc/Caliptra.md#caliptra-assets-and-threats).
 
-*Table 17: SoC integration requirements*
+*Table 18: SoC integration requirements*
 
 | Category | Requirement | Definition of done | Rationale |
 | :--------- | :--------- | :--------- | :--------- |
@@ -762,7 +773,7 @@ For additional information, see [Caliptra assets and threats](https://github.com
 | Implementation                   | SoC shall apply size-only constraints on cells tagged with the "u\_\_size\_only\_\_" string and shall ensure that these are not optimized in synthesis and PNR                                                                                                                 | Statement of conformance | Required for Caliptra threat model                |
 | GLS FEV                          | GLS FEV must be run to make sure netlist and RTL match and none of the countermeasures are optimized away. See the following table for example warnings from synthesis runs to resolve through FEV                                                                             | GLS simulations pass                 | Functional requirement                |
 
-*Table 18: Caliptra synthesis warnings for FEV evaluation*
+*Table 19: Caliptra synthesis warnings for FEV evaluation*
 
 | Module                    | Warning | Line No. | Description |
 | :--------- | :--------- | :--------- | :--------- |
@@ -776,7 +787,7 @@ For additional information, see [Caliptra assets and threats](https://github.com
 
 Several files contain code that may be specific to an integrator's implementation and should be overridden. This overridable code is either configuration parameters with integrator-specific values or modules that implement process-specific functionality. Code in these files should be modified or replaced by integrators using components from the cell library of their fabrication vendor. The following table describes recommended modifications for each file.
 
-*Table 19: Caliptra integrator custom RTL file list*
+*Table 20: Caliptra integrator custom RTL file list*
 
 | File                                                                                   | Description                                                            |
 | :------------------------------------------------------------------------------------- | :--------------------------------------------------------------------- |
@@ -838,7 +849,7 @@ In an unconstrained environment, several RDC violations are anticipated. RDC ana
 ### Reset domains
 The following table identifies the major reset domains in Caliptra core IP design.
 
-*Table 20: Reset definitions (functional resets are marked in **bold**)*
+*Table 21: Reset definitions (functional resets are marked in **bold**)*
 
 | Reset name | Reset type | Reset polarity | Definition point | Reset generated by |
 | ---------- | ---------- | -------------- | ---------------- | ------------------ |
@@ -863,7 +874,7 @@ The reset definitions can be visually represented as shown in the following diag
 
 The following table shows the false paths between various reset groups.
 
-*Table 21: Reset domain crossing false paths*
+*Table 22: Reset domain crossing false paths*
 
 | Launch flop reset | Capture flop reset | Comment |
 | ------------------| ------------------ | ------- |
@@ -876,7 +887,7 @@ The following table shows the false paths between various reset groups.
 
 ## Reset sequencing scenarios
 
-The resets defined in *Table 20* have the following sequencing phases, which are applicable for different reset scenarios: cold boot, cold reset, warm reset and firmware reset.
+The resets defined in *Table 21* have the following sequencing phases, which are applicable for different reset scenarios: cold boot, cold reset, warm reset and firmware reset.
 
 The reset sequencing is illustrated in the following waveform.
 
@@ -888,7 +899,7 @@ The reset sequencing is illustrated in the following waveform.
 
 The following table defines the order in which resets can get asserted. A ">>" in a cell at row X and column Y indicates that if the reset in row X is asserted, the reset in row Y is also asserted. For rest of the cells (in which symbol ">>" is not present) the preceding assumption is not true and so the paths between those resets are potential RDC violations. The black cells are ignored because they are between the same resets.
 
-*Table 22: Reset sequence ordering constraints*
+*Table 23: Reset sequence ordering constraints*
 
 ![](./images/reset_ordering.png)
 
@@ -902,7 +913,7 @@ The following set of constraints and assumptions must be provided before running
 2. The following debug register, which is driven from JTAG, is not toggled during functional flow.
     - u_caliptra.rvtop.veer.dbg.dmcontrol_reg[0] = 0
 3. Set *scan_mode* to 0 for functional analysis.
-4. Stamp or create functional resets for *cptra_noncore_rst_b* and *cptra_uc_rst_b* at the definition points, as mentioned in *Table 20*.
+4. Stamp or create functional resets for *cptra_noncore_rst_b* and *cptra_uc_rst_b* at the definition points, as mentioned in *Table 21*.
 5. Create funtional reset grouping - This step must be customized as per the EDA tool, which is being used for RDC analysis. The goal of this customization is to achieve the following three sequencing requirements/constraints.
     - Gate all clocks when *cptra_noncore_rst_b* is asserted. This ensures that the capture flop clock is gated while the source flop's reset is getting asserted, thereby preventing the capture flop from becoming metastable. The result is when *cptra_noncore_rst_b* is going to be asserted, the following signals are constrained to be at 1 at around that time.
         - soc_ifc_top1.i_soc_ifc_boot_fsm.rdc_clk_dis
@@ -922,14 +933,14 @@ The following set of constraints and assumptions must be provided before running
         - csrng.u_reg.u_ahb_slv_sif.dv
         - entropy_src.u_reg.u_ahb_slv_sif.dv
         - aes_inst.ahb_slv_sif_inst.dv
-6. Constrain the RDC false paths as per *Table 21*.
+6. Constrain the RDC false paths as per *Table 22*.
 
 
 ## RDC violations and waivers
 
-Considering the given constraints, three sets of crossings were identified as RDC violations. All of them can be waived as explained in *Table 23*. Note that the report may differ across EDA tools due to variations in structural analysis, which can be influenced by a range of settings.
+Considering the given constraints, three sets of crossings were identified as RDC violations. All of them can be waived as explained in *Table 24*. Note that the report may differ across EDA tools due to variations in structural analysis, which can be influenced by a range of settings.
 
-*Table 23: Reset domain crossing violations*
+*Table 24: Reset domain crossing violations*
 
 | Sl no | Launch reset | Launch flop | Capture reset | Capture flop |
 | ------| ------------ | ----------- | ------------- | ------------ |
@@ -971,7 +982,7 @@ The following scenarios can occur.
 
 <br>
 
-*Table 24: Reset domain crossing scenarios for #3 and #4 crossing*
+*Table 25: Reset domain crossing scenarios for #3 and #4 crossing*
 
 | #Case | *es_bypass_mode* | *fw_ov_mode_entropy_insert* | *pfifo_bypass_push* | *pfifo_bypass_wdata* | Comment |
 | ------| ---------------- | --------------------------- | ------------------- | -------------------- | ------- |
@@ -999,7 +1010,7 @@ The area is expressed in units of square microns.
 
 The target foundry technology node is an industry standard, moderately advanced technology node as of 2024 June.
 
-*Table 25: Netlist synthesis data*
+*Table 26: Netlist synthesis data*
 
 | **IP Name**      | **Date**  | **Path Group**       | **Target Freq** | **QoR WNS** | **QoR Achieveable Freq** |
 | :--------- | :--------- | :--------- | :--------- | :--------- | :--------- |
@@ -1021,7 +1032,7 @@ A standardized set of lint rules is used to sign off on each release. The lint p
 
 The following terminology is used in this document.
 
-*Table 26: Terminology*
+*Table 27: Terminology*
 
 | Abbreviation | Description                                                                                      |
 | :--------- | :--------- |

--- a/src/axi/rtl/axi_dma_reg.rdl
+++ b/src/axi/rtl/axi_dma_reg.rdl
@@ -54,7 +54,7 @@ addrmap axi_dma_reg {
         name="Caliptra AXI DMA Control";
         desc="Used to drive command parameters and initiate operations to DMA block.";
         field { desc="Initiate current configured operation."; sw=rw; swwel=dma_swwel; onwrite=woset; swmod; hw=r; hwclr=true; } go=1'b0;
-        field { desc="Flush active operations, reset state machines, clear FIFO data. Any in-flight AXI transactions will be gracefully completed."; sw=rw; swwel=soc_req; onwrite=woset; hw=r; hwclr=true; } flush=1'b0;
+        field { desc="Flush active operations, reset state machines, clear FIFO data. Not yet implemented: Any in-flight AXI transactions will be gracefully completed."; sw=rw; swwel=soc_req; onwrite=woset; hw=r; hwclr=true; } flush=1'b0;
         field { desc="RESERVED."; sw=r; } rsvd0[14]=14'h0000;
         field { desc="Read Route. Configures how the AXI read channel operates for the current operation.";
                 enum rd_route_e {

--- a/src/axi/rtl/axi_sub_arb.sv
+++ b/src/axi/rtl/axi_sub_arb.sv
@@ -99,10 +99,10 @@ module axi_sub_arb import axi_pkg::*; #(
             r_pri <= 1'b1;
         else if (r_dv && !r_hld &&  r_last)
             r_pri <= 1'b0;
-        // Keep priority when burst starts
-        else if (w_dv && !r_win && !w_last)
+        // Keep priority when xfer is in progress
+        else if (w_dv && !r_win)
             r_pri <= 1'b0;
-        else if (r_dv &&  r_win && !r_last)
+        else if (r_dv &&  r_win)
             r_pri <= 1'b1;
     end
 

--- a/src/entropy_src/config/compile.yml
+++ b/src/entropy_src/config/compile.yml
@@ -58,7 +58,7 @@ schema_version: 2.4.0
 requires:
   - entropy_src
 targets:
-  rtl:
+  tb:
     directories: [$COMPILE_ROOT/tb]
     files:
       - $COMPILE_ROOT/tb/physical_rng.sv

--- a/src/entropy_src/config/entropy_src_tb.vf
+++ b/src/entropy_src/config/entropy_src_tb.vf
@@ -45,6 +45,7 @@ ${CALIPTRA_ROOT}/src/csrng/rtl/csrng_reg_pkg.sv
 ${CALIPTRA_ROOT}/src/csrng/rtl/csrng_pkg.sv
 ${CALIPTRA_ROOT}/src/edn/rtl/edn_pkg.sv
 ${CALIPTRA_ROOT}/src/entropy_src/tb/physical_rng.sv
+${CALIPTRA_ROOT}/src/entropy_src/tb/entropy_src_tb.sv
 ${CALIPTRA_ROOT}/src/libs/rtl/ahb_to_reg_adapter.sv
 ${CALIPTRA_ROOT}/src/kmac/rtl/sha3_pkg.sv
 ${CALIPTRA_ROOT}/src/kmac/rtl/keccak_round.sv
@@ -127,4 +128,3 @@ ${CALIPTRA_ROOT}/src/entropy_src/rtl/entropy_src_core.sv
 ${CALIPTRA_ROOT}/src/entropy_src/rtl/entropy_src_repcnt_ht.sv
 ${CALIPTRA_ROOT}/src/entropy_src/rtl/entropy_src_ack_sm.sv
 ${CALIPTRA_ROOT}/src/entropy_src/rtl/entropy_src.sv
-${CALIPTRA_ROOT}/src/entropy_src/tb/entropy_src_tb.sv

--- a/src/integration/rtl/caliptra_top.sv
+++ b/src/integration/rtl/caliptra_top.sv
@@ -152,6 +152,10 @@ module caliptra_top
     logic                       rdc_clk_cg      ;
     logic                       uc_clk_cg       ;
 
+    // Synchronized inputs
+    logic                       recovery_data_avail_sync;
+    logic                       recovery_image_activated_sync;
+
     logic        [2:0]          s_axi_active    ;
 
     logic        [31:0]         ic_haddr        ;
@@ -1229,6 +1233,27 @@ entropy_src #(
 
 `endif
 
+// Synchronizers for input from Subsystem Recovery Interface
+caliptra_prim_flop_2sync #(
+    .Width            (1),
+    .ResetValue       (0),
+    .EnablePrimCdcRand(1)
+) sync_payload_avail (
+    .clk_i (clk                     ),
+    .rst_ni(cptra_noncore_rst_b     ),
+    .d_i   (recovery_data_avail     ),
+    .q_o   (recovery_data_avail_sync)
+);
+caliptra_prim_flop_2sync #(
+    .Width            (1),
+    .ResetValue       (0),
+    .EnablePrimCdcRand(1)
+) sync_image_activated (
+    .clk_i (clk                          ),
+    .rst_ni(cptra_noncore_rst_b          ),
+    .d_i   (recovery_image_activated     ),
+    .q_o   (recovery_image_activated_sync)
+);
 
 soc_ifc_top #(
     .AHB_ADDR_WIDTH(`CALIPTRA_SLAVE_ADDR_WIDTH(`CALIPTRA_SLAVE_SEL_SOC_IFC)),
@@ -1258,8 +1283,8 @@ soc_ifc_top1
     .mailbox_data_avail(mailbox_data_avail),
     .mailbox_flow_done(mailbox_flow_done),
 
-    .recovery_data_avail(recovery_data_avail),
-    .recovery_image_activated(recovery_image_activated),
+    .recovery_data_avail     (recovery_data_avail_sync     ),
+    .recovery_image_activated(recovery_image_activated_sync),
 
     .security_state(cptra_security_state_Latched),
     

--- a/src/integration/rtl/caliptra_top.sv
+++ b/src/integration/rtl/caliptra_top.sv
@@ -122,6 +122,15 @@ module caliptra_top
     input logic  [63:0]                generic_input_wires,
     output logic [63:0]                generic_output_wires,
 
+    // RISC-V Trace Ports
+    output logic [31:0]         trace_rv_i_insn_ip,
+    output logic [31:0]         trace_rv_i_address_ip,
+    output logic                trace_rv_i_valid_ip,
+    output logic                trace_rv_i_exception_ip,
+    output logic [4:0]          trace_rv_i_ecause_ip,
+    output logic                trace_rv_i_interrupt_ip,
+    output logic [31:0]         trace_rv_i_tval_ip,
+
     input security_state_t             security_state,
     input logic                        scan_mode
 );
@@ -155,14 +164,6 @@ module caliptra_top
     logic        [63:0]         ic_hrdata       ;
     logic                       ic_hready       ;
     logic                       ic_hresp        ;
-
-    logic        [31:0]         trace_rv_i_insn_ip;
-    logic        [31:0]         trace_rv_i_address_ip;
-    logic                       trace_rv_i_valid_ip;
-    logic                       trace_rv_i_exception_ip;
-    logic        [4:0]          trace_rv_i_ecause_ip;
-    logic                       trace_rv_i_interrupt_ip;
-    logic        [31:0]         trace_rv_i_tval_ip;
 
     logic                       o_debug_mode_status;
 

--- a/src/integration/tb/caliptra_top_tb.sv
+++ b/src/integration/tb/caliptra_top_tb.sv
@@ -284,6 +284,15 @@ caliptra_top caliptra_top_dut (
     .generic_input_wires (generic_input_wires),
     .generic_output_wires(                   ),
 
+    // RISC-V Trace Ports
+    .trace_rv_i_insn_ip     (), // TODO
+    .trace_rv_i_address_ip  (), // TODO
+    .trace_rv_i_valid_ip    (), // TODO
+    .trace_rv_i_exception_ip(), // TODO
+    .trace_rv_i_ecause_ip   (), // TODO
+    .trace_rv_i_interrupt_ip(), // TODO
+    .trace_rv_i_tval_ip     (), // TODO
+
     .security_state(security_state),
     .scan_mode     (scan_mode)
 );

--- a/src/integration/uvmf_caliptra_top/uvmf_template_output/project_benches/caliptra_top/tb/testbench/hdl_top.sv
+++ b/src/integration/uvmf_caliptra_top/uvmf_template_output/project_benches/caliptra_top/tb/testbench/hdl_top.sv
@@ -366,6 +366,15 @@ import aaxi_uvm_pkg::*;
         .generic_input_wires (soc_ifc_subenv_soc_ifc_ctrl_agent_bus.generic_input_wires),
         .generic_output_wires(soc_ifc_subenv_soc_ifc_status_agent_bus.generic_output_wires),
 
+        // RISC-V Trace Ports
+        .trace_rv_i_insn_ip     (), // TODO
+        .trace_rv_i_address_ip  (), // TODO
+        .trace_rv_i_valid_ip    (), // TODO
+        .trace_rv_i_exception_ip(), // TODO
+        .trace_rv_i_ecause_ip   (), // TODO
+        .trace_rv_i_interrupt_ip(), // TODO
+        .trace_rv_i_tval_ip     (), // TODO
+
         .security_state(soc_ifc_subenv_soc_ifc_ctrl_agent_bus.security_state),
         .scan_mode     (1'b0) // TODO
     );

--- a/src/soc_ifc/rtl/soc_ifc_reg.sv
+++ b/src/soc_ifc/rtl/soc_ifc_reg.sv
@@ -4627,8 +4627,8 @@ module soc_ifc_reg (
             field_combo.SS_SOC_DBG_UNLOCK_LEVEL[i0].LEVEL.next = next_c;
             field_combo.SS_SOC_DBG_UNLOCK_LEVEL[i0].LEVEL.load_next = load_next_c;
         end
-        always_ff @(posedge clk or negedge hwif_in.cptra_rst_b) begin
-            if(~hwif_in.cptra_rst_b) begin
+        always_ff @(posedge clk or negedge hwif_in.cptra_pwrgood) begin
+            if(~hwif_in.cptra_pwrgood) begin
                 field_storage.SS_SOC_DBG_UNLOCK_LEVEL[i0].LEVEL.value <= 32'h0;
             end else if(field_combo.SS_SOC_DBG_UNLOCK_LEVEL[i0].LEVEL.load_next) begin
                 field_storage.SS_SOC_DBG_UNLOCK_LEVEL[i0].LEVEL.value <= field_combo.SS_SOC_DBG_UNLOCK_LEVEL[i0].LEVEL.next;

--- a/src/soc_ifc/rtl/soc_ifc_subsystem_reg.rdl
+++ b/src/soc_ifc/rtl/soc_ifc_subsystem_reg.rdl
@@ -201,7 +201,7 @@ reg {
             [br]Caliptra Access: RW
             [br]SOC Access:      RO
             [br]TAP Access [in debug/manuf mode]: RO";
-    field {desc="Debug unlock level"; sw=rw; swwel=true/*soc_req || !debug_intent*/; hw=rw; we;} LEVEL[32] = 32'h0;
+    field {desc="Debug unlock level"; sw=rw; swwel=true/*soc_req || !debug_intent*/; hw=rw; we; resetsignal = cptra_pwrgood; } LEVEL[32] = 32'h0;
 } SS_SOC_DBG_UNLOCK_LEVEL[2];
 
 reg {

--- a/src/soc_ifc/stimulus/testsuites/uvmf_soc_ifc_promote_regression.yml
+++ b/src/soc_ifc/stimulus/testsuites/uvmf_soc_ifc_promote_regression.yml
@@ -8,8 +8,10 @@ contents:
       weight: 100
       generations: 6
       formats: 
-        generate: "reseed {template}.yml -seed {seed}"
-        path: "{template_basename}__{seed}.yml"
+#        generate: "reseed {template}.yml -seed {seed}"
+#        path: "{template_basename}__{seed}.yml"
+        generate: "reseed {template}.yml -seed 1"
+        path: "{template_basename}__1.yml"
       templates:
         $CALIPTRA_ROOT/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/project_benches/soc_ifc/tb/tests/src/soc_ifc_cmdline_test   : { weight 100 }
         $CALIPTRA_ROOT/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/project_benches/soc_ifc/tb/tests/src/soc_ifc_rand_test      : { weight 500 }


### PR DESCRIPTION
AXI Sub Arb fix. 
* Resolves #753 

Add synchronizers to input signals from subsystem recovery interface. 
Export RISC-V trace signals for debug.
Move SS dbg unlock level reg to pwrgood so it's sticky and persists across warm resets without having to redo the debug unlock flow.