### PR TITLE
[RTL] Add valid-based guarding conditions to data outputs of AES and SHA256/512

### DIFF
--- a/src/aes/rtl/aes_cipher_core.sv
+++ b/src/aes/rtl/aes_cipher_core.sv
@@ -781,7 +781,7 @@ module aes_cipher_core import aes_pkg::*;
   /////////////
 
   // The output of the last round is not stored into the state register but forwarded directly.
-  assign state_o = add_round_key_out;
+  assign state_o =  out_valid_o ? add_round_key_out : '{default: '{default: '0}};
 
   ////////////////
   // Assertions //

--- a/src/sha256/rtl/sha256_core.v
+++ b/src/sha256/rtl/sha256_core.v
@@ -189,8 +189,9 @@ module sha256_core(
   //----------------------------------------------------------------
   assign ready = ready_flag;
 
-  assign digest = {H0_reg, H1_reg, H2_reg, H3_reg,
-                   H4_reg, H5_reg, H6_reg, H7_reg};
+  assign digest = digest_valid_reg ? 
+                  {H0_reg, H1_reg, H2_reg, H3_reg,
+                   H4_reg, H5_reg, H6_reg, H7_reg} : 256'b0;
 
   assign digest_valid = digest_valid_reg;
 

--- a/src/sha512/rtl/sha512_core.v
+++ b/src/sha512/rtl/sha512_core.v
@@ -198,8 +198,9 @@ module sha512_core(
   //----------------------------------------------------------------
   assign ready = ready_reg;
 
-  assign digest = {H0_reg, H1_reg, H2_reg, H3_reg,
-                   H4_reg, H5_reg, H6_reg, H7_reg};
+  assign digest = digest_valid_reg ?
+                  {H0_reg, H1_reg, H2_reg, H3_reg,
+                   H4_reg, H5_reg, H6_reg, H7_reg} : 512'b0;
 
   assign digest_valid = digest_valid_reg;
 

--- a/src/sha512_masked/rtl/sha512_masked_core.sv
+++ b/src/sha512_masked/rtl/sha512_masked_core.sv
@@ -237,8 +237,9 @@ module sha512_masked_core
   //----------------------------------------------------------------
   assign ready = ready_reg;
 
-  assign digest = {H0_reg, H1_reg, H2_reg, H3_reg,
-                   H4_reg, H5_reg, H6_reg, H7_reg};
+  assign digest = digest_valid_reg ?
+                  {H0_reg, H1_reg, H2_reg, H3_reg,
+                   H4_reg, H5_reg, H6_reg, H7_reg} : 512'b0;
 
   assign digest_valid = digest_valid_reg;
 


### PR DESCRIPTION
## Summary

- This pull request adds a valid-based guarding condition to the RTL code driving the cryptographic state/results to the output of the `aes_cipher_core`, `sha256_core`, `sha512_core`, and `sha512_masked_core` modules.
- Without this guarding condition, intermediate cryptographic state/results are continuously driven to the module output.
- With the guarding condition, a safe default value (i.e., zero) is driven to the output unless the final cryptographic state/results are available (indicated by the valid signal).

Note: A similar [issue](https://github.com/chipsalliance/caliptra-rtl/issues/191) was previously raised and a previous [pull request](https://github.com/chipsalliance/caliptra-rtl/pull/589) addressed that issue.

## Details

### Potential for Intermediate Crypto State/Results Leakage
The `aes_cipher_core`, `sha256_core`, `sha512_core`, and `sha512_masked_core` modules are cryptographic primitives that produce a complete cryptographic output (e.g., ciphertext, digest, etc.) for AES, SHA256, and SHA512, respectively. From a security perspective, these modules should refrain from outputting any intermediate state/results to ensure they remain cryptographically sound. Any leakage of intermediate state/results could be used by an adversary to jeopardize the security of the final state/results produced by these modules through direct access or side channel attacks (see [CWE-1431](https://cwe.mitre.org/data/definitions/1431)). 

In the following code block, we highlight the RTL code responsible for driving the cryptographic output of these four modules.

```verilog
//Relevant code from aes_cipher_core
assign state_o = add_round_key_out;

//Relevant code from sha256_core.sv, sha512_core.sv, and sha512_masked_core.sv
assign digest = {H0_reg, H1_reg, H2_reg, H3_reg,
                 H4_reg, H5_reg, H6_reg, H7_reg};
```

At the end of the crypto operation, the `add_round_key_out` and `HX_reg` signals contain final state/results. However, during the various rounds of the crypto operation, they contain intermediate state/results. As seen in the RTL code, these intermediate values are driven to the output, creating unnecessary security risk due to intermediate leakage.

Note: These potential leakages were detected using the hyperflow graph static analysis tool and verified using Cycuity's Radix with VCS.

### Security Impact and Mitigation
The security impact of this intermediate leakage is low due to how these modules are used within Caliptra. All four of these `<x>_core` modules are wrapped in other modules. The wrapper modules only sample the final crypto state/results of the cores thanks to conditional expressions involving the cores' `valid` or `ready` signals. The following code block highlights how the wrapper modules use `valid` or `ready` to prevent the intermediate leakage from propagating any further.

```verilog
// Wrapper for aes_cipher_core
module aes_core
  //...
  aes_cipher_core #(...) u_aes_cipher_core (
    //...
    .out_valid_o ( cipher_out_valid ),
    //...
    .state_o     ( state_done )
  );
  //...
    logic [3:0][3:0][7:0] state_done_muxed [NumShares];
    for (genvar s = 0; s < NumShares; s++) begin : gen_state_done_muxed
      assign state_done_muxed[s] = ((cipher_out_valid == SP2V_HIGH) &&
          !(aes_mode_q == AES_GCM &&
              gcm_phase_q == GCM_INIT)) ? state_done[s] : prd_clearing_state[s];
    end
  //...
endmodule


// Wrapper for sha256_core
module sha256 
  //...
  sha256_core core(
    //...
    .digest(core_digest),    
    .digest_valid(core_digest_valid)
  );
  //...
        if (core_digest_valid & ~digest_valid_reg) begin
          digest_reg <= core_digest & get_mask;
  //...
endmodule


// Wrapper for sha512_core
module sha512
  //...
  sha512_core core(
    //...
    .digest(core_digest),
    .digest_valid(core_digest_valid)
  );
  //...
      if (core_digest_valid & ~digest_valid_reg & ~(dest_keyvault | kv_read_data_present)) begin
        digest_reg <= core_digest;
  //...
endmodule


// Wrapper for sha512_masked_core
module hmac_core
  //...
  assign ready      = ready_flag;
  assign tag        = digest_valid_reg? H2_digest : 512'b0;
  assign tag_valid  = digest_valid_reg;
  //...
  sha512_masked_core u_sha512_core_h1 (
    //...
    .ready(H1_ready),
    .digest(H1_digest),
    .digest_valid(H1_digest_valid)
  );

  sha512_masked_core u_sha512_core_h2 (
    //...
    .ready(H2_ready),
    .digest(H2_digest),
    .digest_valid(H2_digest_valid)
  );

  //... RTL code that uses H1_ready and H2_ready
  //... to compute digest_valid_reg
endmodule
```

From the code above, it is evident that the security impact of the intermediate state/result leakage is relatively low since the leakage is stopped in these wrappers. However, future implementations of Caliptra may reuse the same `<x>_core` modules and erroneously exclude a check for the `valid` or `ready` signals. Therefore, it is suggested to add a guarding condition to prevent this leakage from propagating in the first place.

```verilog
//Relevant code from aes_cipher_core
//assign state_o = add_round_key_out;
assign state_o = out_valid_o ? add_round_key_out : '{default: '{default: '0}};

//Relevant code from sha256_core.sv, sha512_core.sv, and sha512_masked_core.sv
//assign digest = {H0_reg, H1_reg, H2_reg, H3_reg,
//                 H4_reg, H5_reg, H6_reg, H7_reg};
assign digest = digest_valid_reg ? 
                {H0_reg, H1_reg, H2_reg, H3_reg,
                 H4_reg, H5_reg, H6_reg, H7_reg} : XXX'b0;
```