### PR TITLE
soc_ifc/mbox: enable SoC DMA access to mailbox SRAM with post-transaction zeroization

### DIFF
--- a/src/axi/rtl/axi_dma_ctrl.sv
+++ b/src/axi/rtl/axi_dma_ctrl.sv
@@ -337,7 +337,7 @@ import kv_defines_pkg::*;
         hwif_in.cptra_pwrgood = cptra_pwrgood;
         hwif_in.cptra_rst_b   = rst_n;
         hwif_in.soc_req       = req_data.soc_req;
-        hwif_in.dma_swwel     = req_data.soc_req || ctrl_fsm_ps != DMA_IDLE;
+        hwif_in.dma_swwel     = ctrl_fsm_ps != DMA_IDLE;
     end
 
 

--- a/src/integration/test_suites/smoke_test_mbox_sram_zeroize/caliptra_isr.h
+++ b/src/integration/test_suites/smoke_test_mbox_sram_zeroize/caliptra_isr.h
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/smoke_test_mbox_sram_zeroize/smoke_test_mbox_sram_zeroize.c
+++ b/src/integration/test_suites/smoke_test_mbox_sram_zeroize/smoke_test_mbox_sram_zeroize.c
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// smoke_test_mbox_sram_zeroize
+//
+// Verifies that the mailbox SRAM is zeroed after each graceful lock release.
+//
+// The zeroization feature (mbox.sv) writes zeros to the entire mailbox SRAM
+// immediately after the lock is released via any graceful arc. The lock is held
+// (lock.value=1) throughout zeroization so that polling masters naturally wait.
+// Only when zeroization completes does the lock become acquirable again.
+//
+// This test covers two flows from the uC perspective:
+//
+// Test 1 — SoC sends command via DMA, uC processes and responds
+//   The UVM testbench must:
+//     - Acquire mbox lock
+//     - Program DMA: rd_route=AXI, wr_route=MBOX, src=known non-zero data,
+//       byte_count=MBOX_DLEN_BYTES (64 bytes)
+//     - Assert DMA go
+//     - Write MBOX_CMD=MBOX_CMD_RESP_BASIC, MBOX_DLEN=MBOX_DLEN_BYTES
+//     - Assert MBOX_EXECUTE
+//     - Wait for DATA_READY status
+//     - Read MBOX_DATAOUT (uC response)
+//     - Clear MBOX_EXECUTE (triggers lock release and zeroization)
+//   The uC (this firmware):
+//     - Reads DMA-written data from MBOX_DATAOUT and verifies it is non-zero
+//     - Sets DATA_READY status to signal response is ready
+//     - Waits for SoC to release lock
+//     - Re-acquires lock (polls MBOX_LOCK; naturally blocked during zeroization)
+//     - Reads mailbox SRAM directly and verifies all words are zero
+//
+// Test 2 — uC initiates a command to SoC (uC→SoC direction)
+//   The UVM testbench must:
+//     - Wait for READY_FOR_RUNTIME signal
+//     - Read MBOX_DATAOUT words (the uC response data)
+//     - Clear MBOX_EXECUTE (triggers lock release and zeroization)
+//   The uC (this firmware):
+//     - Acquires mbox lock
+//     - Writes known non-zero data to MBOX_DATAIN
+//     - Sets MBOX_CMD and MBOX_DLEN
+//     - Asserts MBOX_EXECUTE (FSM -> MBOX_EXECUTE_SOC)
+//     - Waits for SoC to clear execute (lock releases, zeroization runs)
+//     - Re-acquires lock (polls; waits through zeroization)
+//     - Verifies SRAM is zero via direct access
+
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "riscv_hw_if.h"
+#include "soc_ifc.h"
+#include <stdint.h>
+#include "printf.h"
+
+volatile uint32_t* stdout    = (uint32_t *)STDOUT;
+volatile uint32_t  intr_count = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+// Number of data words used in each test
+#define MBOX_TEST_DWORDS      16
+#define MBOX_DLEN_BYTES       (MBOX_TEST_DWORDS * 4)
+
+// Number of SRAM words to verify after zeroization
+// Checks the region that was written during the test plus a few extra
+#define MBOX_VERIFY_DWORDS    32
+
+// Response payload written by uC in Test 1
+static const uint32_t uc_response[MBOX_TEST_DWORDS] = {
+    0xDEADBEEF, 0xCAFEBABE, 0xA5A5A5A5, 0x12345678,
+    0x11111111, 0x22222222, 0x33333333, 0x44444444,
+    0x55555555, 0x66666666, 0x77777777, 0x88888888,
+    0x99999999, 0xAAAAAAAA, 0xBBBBBBBB, 0xCCCCCCCC
+};
+
+// Data written by uC in Test 2
+static const uint32_t uc_payload[MBOX_TEST_DWORDS] = {
+    0xFEEDFACE, 0xBAADF00D, 0xDEADC0DE, 0xC0FFEE00,
+    0x01234567, 0x89ABCDEF, 0xFEDCBA98, 0x76543210,
+    0xAAAA5555, 0x5555AAAA, 0xF0F0F0F0, 0x0F0F0F0F,
+    0xFF00FF00, 0x00FF00FF, 0xABCDABCD, 0xEFEFEFEF
+};
+
+// Verify the first MBOX_VERIFY_DWORDS words of mbox SRAM are zero
+// Uses direct SRAM access (uC must hold the lock)
+static uint8_t verify_sram_zeroed(void) {
+    uint32_t data;
+    uint32_t fail = 0;
+    for (uint32_t ii = 0; ii < MBOX_VERIFY_DWORDS; ii++) {
+        data = lsu_read_32(CLP_MBOX_SRAM_BASE_ADDR + (ii * 4));
+        if (data != 0) {
+            VPRINTF(ERROR, "ERROR: SRAM[%d] = 0x%x, expected 0 after zeroization\n", ii, data);
+            fail = 1;
+        }
+    }
+    return fail;
+}
+
+void main() {
+    mbox_op_s op;
+    uint32_t data;
+    uint32_t ii;
+    uint32_t fail = 0;
+
+    VPRINTF(LOW, "----------------------------------\n");
+    VPRINTF(LOW, " Mbox SRAM Zeroization Smoke Test\n");
+    VPRINTF(LOW, "----------------------------------\n");
+
+    init_interrupts();
+
+    // =========================================================================
+    // Test 1: SoC DMA writes data to mbox, uC reads, responds, verifies zero
+    // =========================================================================
+    VPRINTF(LOW, "Test 1: SoC DMA -> uC -> verify zeroization\n");
+
+    // Signal ready so UVM testbench sends the DMA-written mailbox command
+    soc_ifc_set_flow_status_field(SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_MB_PROCESSING_MASK);
+
+    // Wait for SoC to acquire lock, write data via DMA, and assert execute
+    VPRINTF(LOW, "FW: Waiting for execute...\n");
+    while (!(lsu_read_32(CLP_MBOX_CSR_MBOX_EXECUTE) & MBOX_CSR_MBOX_EXECUTE_EXECUTE_MASK));
+
+    op = soc_ifc_read_mbox_cmd();
+    VPRINTF(LOW, "FW: cmd=0x%x dlen=0x%x\n", op.cmd, op.dlen);
+
+    // Read data written by SoC DMA and verify it is non-zero
+    VPRINTF(LOW, "FW: Reading DMA-written data from mbox\n");
+    for (ii = 0; ii < op.dlen / 4; ii++) {
+        data = soc_ifc_mbox_read_dataout_single();
+        VPRINTF(HIGH, "FW: dataout[%d] = 0x%x\n", ii, data);
+        if (data == 0) {
+            VPRINTF(ERROR, "ERROR: Test 1: dataout[%d] is 0 — expected non-zero DMA data\n", ii);
+            fail = 1;
+        }
+    }
+
+    // Write response data back to mbox (uC response for SoC to read)
+    VPRINTF(LOW, "FW: Writing uC response to mbox\n");
+    for (ii = 0; ii < MBOX_TEST_DWORDS; ii++) {
+        lsu_write_32(CLP_MBOX_CSR_MBOX_DATAIN, uc_response[ii]);
+    }
+
+    // Signal data is ready — FSM transitions to MBOX_EXECUTE_SOC
+    lsu_write_32(CLP_MBOX_CSR_MBOX_STATUS, DATA_READY);
+    VPRINTF(LOW, "FW: Set DATA_READY, waiting for SoC to clear execute...\n");
+
+    // Wait for SoC to clear execute (lock releases, zeroization begins)
+    while (lsu_read_32(CLP_MBOX_CSR_MBOX_EXECUTE) & MBOX_CSR_MBOX_EXECUTE_EXECUTE_MASK);
+    VPRINTF(LOW, "FW: Execute cleared — zeroization running\n");
+
+    // Re-acquire lock — lock.value stays 1 throughout zeroization so this
+    // poll naturally waits until zeroization completes
+    VPRINTF(LOW, "FW: Polling for lock (blocks through zeroization)...\n");
+    while ((lsu_read_32(CLP_MBOX_CSR_MBOX_LOCK) & MBOX_CSR_MBOX_LOCK_LOCK_MASK) == 1);
+    VPRINTF(LOW, "FW: Lock acquired — zeroization complete\n");
+
+    // Verify SRAM is zero via direct access (uC holds lock, FSM in RDY_FOR_CMD)
+    VPRINTF(LOW, "FW: Verifying SRAM zeroed...\n");
+    if (verify_sram_zeroed()) {
+        VPRINTF(ERROR, "ERROR: Test 1: SRAM not zeroed after lock release\n");
+        fail = 1;
+    } else {
+        VPRINTF(LOW, "FW: PASS Test 1 — SRAM verified zero\n");
+    }
+
+    // Release lock before Test 2
+    lsu_write_32(CLP_MBOX_CSR_MBOX_UNLOCK, MBOX_CSR_MBOX_UNLOCK_UNLOCK_MASK);
+
+    // =========================================================================
+    // Test 2: uC writes data and sends to SoC, then verifies zeroization
+    // =========================================================================
+    VPRINTF(LOW, "Test 2: uC -> SoC -> verify zeroization\n");
+
+    // Acquire mbox lock
+    VPRINTF(LOW, "FW: Acquiring lock...\n");
+    while ((lsu_read_32(CLP_MBOX_CSR_MBOX_LOCK) & MBOX_CSR_MBOX_LOCK_LOCK_MASK) == 1);
+    VPRINTF(LOW, "FW: Lock acquired\n");
+
+    // Write command and data length
+    lsu_write_32(CLP_MBOX_CSR_MBOX_CMD,  MBOX_CMD_RESP_BASIC);
+    lsu_write_32(CLP_MBOX_CSR_MBOX_DLEN, MBOX_DLEN_BYTES);
+
+    // Write payload into mbox via DATAIN register
+    VPRINTF(LOW, "FW: Writing payload to mbox\n");
+    for (ii = 0; ii < MBOX_TEST_DWORDS; ii++) {
+        lsu_write_32(CLP_MBOX_CSR_MBOX_DATAIN, uc_payload[ii]);
+    }
+
+    // Signal SoC that data is ready — FSM -> MBOX_EXECUTE_SOC (uC holds lock)
+    // Signal to UVM to start reading after READY_FOR_RUNTIME
+    soc_ifc_set_flow_status_field(SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_RUNTIME_MASK);
+    lsu_write_32(CLP_MBOX_CSR_MBOX_EXECUTE, MBOX_CSR_MBOX_EXECUTE_EXECUTE_MASK);
+    VPRINTF(LOW, "FW: Execute asserted — waiting for SoC to consume and clear execute...\n");
+
+    // Wait for SoC to read data and clear execute (lock releases, zeroization begins)
+    while (lsu_read_32(CLP_MBOX_CSR_MBOX_EXECUTE) & MBOX_CSR_MBOX_EXECUTE_EXECUTE_MASK);
+    VPRINTF(LOW, "FW: Execute cleared — zeroization running\n");
+
+    // Re-acquire lock — waits through zeroization (lock.value=1 throughout)
+    VPRINTF(LOW, "FW: Polling for lock (blocks through zeroization)...\n");
+    while ((lsu_read_32(CLP_MBOX_CSR_MBOX_LOCK) & MBOX_CSR_MBOX_LOCK_LOCK_MASK) == 1);
+    VPRINTF(LOW, "FW: Lock acquired — zeroization complete\n");
+
+    // Verify SRAM is zero
+    VPRINTF(LOW, "FW: Verifying SRAM zeroed...\n");
+    if (verify_sram_zeroed()) {
+        VPRINTF(ERROR, "ERROR: Test 2: SRAM not zeroed after lock release\n");
+        fail = 1;
+    } else {
+        VPRINTF(LOW, "FW: PASS Test 2 — SRAM verified zero\n");
+    }
+
+    // Release lock
+    lsu_write_32(CLP_MBOX_CSR_MBOX_UNLOCK, MBOX_CSR_MBOX_UNLOCK_UNLOCK_MASK);
+
+    // =========================================================================
+    // Result
+    // =========================================================================
+    if (fail) {
+        VPRINTF(FATAL, "smoke_test_mbox_sram_zeroize FAILED\n");
+        SEND_STDOUT_CTRL(0x1);
+        while (1);
+    } else {
+        VPRINTF(LOW, "smoke_test_mbox_sram_zeroize PASSED\n");
+        SEND_STDOUT_CTRL(0xff);
+    }
+}

