### PR TITLE
Added generic synthesis define to guard non synthesizable code in axi_if.sv

### DIFF
--- a/src/axi/rtl/axi_if.sv
+++ b/src/axi/rtl/axi_if.sv
@@ -164,6 +164,7 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
         input  bready
     );
 
+`ifndef SYNTHESIS
     // synopsys translate_off
 
     // Tasks
@@ -397,5 +398,6 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
     `undef TIME_ALGN
 
     // synopsys translate_on
+ `endif
 
 endinterface


### PR DESCRIPTION
Added generic synthesis define to guard non synthesizable code in axi_if.sv

There is an existing guard pragma (synopsys translate_off) but this only works for synopsys tools. Using this common SYNTHESIS define that is also used in other files in Caliptra the guard is extended to other tools as well. 

One could argue that with this change the synopsys pragma is no longer needed and should be removed entirely. I did not do so to minimize the delta, but would be open to feedback and can push another commit to this PR removing it if desired.

Fixes #811 