### PR TITLE
[ENV] Fix double-nested hierarchy on regress results publication

### DIFF
--- a/.github/workflows/doc-gen.yml
+++ b/.github/workflows/doc-gen.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Stage regression results
         run: |
           if [ -d "nightly-results" ]; then
-            rsync -a --exclude='.git' --exclude='.github' nightly-results/ /tmp/pages-docs/nightly-results-main/
+            rsync -a --exclude='.git' --exclude='.github' nightly-results/nightly-results-main/ /tmp/pages-docs/nightly-results-main/
           fi
 
       - name: Generate GitHub Pages artifacts

--- a/.github/workflows/pre-run-check.yml
+++ b/.github/workflows/pre-run-check.yml
@@ -246,7 +246,7 @@ jobs:
           else
             echo "Only modified files in ${SOURCE_BR} are for documentation"
             echo " ============== modified files ============="
-            IFS='\n' grep -v "${excludes}" <<< "$mods"
+            IFS='\n' grep -v "${excludes}" <<< "$mods" || true
             echo "src_mods=false" >> "${GITHUB_OUTPUT}"
           fi
 


### PR DESCRIPTION
Results are published to https://chipsalliance.github.io/caliptra-rtl/nightly-results-main/nightly-results-main/
This PR publishes them to https://chipsalliance.github.io/caliptra-rtl/nightly-results-main/