--- a/src/integration/test_suites/smoke_test_mbox_sram_zeroize/smoke_test_mbox_sram_zeroize.yml
+++ b/src/integration/test_suites/smoke_test_mbox_sram_zeroize/smoke_test_mbox_sram_zeroize.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: 1
+testname: smoke_test_mbox_sram_zeroize

--- a/src/soc_ifc/rtl/mbox.sv
+++ b/src/soc_ifc/rtl/mbox.sv
@@ -88,6 +88,7 @@ module mbox
 
     // Status
     output logic uc_mbox_lock,
+    output logic soc_mbox_lock,
 
     //interrupts
     output logic uc_mbox_data_avail,
@@ -141,6 +142,12 @@ logic arc_MBOX_RDY_FOR_DATA_MBOX_ERROR;
 logic arc_MBOX_EXECUTE_UC_MBOX_ERROR;
 logic arc_MBOX_EXECUTE_SOC_MBOX_ERROR;
 logic arc_MBOX_EXECUTE_TAP_MBOX_ERROR;
+logic arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT;
+//zeroization
+logic                   zeroize_active;
+logic                   zeroize_trigger;
+logic                   zeroize_done;
+logic [MBOX_ADDR_W-1:0] zeroize_addr;
 //sram
 logic [MBOX_DATA_W-1:0] sram_wdata;
 logic [MBOX_ECC_DATA_W-1:0] sram_wdata_ecc;
