### PR TITLE
mldsa.c: Cover ACK to RO/WO regs

### DIFF
--- a/src/integration/test_suites/libs/mldsa/mldsa.c
+++ b/src/integration/test_suites/libs/mldsa/mldsa.c
@@ -133,6 +133,8 @@ void mldsa_keygen_flow(mldsa_io seed, uint32_t entropy[MLDSA87_ENTROPY_SIZE], ui
         reg_ptr = (uint32_t *) CLP_ABR_REG_MLDSA_PRIVKEY_OUT_BASE_ADDR;
         offset = 0;
         while (offset < MLDSA87_PRIVKEY_SIZE) {
+            *reg_ptr = 0; // Try overwrite, the register should be read-only
+
             actual_data = *reg_ptr;
             if (actual_data != privkey[offset]) {
                 VPRINTF(ERROR, "At offset [%d], mldsa_privkey data mismatch!\n", offset);
@@ -283,6 +285,16 @@ void mldsa_signing_flow(uint32_t privkey[MLDSA87_PRIVKEY_SIZE], uint32_t msg[MLD
     // Program MLDSA PRIVKEY
     VPRINTF(LOW, "Writing privkey\n");
     write_mldsa_reg((uint32_t*) CLP_ABR_REG_MLDSA_PRIVKEY_IN_BASE_ADDR, privkey, MLDSA87_PRIVKEY_SIZE);
+
+    reg_ptr = (uint32_t*) CLP_ABR_REG_MLDSA_PRIVKEY_IN_BASE_ADDR;
+    while (reg_ptr < CLP_ABR_REG_MLDSA_PRIVKEY_IN_BASE_ADDR) {
+        actual_data = *reg_ptr;
+        if (actual_data) {
+            printf("MLDSA_PRIVKEY_IN at address: 0x%0x doesn't return 0 on read!\n", reg_ptr);
+            printf("%c", fail_cmd);
+        }
+        reg_ptr++;
+    }
     
     // Program MLDSA MSG
     VPRINTF(LOW, "Writing msg\n");

--- a/src/integration/test_suites/libs/mldsa/mldsa.c
+++ b/src/integration/test_suites/libs/mldsa/mldsa.c
@@ -286,16 +286,16 @@ void mldsa_signing_flow(uint32_t privkey[MLDSA87_PRIVKEY_SIZE], uint32_t msg[MLD
     VPRINTF(LOW, "Writing privkey\n");
     write_mldsa_reg((uint32_t*) CLP_ABR_REG_MLDSA_PRIVKEY_IN_BASE_ADDR, privkey, MLDSA87_PRIVKEY_SIZE);
 
-    reg_ptr = (uint32_t*) CLP_ABR_REG_MLDSA_PRIVKEY_IN_BASE_ADDR;
-    while (reg_ptr < CLP_ABR_REG_MLDSA_PRIVKEY_IN_BASE_ADDR) {
+    reg_ptr = (volatile uint32_t *)CLP_ABR_REG_MLDSA_PRIVKEY_IN_BASE_ADDR;
+    for (offset = 0; offset < MLDSA87_PRIVKEY_SIZE; offset++, reg_ptr++) {
         actual_data = *reg_ptr;
-        if (actual_data) {
-            printf("MLDSA_PRIVKEY_IN at address: 0x%0x doesn't return 0 on read!\n", reg_ptr);
-            printf("%c", fail_cmd);
+        if (actual_data != 0) {
+            VPRINTF(ERROR, "MLDSA_PRIVKEY_IN at address: %p returned 0x%x on read (expected 0)\n", (void *)reg_ptr, actual_data);
+            SEND_STDOUT_CTRL(fail_cmd);
+            while (1);
         }
-        reg_ptr++;
     }
-    
+
     // Program MLDSA MSG
     VPRINTF(LOW, "Writing msg\n");
     write_mldsa_reg((uint32_t*) CLP_ABR_REG_MLDSA_MSG_0, msg, MLDSA87_MSG_SIZE);


### PR DESCRIPTION
Adds write to `MLDSA_PRIVKEY_OUT` (RO) and read from `MLDSA_PRIVKEY_IN` (WO) verifying registers' properties on the integration level.

* Covers MLDSA_PRIVKEY_OUT.wr_ack and MLDSA_PRIVKEY_IN.rd_ack