### PR TITLE
integration/test_suites: Improve randomization

### DIFF
--- a/src/integration/test_suites/libs/caliptra_rtl_lib/caliptra_rtl_lib.c
+++ b/src/integration/test_suites/libs/caliptra_rtl_lib/caliptra_rtl_lib.c
@@ -16,17 +16,15 @@
 
 #include <stdint.h>
 
-#ifdef MY_RANDOM_SEED
-    uint32_t state = (unsigned) MY_RANDOM_SEED;
-#else
-    uint32_t state = 0xabcd;
-#endif
+uint32_t __xorshift32_state = (unsigned) MY_RANDOM_SEED;
 
+void xorshift32_init(uint32_t seed) {
+    __xorshift32_state = seed;
+}
 
-uint32_t xorshift32(void)
-{
-    state ^= state << 13;
-    state ^= state >> 17;
-    state ^= state << 5;
-    return state;
+uint32_t xorshift32(void) {
+    __xorshift32_state ^= __xorshift32_state << 13;
+    __xorshift32_state ^= __xorshift32_state >> 17;
+    __xorshift32_state ^= __xorshift32_state << 5;
+    return __xorshift32_state;
 }

--- a/src/integration/test_suites/libs/caliptra_rtl_lib/caliptra_rtl_lib.c
+++ b/src/integration/test_suites/libs/caliptra_rtl_lib/caliptra_rtl_lib.c
@@ -15,16 +15,17 @@
 //
 
 #include <stdint.h>
+#include "caliptra_rtl_lib.h"
 
-uint32_t __xorshift32_state = (unsigned) MY_RANDOM_SEED;
+uint32_t xorshift32_state = (unsigned) MY_RANDOM_SEED;
 
 void xorshift32_init(uint32_t seed) {
-    __xorshift32_state = seed;
+    xorshift32_state = seed;
 }
 
 uint32_t xorshift32(void) {
-    __xorshift32_state ^= __xorshift32_state << 13;
-    __xorshift32_state ^= __xorshift32_state >> 17;
-    __xorshift32_state ^= __xorshift32_state << 5;
-    return __xorshift32_state;
+    xorshift32_state ^= xorshift32_state << 13;
+    xorshift32_state ^= xorshift32_state >> 17;
+    xorshift32_state ^= xorshift32_state << 5;
+    return xorshift32_state;
 }

--- a/src/integration/test_suites/libs/caliptra_rtl_lib/caliptra_rtl_lib.h
+++ b/src/integration/test_suites/libs/caliptra_rtl_lib/caliptra_rtl_lib.h
@@ -18,8 +18,11 @@
 #define CALIPTRA_RTL_LIB
 #include <stdint.h>
 
-extern uint32_t state;
+#ifndef MY_RANDOM_SEED
+    #define MY_RANDOM_SEED 0xabcd
+#endif
 
+void xorshift32_init(uint32_t seed);
 uint32_t xorshift32(void);
 
 #endif // CALIPTRA_RTL_LIB

--- a/src/integration/test_suites/smoke_test_datavault_basic/smoke_test_datavault_basic.c
+++ b/src/integration/test_suites/smoke_test_datavault_basic/smoke_test_datavault_basic.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "printf.h"
+#include "xorshift.h"
 #include "datavault.h"
 
 volatile uint32_t* stdout           = (uint32_t *)STDOUT;
@@ -37,13 +38,8 @@ volatile uint32_t  err_count __attribute__((section(".dccm.persistent"))) = 0;
 
 volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 
-#ifndef MY_RANDOM_SEED
-#define MY_RANDOM_SEED 17
-#endif // MY_RANDOM_SEED
-// -- End Boilerplate --
-
-const long seed = MY_RANDOM_SEED; 
-
+unsigned seed = (unsigned) MY_RANDOM_SEED;
+ptrdiff_t expected_alias_offset = 1U << 11;
 
 int wr_regs_per_pfx(widereg_t *dv_reg, uint32_t rmask) {
 
@@ -61,7 +57,7 @@ int wr_regs_per_pfx(widereg_t *dv_reg, uint32_t rmask) {
     for (int j = 0; j < dv_reg->width; j++) {
         tmpreg = baseaddr + j; 
 
-        wdata = (uint32_t) rand(); 
+        wdata = xorshift32();
         *tmpreg = wdata;
 
         rdata = *tmpreg;
@@ -78,6 +74,16 @@ int wr_regs_per_pfx(widereg_t *dv_reg, uint32_t rmask) {
             VPRINTF(ERROR,"\nMismatch at addr 0x%x (%s[%d]), read data 0x%08x != expected data 0x%08x --\n",  
                 tmpreg, dv_reg->pfx, j, rdata, expdata); 
         } 
+
+        tmpreg = (uint32_t*)((uintptr_t)tmpreg + expected_alias_offset);
+        rdata = *tmpreg;
+        if (rdata) {
+            errs++;
+            VPRINTF(ERROR,"\nNon-zero read at alias addr 0x%x (%s[%d] + 0x%x), read data 0x%08x--\n",
+                tmpreg, dv_reg->pfx, j, expected_alias_offset, rdata);
+        }
+
+
     }
     VPRINTF(LOW,"\n");
 

--- a/src/integration/test_suites/smoke_test_datavault_basic/smoke_test_datavault_basic.c
+++ b/src/integration/test_suites/smoke_test_datavault_basic/smoke_test_datavault_basic.c
@@ -17,12 +17,12 @@
 // -- Begin Boilerplate --
 #include "caliptra_defines.h"
 #include "caliptra_isr.h"
+#include "caliptra_rtl_lib.h"
 #include "riscv-csr.h"
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "printf.h"
-#include "xorshift.h"
 #include "datavault.h"
 
 volatile uint32_t* stdout           = (uint32_t *)STDOUT;

--- a/src/integration/test_suites/smoke_test_datavault_basic/smoke_test_datavault_basic.c
+++ b/src/integration/test_suites/smoke_test_datavault_basic/smoke_test_datavault_basic.c
@@ -20,6 +20,7 @@
 #include "caliptra_rtl_lib.h"
 #include "riscv-csr.h"
 #include <string.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "printf.h"
@@ -100,7 +101,6 @@ void main() {
 
 
     VPRINTF(LOW,"\nINFO. Using random seed = %d\n", seed);
-    srand(seed);
 
     VPRINTF(LOW,"\n** Phase 1. Basic random writes and reads **\n"); 
 

--- a/src/integration/test_suites/smoke_test_datavault_lock/smoke_test_datavault_lock.c
+++ b/src/integration/test_suites/smoke_test_datavault_lock/smoke_test_datavault_lock.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include "printf.h"
 #include "datavault.h"
+#include "xorshift.h"
 
 volatile uint32_t* stdout           = (uint32_t *)STDOUT;
 volatile uint32_t  intr_count = 0;
@@ -37,12 +38,7 @@ volatile uint32_t  err_count __attribute__((section(".dccm.persistent"))) = 0;
 
 volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 
-#ifndef MY_RANDOM_SEED
-#define MY_RANDOM_SEED 17
-#endif // MY_RANDOM_SEED
-// -- End Boilerplate --
-
-const long seed = MY_RANDOM_SEED; 
+unsigned seed = (unsigned) MY_RANDOM_SEED;
 
 const int EXPECT_LOCKED = 1;
 const int EXPECT_UNLOCKED = 0;
@@ -64,7 +60,7 @@ int wr_regs_per_pfx(widereg_t *dv_reg, uint32_t rmask, int locked) {
         if (locked)
             expdata = *tmpreg; 
 
-        wdata = (uint32_t) rand(); 
+        wdata = xorshift32();
         *tmpreg = wdata;
 
         rdata = *tmpreg;
@@ -154,7 +150,7 @@ int exercise_unlocked() {
         }
 
         if (found_unlocked) {
-            uint32_t rand_data = rand();
+            uint32_t rand_data = xorshift32();
             errs += wr_single_reg_explicit( dv_ptr, rand_data, rand_data, pos );  // unlocked registers
         }
 
@@ -227,10 +223,10 @@ int handle_1d_locking(ctrl_reg_t *dv_ctrl_ptr) {
 
         VPRINTF(LOW, "%s[%d] -LOCKS-> %s[%d]\n", ctrlgrp_ptr->pfx, j, datagrp_ptr->pfx, j);
 
-        uint32_t locked_data = rand();
+        uint32_t locked_data = xorshift32();
         errs += wr_single_reg_explicit( datagrp_ptr, locked_data, locked_data, j );     // write random
         errs += wr_single_reg_explicit( ctrlgrp_ptr, 0x1, 0x1, j );                     // lock register 
-        errs += wr_single_reg_explicit( datagrp_ptr, rand(), locked_data, j );          // attempt write random
+        errs += wr_single_reg_explicit( datagrp_ptr, xorshift32(), locked_data, j );          // attempt write random
         update_bitmap(datagrp_ptr - datagrp_head, j);                                   // mark lock bitmap
         errs += exercise_unlocked();                                                    // attempt write random to unlocked blocks
         errs += wr_single_reg_explicit( ctrlgrp_ptr, 0x0, 0x1, j );                     // attempt unlock register 
@@ -259,11 +255,8 @@ void main() {
 
     if (rst_count == 0) {
 
-        int i = rand() % 4;  // Looping through all 4 groups of control registers take too long!
-
         // CYCLE THROUGH 4 CTRL GROUP 
-        // for (int i = 0; i < 4; i++) {
-
+        for (int i = 0; i < 4; i++) {
             dv_ctrl_ptr = & dv_ctrl_regids[ctrl_data_indices[i]]; 
             VPRINTF (LOW, "\n\n** Working on new Control Group Prefix %s to Start Locking Data Registers **\n\n", dv_regs[dv_ctrl_ptr->index].pfx);
 
@@ -271,7 +264,7 @@ void main() {
                 err_count += handle_2d_locking(dv_ctrl_ptr);
             else
                 err_count += handle_1d_locking(dv_ctrl_ptr);
-        // }
+        }
 
         VPRINTF(LOW,"\n\n-- Done w/test; %d errors found -- \n", err_count);
         if (err_count != 0)  {

--- a/src/integration/test_suites/smoke_test_datavault_lock/smoke_test_datavault_lock.c
+++ b/src/integration/test_suites/smoke_test_datavault_lock/smoke_test_datavault_lock.c
@@ -17,13 +17,13 @@
 // -- Begin Boilerplate --
 #include "caliptra_defines.h"
 #include "caliptra_isr.h"
+#include "caliptra_rtl_lib.h"
 #include "riscv-csr.h"
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "printf.h"
 #include "datavault.h"
-#include "xorshift.h"
 
 volatile uint32_t* stdout           = (uint32_t *)STDOUT;
 volatile uint32_t  intr_count = 0;

--- a/src/integration/test_suites/smoke_test_datavault_lock/smoke_test_datavault_lock.c
+++ b/src/integration/test_suites/smoke_test_datavault_lock/smoke_test_datavault_lock.c
@@ -137,11 +137,11 @@ int exercise_unlocked() {
         } else if (curr == 0) { 
             // VPRINTF (LOW, "found fully unlocked registers at dv_regs[%d]...(curr status is 0x%-3x):\n", i, curr);
             found_unlocked = 1;
-            pos = rand() % dv_ptr->width; 
+            pos = xorshift32() % dv_ptr->width;
         } else {
             // VPRINTF (LOW, "found partially unlocked registers at dv_regs[%d]...(curr status is 0x%-3x):\n", i, curr);
             for (int j = 0; j < dv_ptr->width; j++) {
-                pos = rand() % dv_ptr-> width;
+                pos = xorshift32() % dv_ptr-> width;
                 if ( (curr & (1 << pos)) == 0 ) { 
                     found_unlocked = 1;
                     break;
@@ -244,7 +244,6 @@ void main() {
     VPRINTF(LOW,"-------------------------------------------\n");
 
     VPRINTF(LOW,"\nINFO. Using random seed = %d\n", seed);
-    srand(seed);
 
     // We have up to 4 array of pairings of Control and Data registers that are lockable 
     ctrl_reg_t *dv_ctrl_ptr;

--- a/src/integration/test_suites/smoke_test_datavault_mini/smoke_test_datavault_mini.c
+++ b/src/integration/test_suites/smoke_test_datavault_mini/smoke_test_datavault_mini.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "printf.h"
+#include "xorshift.h"
 #include "datavault.h"
 
 volatile uint32_t* stdout           = (uint32_t *)STDOUT;
@@ -44,13 +45,7 @@ volatile uint32_t err_count __attribute__((section(".dccm.persistent"))) = 0;
 
 volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 
-
-#ifndef MY_RANDOM_SEED
-#define MY_RANDOM_SEED 17
-#endif // MY_RANDOM_SEED
-// -- End Boilerplate --
-
-const long seed = MY_RANDOM_SEED; 
+unsigned seed = (unsigned) MY_RANDOM_SEED;
 
 const int EXPECT_LOCKED = 1;
 const int EXPECT_UNLOCKED = 0;
@@ -110,7 +105,7 @@ int wr_regs_per_pfx(widereg_t *dv_reg, uint32_t rmask, int locked) {
         if (locked)
             expdata = *tmpreg; 
 
-        wdata = (uint32_t) rand(); 
+        wdata = xorshift32();
         *tmpreg = wdata;
 
         rdata = *tmpreg;
@@ -200,7 +195,7 @@ int sm_exercise_unlocked() {
         }
 
         if (found_unlocked) {
-            uint32_t rand_data = rand();
+            uint32_t rand_data = xorshift32();
             errs += wr_single_reg_explicit( dv_ptr, rand_data, rand_data, pos );  // unlocked registers
         }
 
@@ -273,10 +268,10 @@ int sm_handle_1d_locking(ctrl_reg_t *dv_ctrl_ptr) {
 
         VPRINTF(LOW, "%s[%d] -LOCKS-> %s[%d]\n", ctrlgrp_ptr->pfx, j, datagrp_ptr->pfx, j);
 
-        uint32_t locked_data = rand();
+        uint32_t locked_data = xorshift32();
         errs += wr_single_reg_explicit( datagrp_ptr, locked_data, locked_data, j );     // write random
         errs += wr_single_reg_explicit( ctrlgrp_ptr, 0x1, 0x1, j );                     // lock register 
-        errs += wr_single_reg_explicit( datagrp_ptr, rand(), locked_data, j );          // attempt write random
+        errs += wr_single_reg_explicit( datagrp_ptr, xorshift32(), locked_data, j );          // attempt write random
         update_bitmap(datagrp_ptr - datagrp_head, j);                                   // mark lock bitmap
         errs += sm_exercise_unlocked();                                                    // attempt write random to unlocked blocks
         errs += wr_single_reg_explicit( ctrlgrp_ptr, 0x0, 0x1, j );                     // attempt unlock register 

--- a/src/integration/test_suites/smoke_test_datavault_mini/smoke_test_datavault_mini.c
+++ b/src/integration/test_suites/smoke_test_datavault_mini/smoke_test_datavault_mini.c
@@ -24,12 +24,12 @@
 // -- Begin Boilerplate --
 #include "caliptra_defines.h"
 #include "caliptra_isr.h"
+#include "caliptra_rtl_lib.h"
 #include "riscv-csr.h"
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "printf.h"
-#include "xorshift.h"
 #include "datavault.h"
 
 volatile uint32_t* stdout           = (uint32_t *)STDOUT;

--- a/src/integration/test_suites/smoke_test_datavault_mini/smoke_test_datavault_mini.c
+++ b/src/integration/test_suites/smoke_test_datavault_mini/smoke_test_datavault_mini.c
@@ -182,11 +182,11 @@ int sm_exercise_unlocked() {
         } else if (curr == 0) { 
             // VPRINTF (LOW, "found fully unlocked registers at sm_dv_regs[%d]...(curr status is 0x%-3x):\n", i, curr);
             found_unlocked = 1;
-            pos = rand() % dv_ptr->width; 
+            pos = xorshift32() % dv_ptr->width;
         } else {
             // VPRINTF (LOW, "found partially unlocked registers at sm_dv_regs[%d]...(curr status is 0x%-3x):\n", i, curr);
             for (int j = 0; j < dv_ptr->width; j++) {
-                pos = rand() % dv_ptr-> width;
+                pos = xorshift32() % dv_ptr-> width;
                 if ( (curr & (1 << pos)) == 0 ) { 
                     found_unlocked = 1;
                     break;
@@ -289,7 +289,6 @@ void main() {
     VPRINTF(LOW,"-------------------------------------------------------------------\n");
 
     VPRINTF(LOW,"\nINFO. Using random seed = %d\n", seed);
-    srand(seed);
 
     // We have up to 4 array of pairings of Control and Data registers that are lockable 
     ctrl_reg_t *dv_ctrl_ptr;

--- a/src/integration/test_suites/smoke_test_datavault_reset/smoke_test_datavault_reset.c
+++ b/src/integration/test_suites/smoke_test_datavault_reset/smoke_test_datavault_reset.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "printf.h"
+#include "xorshift.h"
 #include "datavault.h"
 
 volatile uint32_t* stdout           = (uint32_t *)STDOUT;
@@ -36,12 +37,7 @@ volatile uint32_t  err_count __attribute__((section(".dccm.persistent"))) = 0;
 
 volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 
-#ifndef MY_RANDOM_SEED
-#define MY_RANDOM_SEED 17
-#endif // MY_RANDOM_SEED
-// -- End Boilerplate --
-
-const long seed = MY_RANDOM_SEED; 
+unsigned seed = (unsigned) MY_RANDOM_SEED;
 
 const int DV_WARM_RESET   = 0;
 const int DV_COLD_RESET   = 1;
@@ -50,20 +46,18 @@ uint32_t wdata_values [DV_PFX_COUNT] [DV_MAXWIDTH];
 uint32_t survived_values [DV_PFX_COUNT] [DV_MAXWIDTH]; 
 
 
-void populate_wr_exp_values(uint32_t init_val) { 
-
+void populate_wr_exp_values(uint32_t local_seed) {
     widereg_t *dvregs_ptr;
-    uint32_t curr = init_val; 
 
-    VPRINTF(LOW, "\n-- Populating write data and expected values into arrays starting w/0x%x--\n", init_val);
+    xorshift32_init(local_seed);
+    VPRINTF(LOW, "\n-- Populating random write data and expected values into arrays --\n");
 
     dvregs_ptr = dv_regs;
     
     for (int i = 0; i < DV_PFX_COUNT; i++, dvregs_ptr++) {
         for (int j = 0; j < dvregs_ptr->width; j++) {
-            wdata_values[i][j] = curr;  
+            wdata_values[i][j] = xorshift32();
             survived_values[i][j] = wdata_values[i][j] & dvregs_ptr->sticky_mask; 
-            curr += 0x10;
         }
     }
     VPRINTF(LOW, "\n-- Done with populating data --\n");
@@ -161,16 +155,14 @@ void main() {
 
 
     if (rst_count == 0) {
-
-        srand(seed);
-
         VPRINTF(LOW,"------------------------------------\n");
         VPRINTF(LOW," DV Smoke Test for Cold/Warm Reset !!\n");
         VPRINTF(LOW,"------------------------------------\n");
 
         VPRINTF(LOW,"\nINFO. Using random seed = %d\n\n", seed);
+        srand(seed);
 
-        populate_wr_exp_values(0x10000001);
+        populate_wr_exp_values(seed);
         write_dv_regs();
 
         VPRINTF(LOW,"\n-- Issue warm reset --\n"); 
@@ -181,7 +173,7 @@ void main() {
 
         VPRINTF(LOW,"** Checking warm reset survived values **\n"); 
 
-        populate_wr_exp_values(0x10000001);
+        populate_wr_exp_values(seed);
         err_count = check_reset_values(DV_WARM_RESET);
 
         if (err_count == 0) {
@@ -190,7 +182,7 @@ void main() {
             VPRINTF(LOW,"-- %d errors found in warm-reset test phase; proceeding to next phase -- \n", err_count);
         }
 
-        populate_wr_exp_values(0x20000001);
+        populate_wr_exp_values(seed + 1);
         write_dv_regs();
 
         VPRINTF(LOW,"\n** Performing a WRITE to all registers again (reporting once per prefix)**\n\n");

--- a/src/integration/test_suites/smoke_test_datavault_reset/smoke_test_datavault_reset.c
+++ b/src/integration/test_suites/smoke_test_datavault_reset/smoke_test_datavault_reset.c
@@ -16,12 +16,12 @@
 // -- Begin Boilerplate --
 #include "caliptra_defines.h"
 #include "caliptra_isr.h"
+#include "caliptra_rtl_lib.h"
 #include "riscv-csr.h"
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "printf.h"
-#include "xorshift.h"
 #include "datavault.h"
 
 volatile uint32_t* stdout           = (uint32_t *)STDOUT;

--- a/src/integration/test_suites/smoke_test_datavault_reset/smoke_test_datavault_reset.c
+++ b/src/integration/test_suites/smoke_test_datavault_reset/smoke_test_datavault_reset.c
@@ -160,7 +160,6 @@ void main() {
         VPRINTF(LOW,"------------------------------------\n");
 
         VPRINTF(LOW,"\nINFO. Using random seed = %d\n\n", seed);
-        srand(seed);
 
         populate_wr_exp_values(seed);
         write_dv_regs();

--- a/src/integration/test_suites/smoke_test_mldsa_zeroize/smoke_test_mldsa_zeroize.c
+++ b/src/integration/test_suites/smoke_test_mldsa_zeroize/smoke_test_mldsa_zeroize.c
@@ -18,7 +18,6 @@
 #include "riscv_hw_if.h"
 #include "riscv-csr.h"
 #include "printf.h"
-#include "xorshift.h"
 #include "mldsa.h"
 #include <stdlib.h>
 

--- a/src/integration/test_suites/smoke_test_mldsa_zeroize/smoke_test_mldsa_zeroize.c
+++ b/src/integration/test_suites/smoke_test_mldsa_zeroize/smoke_test_mldsa_zeroize.c
@@ -18,6 +18,7 @@
 #include "riscv_hw_if.h"
 #include "riscv-csr.h"
 #include "printf.h"
+#include "xorshift.h"
 #include "mldsa.h"
 #include <stdlib.h>
 
@@ -105,13 +106,13 @@ void main() {
         seed.kv_id = 8; //KV_ENTRY_FOR_MLDSA_SIGNING
 
         for (int i = 0; i < MLDSA87_SIGN_RND_SIZE; i++)
-            sign_rnd[i] = rand() % 0xffffffff;
+            sign_rnd[i] = xorshift32();
 
         for (int i = 0; i < MLDSA87_ENTROPY_SIZE; i++)
-            entropy[i] = rand() % 0xffffffff;
+            entropy[i] = xorshift32();
         
         for (int i = 0; i < MLDSA87_MSG_SIZE; i++)
-            msg[i] = rand() % 0xffffffff;
+            msg[i] = xorshift32();
 
         VPRINTF(LOW, "inject random mldsa seed to kv key reg (in RTL)\n");
         SEND_STDOUT_CTRL(0x93);
@@ -194,7 +195,7 @@ void main() {
         offset = 0;
         while ((*status_ptr == 0) & (offset < end_addr)) {
             // Try to Overwrite data in MLDSA
-            *reg_ptr = rand() % 0xffffffff;
+            *reg_ptr = xorshift32();
             if (*reg_ptr != 0) {
                 VPRINTF(ERROR, "At offset [%d], mldsa data mismatch!\n", offset);
                 VPRINTF(ERROR, "Actual   data: 0x%x\n", *reg_ptr);

--- a/src/integration/test_suites/smoke_test_mldsa_zeroize/smoke_test_mldsa_zeroize.c
+++ b/src/integration/test_suites/smoke_test_mldsa_zeroize/smoke_test_mldsa_zeroize.c
@@ -15,6 +15,7 @@
 
 #include "caliptra_defines.h"
 #include "caliptra_isr.h"
+#include "caliptra_rtl_lib.h"
 #include "riscv_hw_if.h"
 #include "riscv-csr.h"
 #include "printf.h"
@@ -86,6 +87,7 @@ void main() {
 
     /* Intializes random number generator */  //TODO    
     srand(time);
+    xorshift32_init(time);
 
     //Call interrupt init
     init_interrupts();


### PR DESCRIPTION
Improves randomization for `smoke_test_datavault*.c` and `smoke_test_mldsa_zeroize.c` integration level tests

- Allows to change the seed for `xorshift32`
- Switches to `xorshift32` usage as opposed to `rand` or constant values
- Extends `smoke_test_datavault_basic.c` with alias address check