@@ -199,7 +206,8 @@ assign mbox_error = read_error | write_error;
 
 assign tap_mode = hwif_out.tap_mode.enabled.value;
 
-assign uc_mbox_lock = uc_has_lock;
+assign uc_mbox_lock  = uc_has_lock;
+assign soc_mbox_lock = soc_has_lock;
 
 assign req_data_uc_req = ~req_data_soc_req;
 
@@ -227,13 +235,17 @@ always_comb mask_rdata = hwif_out.mbox_dataout.dataout.swacc & ~valid_receiver;
 
 //move from idle to rdy for command when lock is acquired
 //we have a valid read, to the lock register, and it's not currently locked
-always_comb arc_MBOX_IDLE_MBOX_RDY_FOR_CMD = (mbox_fsm_ps == MBOX_IDLE) & ~hwif_out.mbox_lock.lock.value & (hwif_out.mbox_lock.lock.swmod | hwif_in.mbox_lock.lock.hwset);
+//blocked during zeroization until SRAM is cleared
+always_comb arc_MBOX_IDLE_MBOX_RDY_FOR_CMD = (mbox_fsm_ps == MBOX_IDLE) & ~hwif_out.mbox_lock.lock.value & (hwif_out.mbox_lock.lock.swmod | hwif_in.mbox_lock.lock.hwset) & ~zeroize_active;
 //move from rdy for cmd to rdy for dlen when cmd is written
 always_comb arc_MBOX_RDY_FOR_CMD_MBOX_RDY_FOR_DLEN = (mbox_fsm_ps == MBOX_RDY_FOR_CMD) & ((hwif_out.mbox_cmd.command.swmod & valid_requester) | hwif_in.mbox_cmd.command.we);
 //move from rdy for dlen to rdy for data when dlen is written
 always_comb arc_MBOX_RDY_FOR_DLEN_MBOX_RDY_FOR_DATA = (mbox_fsm_ps == MBOX_RDY_FOR_DLEN) & ((hwif_out.mbox_dlen.length.swmod & valid_requester) | hwif_in.mbox_dlen.length.we);
