### PR TITLE
[RTL] Fix MBOX CSR address aliasing and missing error response for register holes

### DIFF
--- a/src/soc_ifc/rtl/mbox_csr.sv
+++ b/src/soc_ifc/rtl/mbox_csr.sv
@@ -648,8 +648,8 @@ module mbox_csr (
     // Write response
     //--------------------------------------------------------------------------
     assign cpuif_wr_ack = decoded_req & decoded_req_is_wr;
-    // Writes are always granted with no error response
-    assign cpuif_wr_err = '0;
+    // Assert write error for register hole accesses (address does not map to any register)
+    assign cpuif_wr_err = decoded_req & decoded_req_is_wr & ~(|decoded_reg_strb);
 
     //--------------------------------------------------------------------------
     // Readback
@@ -687,7 +687,7 @@ module mbox_csr (
     always_comb begin
         automatic logic [31:0] readback_data_var;
         readback_done = decoded_req & ~decoded_req_is_wr;
-        readback_err = '0;
+        readback_err = decoded_req & ~decoded_req_is_wr & ~(|decoded_reg_strb);
         readback_data_var = '0;
         for(int i=0; i<10; i++) readback_data_var |= readback_array[i];
         readback_data = readback_data_var;

--- a/src/soc_ifc/rtl/sha512_acc_csr.sv
+++ b/src/soc_ifc/rtl/sha512_acc_csr.sv
@@ -1615,8 +1615,8 @@ module sha512_acc_csr (
     // Write response
     //--------------------------------------------------------------------------
     assign cpuif_wr_ack = decoded_req & decoded_req_is_wr;
-    // Writes are always granted with no error response
-    assign cpuif_wr_err = '0;
+    // Assert write error for register hole accesses (address does not map to any register)
+    assign cpuif_wr_err = decoded_req & decoded_req_is_wr & ~(|decoded_reg_strb);
 
     //--------------------------------------------------------------------------
     // Readback
@@ -1695,7 +1695,7 @@ module sha512_acc_csr (
     always_comb begin
         automatic logic [31:0] readback_data_var;
         readback_done = decoded_req & ~decoded_req_is_wr;
-        readback_err = '0;
+        readback_err = decoded_req & ~decoded_req_is_wr & ~(|decoded_reg_strb);
         readback_data_var = '0;
         for(int i=0; i<44; i++) readback_data_var |= readback_array[i];
         readback_data = readback_data_var;

--- a/src/soc_ifc/rtl/soc_ifc_reg.sv
+++ b/src/soc_ifc/rtl/soc_ifc_reg.sv
@@ -7287,8 +7287,8 @@ module soc_ifc_reg (
     // Write response
     //--------------------------------------------------------------------------
     assign cpuif_wr_ack = decoded_req & decoded_req_is_wr;
-    // Writes are always granted with no error response
-    assign cpuif_wr_err = '0;
+    // Assert write error for register hole accesses (address does not map to any register)
+    assign cpuif_wr_err = decoded_req & decoded_req_is_wr & ~(|decoded_reg_strb);
 
     //--------------------------------------------------------------------------
     // Readback
@@ -7620,7 +7620,7 @@ module soc_ifc_reg (
     always_comb begin
         automatic logic [31:0] readback_data_var;
         readback_done = decoded_req & ~decoded_req_is_wr;
-        readback_err = '0;
+        readback_err = decoded_req & ~decoded_req_is_wr & ~(|decoded_reg_strb);
         readback_data_var = '0;
         for(int i=0; i<251; i++) readback_data_var |= readback_array[i];
         readback_data = readback_data_var;


### PR DESCRIPTION
## Summary

Fixes #1184 — two issues in the soc_ifc register block