### PR TITLE
[AXI] Comment fixed to subordinate

### DIFF
--- a/src/axi/rtl/axi_mgr_rd.sv
+++ b/src/axi/rtl/axi_mgr_rd.sv
@@ -169,7 +169,7 @@ module axi_mgr_rd import axi_pkg::*; #(
         end
         // Accumulate status codes...
         // TODO what if ERROR is interleaved with EXOKAY?
-        //      That would be a mistake by the slave, since we don't use Exclusive Access feature
+        //      That would be a mistake by the subordinate, since we don't use Exclusive Access feature
         else if (m_axi_if.rvalid && m_axi_if.rready) begin
             req_if.resp       <= req_if.resp | m_axi_if.rresp;
             req_if.resp_valid <= m_axi_if.rlast;


### PR DESCRIPTION
AXI uses manager and subordinate in the specificaiton now. This comment did not comply with that.