-//move from rdy for data to execute uc when SoC sets execute bit
-always_comb arc_MBOX_RDY_FOR_DATA_MBOX_EXECUTE_UC = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & (soc_has_lock | tap_has_lock);
+//move from rdy for data directly to idle when SoC sets execute with SoC-direct flag (bit 28)
+//used for idle memory graceful exit — no uC involvement needed
+always_comb arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & soc_has_lock & hwif_out.mbox_cmd.command.value[28];
+//move from rdy for data to execute uc when SoC sets execute bit (excluded when SoC-direct flag set)
+always_comb arc_MBOX_RDY_FOR_DATA_MBOX_EXECUTE_UC = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & ((soc_has_lock & ~hwif_out.mbox_cmd.command.value[28]) | tap_has_lock);
 //move from rdy for data to execute soc when uc writes to execute
 always_comb arc_MBOX_RDY_FOR_DATA_MBOX_EXECUTE_SOC = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & uc_has_lock & ~tap_mode;
 //move from rdy for data to execute tap when uc writes to execute in tap_mode
@@ -364,7 +376,10 @@ always_comb begin : mbox_fsm_combo
             //update the write pointers to sram when accessing datain register
             inc_wrptr = (hwif_out.mbox_datain.datain.swmod & valid_requester & ~req_hold) |
                         (dmi_inc_wrptr & tap_has_lock);
