### PR TITLE
Add smoke_test_axi_wr_rst: Initiate SoC write after cptra_rst deassertion

### DIFF
--- a/src/integration/stimulus/testsuites/caliptra_top_nightly_directed_regression.yml
+++ b/src/integration/stimulus/testsuites/caliptra_top_nightly_directed_regression.yml
@@ -69,6 +69,7 @@ contents:
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_ecc_errortrigger5/smoke_test_ecc_errortrigger5.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_pcr_zeroize/smoke_test_pcr_zeroize.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_ahb_mux/smoke_test_ahb_mux.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_axi_wr_rst/smoke_test_axi_wr_rst.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_doe_rand/smoke_test_doe_rand.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_doe_scan/smoke_test_doe_scan.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_zeroize_crypto/smoke_test_zeroize_crypto.yml

--- a/src/integration/tb/caliptra_top_tb_soc_bfm.sv
+++ b/src/integration/tb/caliptra_top_tb_soc_bfm.sv
@@ -723,4 +723,31 @@ initial begin
     end
 end
 
+initial begin
+    forever @(posedge cptra_rst_b) begin
+        if($test$plusargs("SOC_WRITE_RST")) begin
+            fork
+                begin
+                    assert (`CPTRA_TOP_PATH.cptra_noncore_rst_b == 0) else begin
+                        $display("* TEST FAILED");
+                        $error("cptra_noncore_rst_b asserted for the SoC access under reset test");
+                        $finish;
+                    end
+                    m_axi_bfm_if.axi_write_single(.addr(`CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_0), .user(32'hFFFF_FFFF), .data(32'hBAADB000), .resp(wresp), .resp_user(buser));
+                    m_axi_bfm_if.axi_read_single(.addr(`CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_0), .user(32'hFFFF_FFFF), .data(rdata), .resp(rresp), .resp_user(buser));
+
+                    if (rdata != 32'hBAADB000) begin
+                        $display("* TEST FAILED");
+                        $error($sformatf("SoC write on reset failed! Expected to read back: 0x%x. Got: 0x%x.", 32'hBAADB000, rdata));
+                        $finish;
+                    end
+
+                    $display("* TEST PASSED");
+                    $finish;
+                end
+            join
+        end
+    end
+end
+
 endmodule

--- a/src/integration/tb/caliptra_top_tb_soc_bfm.sv
+++ b/src/integration/tb/caliptra_top_tb_soc_bfm.sv
@@ -730,7 +730,7 @@ initial begin
                 begin
                     assert (`CPTRA_TOP_PATH.cptra_noncore_rst_b == 0) else begin
                         $display("* TEST FAILED");
-                        $error("cptra_noncore_rst_b asserted for the SoC access under reset test");
+                        $error("cptra_noncore_rst_b deasserted for the SoC access under reset test");
                         $finish;
                     end
                     m_axi_bfm_if.axi_write_single(.addr(`CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_0), .user(32'hFFFF_FFFF), .data(32'hBAADB000), .resp(wresp), .resp_user(buser));

--- a/src/integration/test_suites/smoke_test_axi_wr_rst/caliptra_isr.h
+++ b/src/integration/test_suites/smoke_test_axi_wr_rst/caliptra_isr.h
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Dummy ISRs
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+#define CALIPTRA_ISR_H
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+
+/* --------------- symbols/typedefs --------------- */
+
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {return;}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {return;}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {return;}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {return;}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {return;}
+inline void service_soc_ifc_notif_intr () {return;}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {return;}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/smoke_test_axi_wr_rst/smoke_test_axi_wr_rst.c
+++ b/src/integration/test_suites/smoke_test_axi_wr_rst/smoke_test_axi_wr_rst.c
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include <stdint.h>
+#include "printf.h"
+
+volatile uint32_t intr_count = 0;
+volatile uint32_t *stdout = (uint32_t *)STDOUT;
+#ifdef CPT_VERBOSITY
+enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+enum printf_verbosity verbosity_g = HIGH;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+void main(void) {
+    // The test is fully executed during the boot stage in the testbench
+    while(1);
+}

--- a/src/integration/test_suites/smoke_test_axi_wr_rst/smoke_test_axi_wr_rst.yml
+++ b/src/integration/test_suites/smoke_test_axi_wr_rst/smoke_test_axi_wr_rst.yml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+plusargs:         
+  - +SOC_WRITE_RST
+seed: 1
+testname: smoke_test_axi_wr_rst

--- a/src/integration/test_suites/smoke_test_axi_wr_rst/smoke_test_axi_wr_rst.yml
+++ b/src/integration/test_suites/smoke_test_axi_wr_rst/smoke_test_axi_wr_rst.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ---
-plusargs:         
+plusargs:
   - +SOC_WRITE_RST
 seed: 1
 testname: smoke_test_axi_wr_rst


### PR DESCRIPTION
Adds a test to verify behavior when SoC initiates access before cptra_rst deassertion.

Covers `s_axi_if.awvalid == 1 AND axi_out_of_rst == 0` within `axi_sub_wr`.