### PR TITLE
[TB] Fix smoke_test_aes_kv_out_rand 

### DIFF
--- a/src/integration/test_suites/smoke_test_aes_kv_out_rand/smoke_test_aes_kv_out_rand.c
+++ b/src/integration/test_suites/smoke_test_aes_kv_out_rand/smoke_test_aes_kv_out_rand.c
@@ -116,7 +116,6 @@ void main(void) {
         
         aes_key.kv_intf = (xorshift32() % 2) ? TRUE : FALSE;
         if (aes_key.kv_intf == TRUE) {
-            // Weight aes_key.kv_id to hit 16 15% of the time
             rand_val = xorshift32() % 100;  // 0-99
             if (rand_val < 10) {
                 // 10% chance: use ID 16


### PR DESCRIPTION
- kv_reuse_key wasn't getting initialized causing it to be corrupted
- Weight KV16 and KV23 to be hit more often in rand test