-            if (arc_MBOX_RDY_FOR_DATA_MBOX_EXECUTE_UC) begin
+            if (arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT) begin
+                mbox_fsm_ns = MBOX_IDLE;
+            end
+            else if (arc_MBOX_RDY_FOR_DATA_MBOX_EXECUTE_UC) begin
                 mbox_fsm_ns = MBOX_EXECUTE_UC;
                 //reset wrptr so receiver can write response
                 rst_mbox_wrptr = 1;
@@ -542,7 +557,33 @@ always_ff @(posedge clk or negedge rst_b) begin
     end
 end
 
-always_comb dma_sram_req_dv_q = dma_sram_req_dv & hwif_out.mbox_lock.lock.value & uc_has_lock & ~dma_sram_req_rd_phase;
+always_comb zeroize_trigger = arc_MBOX_EXECUTE_UC_MBOX_IDLE
+                            | arc_MBOX_EXECUTE_SOC_MBOX_IDLE
+                            | arc_MBOX_EXECUTE_TAP_MBOX_IDLE
+                            | arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT;
+
+always_comb zeroize_done = zeroize_active & (zeroize_addr == MBOX_ADDR_W'(MBOX_DEPTH - 1));
+
+always_ff @(posedge clk or negedge rst_b) begin
+    if (!rst_b) begin
+        zeroize_active <= 1'b0;
+        zeroize_addr   <= '0;
+    end else if (zeroize_trigger) begin
+        zeroize_active <= 1'b1;
+        zeroize_addr   <= '0;
+    end else if (zeroize_active) begin
+        if (zeroize_done) begin
+            zeroize_active <= 1'b0;
+            zeroize_addr   <= '0;
+        end else begin
+            zeroize_addr <= zeroize_addr + 1'b1;
+        end
+    end
+end
+
+always_comb dma_sram_req_dv_q = dma_sram_req_dv & hwif_out.mbox_lock.lock.value
+                                & (uc_has_lock | soc_has_lock)
+                                & ~dma_sram_req_rd_phase;
 //need to hold direct read accesses for 1 clock to get response
 //create a qualified direct request signal that is masked during the data phase
 //hold the interface to insert wait state when direct request comes
@@ -588,9 +629,10 @@ always_comb dma_sram_error = 1'b0; // TODO: ecc error?
 
 always_comb begin: mbox_sram_inf
     //read live on direct access, or when pointer has been incremented, for pre-load on read pointer reset, or ecc correction
-    mbox_sram_req_cs = dir_req_dv_q | mbox_protocol_sram_we | mbox_protocol_sram_rd;
-    mbox_sram_req_we = sram_we;
-    mbox_sram_req_addr = sram_we ? sram_waddr : sram_rdaddr;
+    //zeroization has highest priority — drives cs/we/addr while active
+    mbox_sram_req_cs = zeroize_active | dir_req_dv_q | mbox_protocol_sram_we | mbox_protocol_sram_rd;
+    mbox_sram_req_we = zeroize_active | sram_we;
+    mbox_sram_req_addr = zeroize_active ? zeroize_addr : (sram_we ? sram_waddr : sram_rdaddr);
     mbox_sram_req_wdata = sram_wdata;
     mbox_sram_req_ecc  = sram_wdata_ecc;
 
@@ -628,8 +670,9 @@ rvecc_decode ecc_decode (
 //SoC access is controlled by mailbox, each subsequent read or write increments the pointer
 //uC accesses can specify the specific read or write address, or rely on mailbox to control
 //if tap has lock or is responding to a request it can write instead
-always_comb sram_wdata = (dma_sram_req_dv_q && dma_sram_req_write )                           ? dma_sram_req_wdata : 
-                         (dmi_inc_wrptr & ((mbox_fsm_ps == MBOX_EXECUTE_TAP) | tap_has_lock)) ? dmi_reg_wdata : 
+always_comb sram_wdata = zeroize_active                                                        ? '0 :
+                         (dma_sram_req_dv_q && dma_sram_req_write )                           ? dma_sram_req_wdata :
+                         (dmi_inc_wrptr & ((mbox_fsm_ps == MBOX_EXECUTE_TAP) | tap_has_lock)) ? dmi_reg_wdata :
                                                                                                 req_data_wdata;
 
 //in ready for data state we increment the pointer each time we write
@@ -672,11 +715,11 @@ always_comb hwif_in.mbox_dataout.dataout.swwe = '0; //no sw write enable, but ne
 always_comb hwif_in.mbox_dataout.dataout.we = mbox_protocol_sram_rd_f;
 always_comb hwif_in.mbox_dataout.dataout.next = mbox_rd_valid_f ? sram_rdata_cor : '0;
 //clear the lock when moving from execute to idle
-always_comb hwif_in.mbox_lock.lock.hwclr = arc_MBOX_EXECUTE_SOC_MBOX_IDLE | arc_MBOX_EXECUTE_UC_MBOX_IDLE | arc_MBOX_EXECUTE_TAP_MBOX_IDLE | arc_FORCE_MBOX_UNLOCK;
+always_comb hwif_in.mbox_lock.lock.hwclr = arc_MBOX_EXECUTE_SOC_MBOX_IDLE | arc_MBOX_EXECUTE_UC_MBOX_IDLE | arc_MBOX_EXECUTE_TAP_MBOX_IDLE | arc_FORCE_MBOX_UNLOCK | arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT;
 //clear the mailbox status when we go back to IDLE
-always_comb hwif_in.mbox_status.status.hwclr = arc_MBOX_EXECUTE_SOC_MBOX_IDLE | arc_MBOX_EXECUTE_UC_MBOX_IDLE | arc_MBOX_EXECUTE_TAP_MBOX_IDLE | arc_FORCE_MBOX_UNLOCK;
-//clear the execute register when we force unlock
-always_comb hwif_in.mbox_execute.execute.hwclr = arc_FORCE_MBOX_UNLOCK;
+always_comb hwif_in.mbox_status.status.hwclr = arc_MBOX_EXECUTE_SOC_MBOX_IDLE | arc_MBOX_EXECUTE_UC_MBOX_IDLE | arc_MBOX_EXECUTE_TAP_MBOX_IDLE | arc_FORCE_MBOX_UNLOCK | arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT;
+//clear the execute register when we force unlock or SoC-direct graceful exit
+always_comb hwif_in.mbox_execute.execute.hwclr = arc_FORCE_MBOX_UNLOCK | arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT;
 // Set mbox_csr status fields in response to ECC errors
 always_comb hwif_in.mbox_status.ecc_single_error.hwset = sram_single_ecc_error;
 always_comb hwif_in.mbox_status.ecc_double_error.hwset = sram_double_ecc_error;

--- a/src/soc_ifc/rtl/mbox.sv
+++ b/src/soc_ifc/rtl/mbox.sv
@@ -235,17 +235,18 @@ always_comb mask_rdata = hwif_out.mbox_dataout.dataout.swacc & ~valid_receiver;
 
 //move from idle to rdy for command when lock is acquired
 //we have a valid read, to the lock register, and it's not currently locked
-//blocked during zeroization until SRAM is cleared
-always_comb arc_MBOX_IDLE_MBOX_RDY_FOR_CMD = (mbox_fsm_ps == MBOX_IDLE) & ~hwif_out.mbox_lock.lock.value & (hwif_out.mbox_lock.lock.swmod | hwif_in.mbox_lock.lock.hwset) & ~zeroize_active;
+//lock.value stays 1 throughout zeroization so this arc is naturally blocked
+//until zeroize_done clears lock.value
+always_comb arc_MBOX_IDLE_MBOX_RDY_FOR_CMD = (mbox_fsm_ps == MBOX_IDLE) & ~hwif_out.mbox_lock.lock.value & (hwif_out.mbox_lock.lock.swmod | hwif_in.mbox_lock.lock.hwset);
 //move from rdy for cmd to rdy for dlen when cmd is written
 always_comb arc_MBOX_RDY_FOR_CMD_MBOX_RDY_FOR_DLEN = (mbox_fsm_ps == MBOX_RDY_FOR_CMD) & ((hwif_out.mbox_cmd.command.swmod & valid_requester) | hwif_in.mbox_cmd.command.we);
 //move from rdy for dlen to rdy for data when dlen is written
 always_comb arc_MBOX_RDY_FOR_DLEN_MBOX_RDY_FOR_DATA = (mbox_fsm_ps == MBOX_RDY_FOR_DLEN) & ((hwif_out.mbox_dlen.length.swmod & valid_requester) | hwif_in.mbox_dlen.length.we);
 //move from rdy for data directly to idle when SoC sets execute with SoC-direct flag (bit 28)
 //used for idle memory graceful exit — no uC involvement needed
-always_comb arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & soc_has_lock & hwif_out.mbox_cmd.command.value[28];
+always_comb arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & soc_has_lock & hwif_out.mbox_cmd.command.value[26];
 //move from rdy for data to execute uc when SoC sets execute bit (excluded when SoC-direct flag set)
-always_comb arc_MBOX_RDY_FOR_DATA_MBOX_EXECUTE_UC = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & ((soc_has_lock & ~hwif_out.mbox_cmd.command.value[28]) | tap_has_lock);
+always_comb arc_MBOX_RDY_FOR_DATA_MBOX_EXECUTE_UC = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & ((soc_has_lock & ~hwif_out.mbox_cmd.command.value[26]) | tap_has_lock);
 //move from rdy for data to execute soc when uc writes to execute
 always_comb arc_MBOX_RDY_FOR_DATA_MBOX_EXECUTE_SOC = (mbox_fsm_ps == MBOX_RDY_FOR_DATA) & hwif_out.mbox_execute.execute.value & uc_has_lock & ~tap_mode;
 //move from rdy for data to execute tap when uc writes to execute in tap_mode
@@ -714,10 +715,12 @@ always_comb hwif_in.mbox_dataout.dataout.swwe = '0; //no sw write enable, but ne
 //we load the first entry on the arc to execute
 always_comb hwif_in.mbox_dataout.dataout.we = mbox_protocol_sram_rd_f;
 always_comb hwif_in.mbox_dataout.dataout.next = mbox_rd_valid_f ? sram_rdata_cor : '0;
-//clear the lock when moving from execute to idle
-always_comb hwif_in.mbox_lock.lock.hwclr = arc_MBOX_EXECUTE_SOC_MBOX_IDLE | arc_MBOX_EXECUTE_UC_MBOX_IDLE | arc_MBOX_EXECUTE_TAP_MBOX_IDLE | arc_FORCE_MBOX_UNLOCK | arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT;
-//clear the mailbox status when we go back to IDLE
-always_comb hwif_in.mbox_status.status.hwclr = arc_MBOX_EXECUTE_SOC_MBOX_IDLE | arc_MBOX_EXECUTE_UC_MBOX_IDLE | arc_MBOX_EXECUTE_TAP_MBOX_IDLE | arc_FORCE_MBOX_UNLOCK | arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT;
+//clear the lock only when zeroization is complete so that polling masters see
+//lock.value=1 throughout zeroization and cannot spuriously acquire the lock.
+//force-unlock bypasses zeroization and clears immediately.
+always_comb hwif_in.mbox_lock.lock.hwclr = zeroize_done | arc_FORCE_MBOX_UNLOCK;
+//clear the mailbox status at the same point as the lock
+always_comb hwif_in.mbox_status.status.hwclr = zeroize_done | arc_FORCE_MBOX_UNLOCK;
 //clear the execute register when we force unlock or SoC-direct graceful exit
 always_comb hwif_in.mbox_execute.execute.hwclr = arc_FORCE_MBOX_UNLOCK | arc_MBOX_RDY_FOR_DATA_MBOX_IDLE_SOC_DIRECT;
 // Set mbox_csr status fields in response to ECC errors

--- a/src/soc_ifc/rtl/soc_ifc_arb.sv
+++ b/src/soc_ifc/rtl/soc_ifc_arb.sv
@@ -153,7 +153,7 @@ always_comb soc_sha_req = (soc_req_dv & (soc_req_data.addr inside {[SHA_REG_STAR
 
 // Requests to DMA
 always_comb uc_dma_req = (uc_req_dv & (uc_req_data.addr inside {[DMA_REG_START_ADDR:DMA_REG_END_ADDR]}));
-always_comb soc_dma_req = (soc_req_dv & (soc_req_data.addr inside {[DMA_REG_START_ADDR:DMA_REG_END_ADDR]}));
+always_comb soc_dma_req = (soc_req_dv & (soc_req_data.addr inside {[DMA_REG_START_ADDR:DMA_REG_END_ADDR]})) & valid_mbox_req;
 
 //Check if SoC request is coming from a valid user
 //There are 5 valid user registers, check if user attribute matches any of them

--- a/src/soc_ifc/rtl/soc_ifc_top.sv
+++ b/src/soc_ifc/rtl/soc_ifc_top.sv
@@ -258,6 +258,7 @@ logic scan_mode_p;
 logic sram_single_ecc_error;
 logic sram_double_ecc_error;
 logic soc_req_mbox_lock;
+logic soc_mbox_lock;
 logic [1:0] generic_input_toggle;
 mbox_protocol_error_t mbox_protocol_error;
 logic mbox_inv_user_p;
@@ -1214,6 +1215,7 @@ i_mbox (
     .sram_single_ecc_error(sram_single_ecc_error),
     .sram_double_ecc_error(sram_double_ecc_error),
     .uc_mbox_lock(uc_mbox_lock),
+    .soc_mbox_lock(soc_mbox_lock),
     .soc_mbox_data_avail(mailbox_data_avail),
     .uc_mbox_data_avail(uc_mbox_data_avail),
     .soc_req_mbox_lock(soc_req_mbox_lock),
@@ -1247,7 +1249,7 @@ axi_dma_top #(
     .recovery_image_activated(recovery_image_activated),
 
     // SOC_IFC Internal Signaling
-    .mbox_lock(uc_mbox_lock),
+    .mbox_lock(uc_mbox_lock | soc_mbox_lock),
     .sha_lock (1'b0        ), // SHA direct-access (internally) not implemented; DMA can use AXI-side for SHA operations
     .debugUnlock_or_scan_mode_switch(debugUnlock_or_scan_mode_switch                               ),
     .ocp_lock_in_progress           (ss_ocp_lock_in_progress                                       ),


### PR DESCRIPTION
 ## Summary

  - Relaxes the AXI DMA engine to allow SoC masters (gated by
    `CPTRA_MBOX_VALID_AXI_USER`) to program and trigger DMA transfers
    to/from the mailbox SRAM, enabling bulk FW load without word-by-word
    register writes
  - Adds a new mailbox FSM arc (MBOX_CMD bit 26) for SoC idle memory
    graceful exit — SoC can release the lock without uC involvement
  - Adds SRAM zeroization after every graceful lock release to prevent
    sensitive data persisting across ownership boundaries; lock is held
    throughout zeroization so existing firmware polling patterns require
    no changes

  ## Files Changed

  | File | Change |
  |------|--------|
  | `src/axi/rtl/axi_dma_ctrl.sv` | Remove SoC blanket block from `dma_swwel`; allow SoC writes when DMA is idle |
  | `src/soc_ifc/rtl/soc_ifc_arb.sv` | Gate SoC DMA register access by existing `CPTRA_MBOX_VALID_AXI_USER` allowlist |
  | `src/soc_ifc/rtl/soc_ifc_top.sv` | Export `soc_mbox_lock`; OR with `uc_mbox_lock` into DMA `mbox_lock` input |
  | `src/soc_ifc/rtl/mbox.sv` | Export `soc_mbox_lock`; relax DMA SRAM gate; add SOC_DIRECT arc (bit 26); add zeroization counter and SRAM write path; hold lock through zeroization |
  | `src/integration/test_suites/smoke_test_mbox_sram_zeroize/` | New uC firmware integration test |

  ## Notes for Reviewers

  - `MBOX_CMD_FMC_UPDATE` and `MBOX_CMD_RT_UPDATE` both have bits 27–28
    set — SOC_DIRECT flag uses bit 26 which is clear in all existing
    command values
  - `ERR_MBOX_LOCK_MUTEX` assertion is unchanged — lock exclusivity is
    not affected by any of these changes
  - `arc_FORCE_MBOX_UNLOCK` is deliberately excluded from the zeroization
    trigger
