### PR TITLE
[UVM] Fix a race condition between interrupt callbacks

### DIFF
--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_delay_job_intr_block_rf_ext.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_delay_job_intr_block_rf_ext.svh
@@ -18,6 +18,8 @@
 class soc_ifc_reg_delay_job_intr_block_rf_ext extends soc_ifc_reg_delay_job;
     `uvm_object_utils( soc_ifc_reg_delay_job_intr_block_rf_ext )
 
+    bit nullify = 1'b0;
+
     uvm_reg_field req_fld; /* used to report the reg field that caused the delay job */
     uvm_reg       sts_reg;
     uvm_reg       en_reg ;
@@ -30,27 +32,40 @@ class soc_ifc_reg_delay_job_intr_block_rf_ext extends soc_ifc_reg_delay_job;
     uvm_reg_data_t val_en_glb ;
     uvm_reg_data_t val_sts_glb;
 
+    virtual function void nullify_job();
+        nullify = 1'b1;
+    endfunction
+
     virtual function void grab_values();
+//        soc_ifc_ctrl_configuration cfg;
+//        if( !uvm_config_db #( soc_ifc_ctrl_configuration )::get( null , "CONFIGURATIONS" , "soc_ifc_ctrl_agent_BFM" , cfg ) ) 
+//          `uvm_fatal("CFG" , "uvm_config_db #( soc_ifc_ctrl_configuration )::get cannot find resource soc_ifc_ctrl_agent_BFM" )
         fork
             begin
             // Wait for all predictor callbacks to run for every intr bit accessed
             // during the current clock cycle, so mirrors are up to date
-            uvm_wait_for_nba_region();
+//            uvm_wait_for_nba_region();
             // There might be delay_jobs running additional bit updates
             // at this point, so wait again
             // FIXME -- find a better way to capture field updates at each clock edge
-            uvm_wait_for_nba_region();
+//            uvm_wait_for_nba_region();
+            #1ps;
             // Snapshot of current value, since next cycle may see value changes again
             val_sts_reg = sts_reg.get_mirrored_value();
             val_en_reg  = en_reg .get_mirrored_value();
             val_en_glb  = en_glb .get_mirrored_value();
             val_sts_glb = sts_glb.get_mirrored_value();
+            `uvm_info("SOC_IFC_REG_DELAY_JOB", $sformatf("Grabbed val_sts_reg 0x%x", val_sts_reg), UVM_LOW)
             end
         join_none
     endfunction
 
     virtual task do_job();
         `uvm_info("SOC_IFC_REG_DELAY_JOB", $sformatf("Running delayed job for %s", req_fld.get_full_name()), UVM_MEDIUM)
+        if (nullify) begin
+            `uvm_info("SOC_IFC_REG_DELAY_JOB", $sformatf("Delayed job for %s is nullified. Exiting...", req_fld.get_full_name()), UVM_MEDIUM)
+            return;
+        end
         if (!sts_glb.get_mirrored_value() && |(val_sts_reg & val_en_reg)) begin
             sts_glb.predict(1'b1);
             `uvm_info("SOC_IFC_REG_DELAY_JOB",

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_model_top_pkg.sv
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/environment_packages/soc_ifc_env_pkg/registers/soc_ifc_reg_model_top_pkg.sv
@@ -30,12 +30,17 @@ package soc_ifc_reg_model_top_pkg;
 
    import uvm_pkg::*;
 // pragma uvmf custom additional_imports begin
+
+    // Generated UVM reg models from RDL
     import soc_ifc_reg_uvm::*;
     import mbox_csr_uvm::*;
     import sha512_acc_csr_uvm::*;
     import axi_dma_reg_uvm::*;
+    // SOC_IFC params
     import mbox_pkg::*;
     import soc_ifc_pkg::*;
+
+    // Avery VIP
     `include "avery_defines.svh"
     import aaxi_pkg::*;
     import aaxi_pkg_xactor::*;

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/interface_packages/soc_ifc_ctrl_pkg/src/soc_ifc_ctrl_configuration.svh
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/interface_packages/soc_ifc_ctrl_pkg/src/soc_ifc_ctrl_configuration.svh
@@ -180,6 +180,14 @@ class soc_ifc_ctrl_configuration  extends uvmf_parameterized_agent_configuration
   endtask
 
   // ****************************************************************************
+  // TASK: wait_for_negedge
+  // *[Required]* Blocks until the next clock negedge. The wait_for_negedge
+  // operation is performed by a task in the monitor bfm.
+  virtual task wait_for_negedge();
+    monitor_bfm.wait_for_negedge();
+  endtask
+
+  // ****************************************************************************
   // FUNCTION : convert2string()
   // This function is used to convert variables in this class into a string for log messaging.
   // 

--- a/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/interface_packages/soc_ifc_ctrl_pkg/src/soc_ifc_ctrl_monitor_bfm.sv
+++ b/src/soc_ifc/uvmf_soc_ifc/uvmf_template_output/verification_ip/interface_packages/soc_ifc_ctrl_pkg/src/soc_ifc_ctrl_monitor_bfm.sv
@@ -212,6 +212,10 @@ end
     @(posedge clk_i);
     repeat (count-1) @(posedge clk_i);                                                    
   endtask      
+
+  task automatic wait_for_negedge();
+      @(negedge clk_i);
+  endtask
   // pragma uvmf custom wait_for_num_clocks end                                                                
 
   //******************************************************************                         


### PR DESCRIPTION
Update callbacks to enforce hwset precedence over swclr on interrupt status regs.