### PR TITLE
[RTL] Restore hmac_param_pkg in TB compile target

### DIFF
--- a/src/hmac/config/compile.yml
+++ b/src/hmac/config/compile.yml
@@ -32,6 +32,7 @@ targets:
     directories: 
       - $COMPILE_ROOT/tb
     files:
+      - $COMPILE_ROOT/rtl/hmac_param_pkg.sv
       - $COMPILE_ROOT/tb/hmac_ctrl_tb.sv
     tops: [hmac_ctrl_tb]
 global:


### PR DESCRIPTION
The TB target needs the package listed explicitly since VCS compiles RTL and TB into separate libraries.
 No `.vf` changes.