### PR TITLE
[VAL] Extend integration tb infrastructure for stress and corner-case testing

### DIFF
--- a/src/axi/rtl/axi_if.sv
+++ b/src/axi/rtl/axi_if.sv
@@ -239,38 +239,14 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             bready  `EQ__ '0;
         endtask
 
-        // TODO: handle IDs?
-        task get_read_beat(output logic [DW-1:0] data,
-                        output logic [UW-1:0] user,
-                        output axi_resp_e     resp);
-            `TIME_ALGN
-            rready `EQ__ 1;
-            do
-                @(posedge clk);
-            while (!rvalid);
-            data   `EQ__ rdata;
-            user   `EQ__ ruser;
-            resp   `EQ__ axi_resp_e'(rresp);
-            `TIME_ALGN
-            rready `EQ__ 0;
-            wait(!rready);
-        endtask
-
-        // Read: default to single beat of native data width
-        task axi_read(input  logic [AW-1:0] addr,
-                    input  axi_burst_e    burst = AXI_BURST_INCR,
-                    input  logic [2:0]    size  = $clog2(DW/8),
-                    input  logic [7:0]    len   = 0,
-                    input  logic [UW-1:0] user  = UW'(0),
-                    input  logic [IW-1:0] id    = IW'(0),
-                    input  logic          lock  = 1'b0,
-                    output logic [DW-1:0] data [],
-                    output logic [UW-1:0] resp_user [],
-                    output axi_resp_e     resp []);
-            axi_resp_e     beat_resp;
-            logic [UW-1:0] beat_user;
-            logic [DW-1:0] beat_data;
-            while(!rst_n) @(posedge clk);
+        task send_read_address(
+                        input  logic [AW-1:0] addr,
+                        input  axi_burst_e    burst = AXI_BURST_INCR,
+                        input  logic [2:0]    size  = $clog2(DW/8),
+                        input  logic [7:0]    len   = 0,
+                        input  logic [UW-1:0] user  = UW'(0),
+                        input  logic [IW-1:0] id    = IW'(0),
+                        input  logic          lock  = 1'b0);
             do begin
                 `TIME_ALGN
                 araddr  `EQ__ addr;
@@ -300,10 +276,57 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             arqos   `EQ__ '0;
             arregion `EQ__ '0;
             arvalid `EQ__ '0;
+        endtask
+
+        task get_read_beat(
+                        input  logic [IW-1:0] id    = IW'(0),
+                        output logic [DW-1:0] data,
+                        output logic [UW-1:0] user,
+                        output axi_resp_e     resp);
+            logic [IW-1:0] resp_id;
+            do begin
+                `TIME_ALGN
+                rready `EQ__ 1;
+                do
+                    @(posedge clk);
+                while (!rvalid);
+                data    `EQ__ rdata;
+                user    `EQ__ ruser;
+                resp    `EQ__ axi_resp_e'(rresp);
+                resp_id `EQ__ rid;
+                `TIME_ALGN
+                rready `EQ__ 0;
+                wait(!rready);
+            end while (id != resp_id);
+        endtask
+
+        // Read: default to single beat of native data width
+        task axi_read(input  logic [AW-1:0] addr,
+                    input  axi_burst_e    burst = AXI_BURST_INCR,
+                    input  logic [2:0]    size  = $clog2(DW/8),
+                    input  logic [7:0]    len   = 0,
+                    input  logic [UW-1:0] user  = UW'(0),
+                    input  logic [IW-1:0] id    = IW'(0),
+                    input  logic          lock  = 1'b0,
+                    input  int            stall = 0,
+                    output logic [DW-1:0] data [],
+                    output logic [UW-1:0] resp_user [],
+                    output axi_resp_e     resp []);
+            axi_resp_e     beat_resp;
+            logic [UW-1:0] beat_user;
+            logic [DW-1:0] beat_data;
+            while(!rst_n) @(posedge clk);
+            send_read_address(addr, burst, size, len, user, id, lock);
             data = new[len+1];
+            resp_user = new[len+1];
             resp = new[len+1];
             for (int beat=0; beat <= len; beat++) begin
-                get_read_beat(beat_data, beat_user, beat_resp);
+                if (stall > 0)
+                    $display($sformatf("[%t] Stalling RREADY for %d clock cycles, AXI id 0x%x", $time, stall, id));
+                repeat (stall) begin
+                    @(posedge clk);
+                end
+                get_read_beat(id, beat_data, beat_user, beat_resp);
                 data[beat]      = beat_data;
                 resp_user[beat] = beat_user;
                 resp[beat]      = beat_resp;
@@ -311,6 +334,7 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
         endtask
 
         task axi_read_single(input  logic [AW-1:0] addr,
+                            input  logic [2:0]    size  = $clog2(DW/8),
                             input  logic [UW-1:0] user  = UW'(0),
                             input  logic [IW-1:0] id    = IW'(0),
                             input  logic          lock  = 1'b0,
@@ -320,7 +344,8 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             automatic axi_resp_e     burst_resp[];
             automatic logic [UW-1:0] burst_ruser[];
             automatic logic [DW-1:0] burst_data[];
-            axi_read(.addr     (addr       ),
+            axi_read(.addr    (addr       ),
+                    .size     (size       ),
                     .user     (user       ),
                     .id       (id         ),
                     .lock     (lock       ),
@@ -332,58 +357,13 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             resp      = burst_resp[0];
         endtask
 
-        task send_write_beat(input logic last,
-                            input logic [DW-1:0] data,
-                            input logic [UW-1:0] user,
-                            input logic [DW/8-1:0] strb);
-            `TIME_ALGN
-            wvalid `EQ__ 1;
-            wlast  `EQ__ last;
-            wdata  `EQ__ data;
-            wstrb  `EQ__ strb;
-            wuser  `EQ__ user;
-            do
-                @(posedge clk);
-            while (!wready);
-            `TIME_ALGN
-            wvalid `EQ__ '0;
-            wlast  `EQ__ '0;
-            wdata  `EQ__ '0;
-            wstrb  `EQ__ '0;
-            wuser  `EQ__ '0;
-            wait(!wvalid);
-        endtask
-
-        // TODO handle ID
-        task get_write_resp(output axi_resp_e     resp,
-                            output logic [UW-1:0] user);
-            `TIME_ALGN
-            bready `EQ__ 1;
-            do
-                @(posedge clk);
-            while(!bvalid);
-            resp `EQ__ axi_resp_e'(bresp);
-            user `EQ__ buser;
-            `TIME_ALGN
-            bready `EQ__ 0;
-            wait(!bready);
-        endtask
-
-        task axi_write(input  logic [AW-1:0]   addr,
+        task send_write_addr(input  logic [AW-1:0]   addr,
                     input  axi_burst_e      burst = AXI_BURST_INCR,
                     input  logic [2:0]      size  = $clog2(DW/8),
                     input  logic [7:0]      len   = 0,
                     input  logic [UW-1:0]   user  = UW'(0),
                     input  logic [IW-1:0]   id    = IW'(0),
-                    input  logic            lock  = 1'b0,
-                    input  logic [DW-1:0]   data [],
-                    input  logic            use_strb = 0,
-                    input  logic [DW/8-1:0] strb [],
-                    input  logic            use_write_user = 0,
-                    input  logic [UW-1:0]   write_user [],
-                    output axi_resp_e       resp,
-                    output logic [UW-1:0]   resp_user);
-            while(!rst_n) @(posedge clk);
+                    input  logic            lock  = 1'b0);
             do begin
                 `TIME_ALGN
                 awaddr  `EQ__ addr;
@@ -413,10 +393,77 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             awqos   `EQ__ '0;
             awregion `EQ__ '0;
             awvalid `EQ__ '0;
+        endtask
+
+        task send_write_beat(input logic last,
+                            input logic [DW-1:0] data,
+                            input logic [UW-1:0] user,
+                            input logic [DW/8-1:0] strb);
+            `TIME_ALGN
+            wvalid `EQ__ 1;
+            wlast  `EQ__ last;
+            wdata  `EQ__ data;
+            wstrb  `EQ__ strb;
+            wuser  `EQ__ user;
+            do
+                @(posedge clk);
+            while (!wready);
+            `TIME_ALGN
+            wvalid `EQ__ '0;
+            wlast  `EQ__ '0;
+            wdata  `EQ__ '0;
+            wstrb  `EQ__ '0;
+            wuser  `EQ__ '0;
+            wait(!wvalid);
+        endtask
+
+        task get_write_resp(input  logic [IW-1:0] id    = IW'(0),
+                            output axi_resp_e     resp,
+                            output logic [UW-1:0] user);
+            logic [IW-1:0] resp_id;
+            do begin
+                `TIME_ALGN
+                bready `EQ__ 1;
+                do
+                    @(posedge clk);
+                while(!bvalid);
+                resp    `EQ__ axi_resp_e'(bresp);
+                user    `EQ__ buser;
+                resp_id `EQ__ bid;
+                `TIME_ALGN
+                bready `EQ__ 0;
+                wait(!bready);
+            end while(resp_id != id);
+        endtask
+
+        task axi_write(input  logic [AW-1:0]   addr,
+                    input  axi_burst_e      burst = AXI_BURST_INCR,
+                    input  logic [2:0]      size  = $clog2(DW/8),
+                    input  logic [7:0]      len   = 0,
+                    input  logic [UW-1:0]   user  = UW'(0),
+                    input  logic [IW-1:0]   id    = IW'(0),
+                    input  logic            lock  = 1'b0,
+                    input  logic [DW-1:0]   data [],
+                    input  logic            use_strb = 0,
+                    input  logic [DW/8-1:0] strb [],
+                    input  logic            use_write_user = 0,
+                    input  logic [UW-1:0]   write_user [],
+                    input  int unsigned     stall = 0,
+                    output axi_resp_e       resp,
+                    output logic [UW-1:0]   resp_user);
+            while(!rst_n) @(posedge clk);
+            send_write_addr(addr, burst, size, len, user, id, lock);
             fork
                 for (int beat=0; beat <= len; beat++)
                     send_write_beat(beat == len, data[beat], use_write_user ? write_user[beat] : UW'(0), use_strb ? strb[beat] : {DW/8{1'b1}});
-                get_write_resp(resp, resp_user);
+                begin
+                    if (stall > 0)
+                        $display($sformatf("[%t] Stalling BREADY for %d clock cycles, AXI id 0x%x", $time, stall, id));
+                    repeat (stall) begin
+                        @(posedge clk);
+                    end
+                    get_write_resp(id, resp, resp_user);
+                end
             join
         endtask
 

--- a/src/axi/rtl/axi_if.sv
+++ b/src/axi/rtl/axi_if.sv
@@ -201,7 +201,30 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
 
     `ifndef SYNTHESIS
     `ifndef XCELIUM
+        typedef struct packed {
+            logic [DW-1:0] data;
+            logic [UW-1:0] user;
+            axi_resp_e     resp;
+            logic          last;
+        } axi_read_beat_t;
+
+        typedef struct packed {
+            logic [UW-1:0] user;
+            axi_resp_e     resp;
+        } axi_write_resp_t;
+
+        localparam int unsigned AxiIDCount = 2**IW;
+        axi_read_beat_t  pending_read_beat [AxiIDCount][$];
+        axi_write_resp_t pending_write_resp[AxiIDCount][$];
+        semaphore read_response_lock  = new(1);
+        semaphore write_response_lock = new(1);
+
         task rst_mgr();
+            for (int unsigned id = 0; id < AxiIDCount; id++) begin
+                pending_read_beat[id].delete();
+                pending_write_resp[id].delete();
+            end
+
             araddr  `EQ__ '0;
             arburst `EQ__ AXI_BURST_FIXED;
             arsize  `EQ__ '0;
@@ -283,21 +306,33 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
                         output logic [DW-1:0] data,
                         output logic [UW-1:0] user,
                         output axi_resp_e     resp);
+            axi_read_beat_t beat;
             logic [IW-1:0] resp_id;
-            do begin
-                `TIME_ALGN
-                rready `EQ__ 1;
-                do
-                    @(posedge clk);
-                while (!rvalid);
-                data    `EQ__ rdata;
-                user    `EQ__ ruser;
-                resp    `EQ__ axi_resp_e'(rresp);
-                resp_id `EQ__ rid;
-                `TIME_ALGN
-                rready `EQ__ 0;
-                wait(!rready);
-            end while (id != resp_id);
+            read_response_lock.get(1);
+            if (pending_read_beat[int'(id)].size() != 0) begin
+                beat = pending_read_beat[int'(id)].pop_front();
+            end else begin
+                do begin
+                    `TIME_ALGN
+                    rready `EQ__ 1;
+                    do
+                        @(posedge clk);
+                    while (!rvalid);
+                    beat.data = rdata;
+                    beat.user = ruser;
+                    beat.resp = axi_resp_e'(rresp);
+                    beat.last = rlast;
+                    resp_id   = rid;
+                    `TIME_ALGN
+                    rready `EQ__ 0;
+                    wait(!rready);
+                    if (resp_id != id) pending_read_beat[int'(resp_id)].push_back(beat);
+                end while (resp_id != id);
+            end
+            read_response_lock.put(1);
+            data = beat.data;
+            user = beat.user;
+            resp = beat.resp;
         endtask
 
         // Read: default to single beat of native data width
@@ -420,20 +455,31 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
         task get_write_resp(input  logic [IW-1:0] id    = IW'(0),
                             output axi_resp_e     resp,
                             output logic [UW-1:0] user);
+            axi_write_resp_t write_resp;
             logic [IW-1:0] resp_id;
-            do begin
-                `TIME_ALGN
-                bready `EQ__ 1;
-                do
-                    @(posedge clk);
-                while(!bvalid);
-                resp    `EQ__ axi_resp_e'(bresp);
-                user    `EQ__ buser;
-                resp_id `EQ__ bid;
-                `TIME_ALGN
-                bready `EQ__ 0;
-                wait(!bready);
-            end while(resp_id != id);
+            write_response_lock.get(1);
+            if (pending_write_resp[int'(id)].size() != 0) begin
+                write_resp = pending_write_resp[int'(id)].pop_front();
+            end else begin
+                do begin
+                    `TIME_ALGN
+                    bready `EQ__ 1;
+                    do
+                        @(posedge clk);
+                    while (!bvalid);
+                    write_resp.resp = axi_resp_e'(bresp);
+                    write_resp.user = buser;
+                    resp_id         = bid;
+                    `TIME_ALGN
+                    bready `EQ__ 0;
+                    wait(!bready);
+                    if (resp_id != id) pending_write_resp[int'(resp_id)].push_back(write_resp);
+                end while (resp_id != id);
+            end
+
+            write_response_lock.put(1);
+            resp = write_resp.resp;
+            user = write_resp.user;
         endtask
 
         task axi_write(input  logic [AW-1:0]   addr,

--- a/src/integration/asserts/caliptra_top_sva.sv
+++ b/src/integration/asserts/caliptra_top_sva.sv
@@ -345,7 +345,7 @@ module caliptra_top_sva
   endgenerate
 
   generate
-    for(genvar dword = 0; dword < KV_NUM_DWORDS; dword++) begin
+    for(genvar dword = 0; dword < KV_NUM_DWORDS; dword++) begin : KV_check
       if (dword < MLDSA_SEED_NUM_DWORDS) begin
       //mldsa seed read
       kv_mldsa_seed_r_flow:   assert property (

--- a/src/integration/tb/caliptra_top_tb.sv
+++ b/src/integration/tb/caliptra_top_tb.sv
@@ -158,7 +158,7 @@ module caliptra_top_tb (
     logic [ 3:0] wstrb[$];
     logic [ 1:0] burst;
     logic        use_id;
-    logic        id;
+    logic [ 7:0] id;
     logic        write;
     logic        write_addr;
     logic        write_data;

--- a/src/integration/tb/caliptra_top_tb.sv
+++ b/src/integration/tb/caliptra_top_tb.sv
@@ -61,13 +61,17 @@ module caliptra_top_tb (
     logic                       recovery_data_avail;
 
     logic [`CLP_OBF_KEY_DWORDS-1:0][31:0]          cptra_obf_key;
-    
+
     logic [`CLP_CSR_HMAC_KEY_DWORDS-1:0][31:0]     cptra_csr_hmac_key;
 
     logic [0:`CLP_OBF_UDS_DWORDS-1][31:0]          cptra_uds_rand;
     logic [0:`CLP_OBF_FE_DWORDS-1][31:0]           cptra_fe_rand;
     logic [0:OCP_LOCK_HEK_NUM_DWORDS-1][31:0]      cptra_hek_rand;
     logic [0:`CLP_OBF_KEY_DWORDS-1][31:0]          cptra_obf_key_tb;
+    logic [`CLP_OBF_UDS_DWORDS-1:0][31:0]          cptra_uds_strap;
+    logic                                          cptra_uds_strap_vld;
+    logic [`CLP_OBF_FE_DWORDS-1:0] [31:0]          cptra_fe_strap;
+    logic                                          cptra_fe_strap_vld;
 
     //jtag interface
     logic                       jtag_tck;    // JTAG clk
@@ -140,6 +144,51 @@ module caliptra_top_tb (
     logic deassert_hard_rst_flag;
     logic assert_rst_flag_from_service;
     logic deassert_rst_flag_from_service;
+    logic route_fatal_to_nmi;
+
+    // Custom event injection
+    logic inject_mbox_soc_lock_on_mbox_unlock;
+
+    //AXI
+    logic [31:0] address;
+    logic [31:0] axuser;
+    logic [31:0] wuser[$];
+    logic [31:0] wdata[$];
+    logic [ 7:0] len;
+    logic [ 3:0] wstrb[$];
+    logic [ 1:0] burst;
+    logic        use_id;
+    logic        id;
+    logic        write;
+    logic        write_addr;
+    logic        write_data;
+    logic        write_resp;
+    logic        read;
+    logic        read_addr;
+    logic        read_resp;
+    logic        put_status;
+    logic        put_rdata;
+
+    logic [31:0] obf_key_value;
+    logic  [2:0] obf_key_idx;
+    logic        set_obf_key;
+    logic        get_obf_key;
+
+
+    // UDS access
+    logic       get_uds_value;
+    logic [2:0] uds_idx;
+
+    // FE access
+    logic       get_fe_value;
+    logic [1:0] fe_idx;
+
+    // KV check cleared
+    logic        check_kv_clear;
+    logic [4:0]  kv_idx;
+
+    //Control singlas
+    logic debug_intent;
 
     el2_mem_if el2_mem_export ();
     abr_mem_if abr_memory_export();
@@ -162,6 +211,10 @@ caliptra_top_tb_soc_bfm soc_bfm_inst (
     .cycleCnt        (cycleCnt        ),
 
     .cptra_obf_key      (cptra_obf_key   ),
+    .cptra_uds_strap    (cptra_uds_strap    ),
+    .cptra_uds_strap_vld(cptra_uds_strap_vld),
+    .cptra_fe_strap     (cptra_fe_strap     ),
+    .cptra_fe_strap_vld (cptra_fe_strap_vld ),
     .cptra_csr_hmac_key (cptra_csr_hmac_key),
 
     .strap_ss_key_release_key_size,
@@ -200,8 +253,49 @@ caliptra_top_tb_soc_bfm soc_bfm_inst (
     .assert_hard_rst_flag(assert_hard_rst_flag),
     .deassert_hard_rst_flag(deassert_hard_rst_flag),
     .assert_rst_flag_from_service(assert_rst_flag_from_service),
-    .deassert_rst_flag_from_service(deassert_rst_flag_from_service)
+    .deassert_rst_flag_from_service(deassert_rst_flag_from_service),
 
+    .route_fatal_to_nmi(route_fatal_to_nmi),
+
+    // Custom event injection
+    .inject_mbox_soc_lock_on_mbox_unlock(inject_mbox_soc_lock_on_mbox_unlock),
+
+    //AXI SoC
+    .axi_addr(address),
+    .axi_axuser(axuser),
+    .axi_wuser(wuser),
+    .axi_wdata(wdata),
+    .axi_len(len),
+    .axi_wstrb(wstrb),
+    .axi_burst(burst),
+    .axi_use_id(use_id),
+    .axi_id(id),
+    .axi_write(write),
+    .axi_write_addr(write_addr),
+    .axi_write_data(write_data),
+    .axi_write_resp(write_resp),
+    .axi_read(read),
+    .axi_read_addr(read_addr),
+    .axi_read_resp(read_resp),
+    .axi_put_status(put_status),
+    .axi_put_rdata(put_rdata),
+
+    .obf_key_value(obf_key_value),
+    .obf_key_idx(obf_key_idx),
+    .set_obf_key(set_obf_key),
+    .get_obf_key(get_obf_key),
+
+    // UDS access
+    .get_uds_value(get_uds_value),
+    .uds_idx(uds_idx),
+
+    // FE access
+    .get_fe_value(get_fe_value),
+    .fe_idx(fe_idx),
+
+    // KV check cleared
+    .check_kv_clear(check_kv_clear),
+    .kv_idx(kv_idx)
 );
     
 // JTAG DPI
@@ -228,10 +322,10 @@ caliptra_top caliptra_top_dut (
     .clk                        (core_clk),
 
     .cptra_obf_key              (cptra_obf_key),
-    .cptra_obf_uds_seed_vld     ('0), //validated at caliptra-ss
-    .cptra_obf_uds_seed         ('0), //validated at caliptra-ss
-    .cptra_obf_field_entropy_vld('0), //validated at caliptra-ss
-    .cptra_obf_field_entropy    ('0), //validated at caliptra-ss
+    .cptra_obf_uds_seed_vld     (cptra_uds_strap_vld),
+    .cptra_obf_uds_seed         (cptra_uds_strap),
+    .cptra_obf_field_entropy_vld(cptra_fe_strap_vld),
+    .cptra_obf_field_entropy    (cptra_fe_strap),
     .cptra_csr_hmac_key         (cptra_csr_hmac_key),
 
     .jtag_tck(jtag_tck),
@@ -311,7 +405,7 @@ caliptra_top caliptra_top_dut (
     .strap_ss_strap_generic_1                               (strap_ss_strap_generic_1),
     .strap_ss_strap_generic_2                               (strap_ss_strap_generic_2),
     .strap_ss_strap_generic_3                               (strap_ss_strap_generic_3),
-    .ss_debug_intent                                        ( 1'b0),
+    .ss_debug_intent                                        (debug_intent),
 
     // Subsystem mode constant strap input indicating OCP LOCK configuration is enabled
     .ss_ocp_lock_en                                         (ss_ocp_lock_en),
@@ -441,6 +535,9 @@ caliptra_top_tb_services #(
     .cycleCnt(cycleCnt),
     .axi_complex_ctrl(axi_complex_ctrl),
 
+    // Custom event injection
+    .inject_mbox_soc_lock_on_mbox_unlock(inject_mbox_soc_lock_on_mbox_unlock),
+
     //Interrupt flags
     .int_flag(int_flag),
     .cycleCnt_smpl_en(cycleCnt_smpl_en),
@@ -451,11 +548,53 @@ caliptra_top_tb_services #(
 
     .assert_rst_flag(assert_rst_flag_from_service),
     .deassert_rst_flag(deassert_rst_flag_from_service),
-    
+
+    .route_fatal_to_nmi(route_fatal_to_nmi),
+
     .cptra_uds_tb(cptra_uds_rand),
     .cptra_fe_tb(cptra_fe_rand),
     .cptra_obf_key_tb(cptra_obf_key_tb),
     .cptra_hek_tb(cptra_hek_rand),
+
+    //AXI SoC
+    .axi_addr(address),
+    .axi_axuser(axuser),
+    .axi_wuser(wuser),
+    .axi_wdata(wdata),
+    .axi_len(len),
+    .axi_wstrb(wstrb),
+    .axi_burst(burst),
+    .axi_use_id(use_id),
+    .axi_id(id),
+    .axi_write(write),
+    .axi_write_addr(write_addr),
+    .axi_write_data(write_data),
+    .axi_write_resp(write_resp),
+    .axi_read(read),
+    .axi_read_addr(read_addr),
+    .axi_read_resp(read_resp),
+    .axi_put_status(put_status),
+    .axi_put_rdata(put_rdata),
+
+    .obf_key_value(obf_key_value),
+    .obf_key_idx(obf_key_idx),
+    .set_obf_key(set_obf_key),
+    .get_obf_key(get_obf_key),
+
+    // UDS access
+    .get_uds_value(get_uds_value),
+    .uds_idx(uds_idx),
+
+    // FE access
+    .get_fe_value(get_fe_value),
+    .fe_idx(fe_idx),
+
+    // KV check cleared
+    .check_kv_clear(check_kv_clear),
+    .kv_idx(kv_idx),
+
+    //Control signals
+    .debug_intent(debug_intent),
 
     .axi_error_inj_en(axi_error_inj_en)
 

--- a/src/integration/tb/caliptra_top_tb_axi_complex.sv
+++ b/src/integration/tb/caliptra_top_tb_axi_complex.sv
@@ -672,7 +672,9 @@ module caliptra_top_tb_axi_complex import caliptra_top_tb_pkg::*; (
         .en_recovery_emulation(ctrl.en_recovery_emulation),
         .recovery_data_avail  (recovery_data_avail       ),
         .dma_gen_done         (ctrl.dma_gen_done         ),
-        .dma_gen_block_size   (ctrl.dma_gen_block_size   )
+        .dma_gen_block_size   (ctrl.dma_gen_block_size   ),
+        .inject_rd_error      (ctrl.fifo_rd_error        ),
+        .inject_wr_error      (ctrl.fifo_wr_error        )
     );
 
     // --------------------- REG Endpoint TODO ---------------------

--- a/src/integration/tb/caliptra_top_tb_axi_fifo.sv
+++ b/src/integration/tb/caliptra_top_tb_axi_fifo.sv
@@ -38,7 +38,9 @@ module caliptra_top_tb_axi_fifo #(
     input  logic en_recovery_emulation,
     output logic recovery_data_avail,
     input  logic dma_gen_done,
-    input  logic [99:0] [11:0] dma_gen_block_size
+    input  logic [99:0] [11:0] dma_gen_block_size,
+    input  logic inject_rd_error,
+    input  logic inject_wr_error
 );
 
     // --------------------------------------- //
@@ -113,8 +115,8 @@ module caliptra_top_tb_axi_fifo #(
     `CALIPTRA_ASSERT(AXI_FIFO_WR_FIXED_ONLY, s_axi_w_if.awvalid && s_axi_w_if.awready |-> s_axi_w_if.awburst == AXI_BURST_FIXED, clk, !rst_n)
     `CALIPTRA_ASSERT(AXI_FIFO_RD_FIXED_ONLY, s_axi_r_if.arvalid && s_axi_r_if.arready |-> s_axi_r_if.arburst == AXI_BURST_FIXED, clk, !rst_n)
 
-    assign rd_error = 1'b0;
-    assign wr_error = 1'b0;
+    assign rd_error = inject_rd_error;
+    assign wr_error = inject_wr_error;
 
     // --------------------------------------- //
     // Data FIFO                               //

--- a/src/integration/tb/caliptra_top_tb_pkg.sv
+++ b/src/integration/tb/caliptra_top_tb_pkg.sv
@@ -81,6 +81,8 @@ typedef struct packed {
     logic en_recovery_emulation;
     logic dma_gen_done;
     logic [99:0] [11:0] dma_gen_block_size;
+    logic fifo_rd_error;
+    logic fifo_wr_error;
 } axi_complex_ctrl_t;
 
 // Transfer types enum
@@ -105,10 +107,11 @@ localparam DMA_ERROR_OBSERVED              = 32'hfadebadd;
 localparam ERROR_NONE_SET                  = 32'hba5eba11; /* default value for a test with no activity observed by TB */
 
 // AXI SRAM config
-localparam AXI_SRAM_SIZE_BYTES   = 262144;
+localparam AXI_SRAM_SIZE_BYTES   = 1048576;
 localparam AXI_SRAM_ADDR_WIDTH   = $clog2(AXI_SRAM_SIZE_BYTES);
 localparam AXI_SRAM_DEPTH        = AXI_SRAM_SIZE_BYTES / (CPTRA_AXI_DMA_DATA_WIDTH/8);
-localparam logic [`CALIPTRA_AXI_DMA_ADDR_WIDTH-1:0] AXI_SRAM_BASE_ADDR = `CALIPTRA_AXI_DMA_ADDR_WIDTH'h0001_2344_0000; 
+localparam logic [`CALIPTRA_AXI_DMA_ADDR_WIDTH-1:0] AXI_SRAM_BASE_ADDR = `CALIPTRA_AXI_DMA_ADDR_WIDTH'h0001_2340_0000; 
+
 
 // AXI FIFO config
 localparam AXI_FIFO_SIZE_BYTES   = 65536;

--- a/src/integration/tb/caliptra_top_tb_services.sv
+++ b/src/integration/tb/caliptra_top_tb_services.sv
@@ -398,94 +398,6 @@ module caliptra_top_tb_services
     //         8'h2 : 8'h5  - Do nothing
     //         8'h6 : 8'h7E - WriteData is an ASCII character - dump to console.log
     //         8'h7F        - Switch to MANUF device lifecycle state
-    //      16'h017F        - Setup SoC Access address from CPTRA_GENERIC_OUTPUT_WIRES[1]
-    //      16'h027F        - Push SoC Access wdata from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wdata queue
-    //      16'h037F        - Send SoC access
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][0]     - write transaction
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][1]     - read transaction
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][2]     - write address only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][3]     - write data only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][4]     - write response only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][5]     - read address only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][6]     - read response only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][7]     - use operation ID, random otherwise
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][15:8]  - AXLEN
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][23:16] - Operation ID
-    //          If partial transfers are used, only one can be executed at any
-    //          given time, and it cannot be combined with full transfer.
-    //          ID must be specified and correct for partial transfers,
-    //          otherwise BFM will lockup
-    //      16'h047F        - Get SoC Access status, 0-In progress, 1-Done
-    //      16'h057F        - Pop SoC Access read response onto generic_input_wires
-    //      16'h067F        - Push SoC Access wuser from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wuser queue
-    //      16'h077F        - Setup SoC Access aXuser from CPTRA_GENERIC_OUTPUT_WIRES[1]
-    //      16'h087F        - Setup SoC Access burst from CPTRA_GENERIC_OUTPUT_WIRES[1]: (0)fixed, (1,default)incr, (2)wrap
-    //      16'h097F        - Push SoC Access wstrb from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wstrb queue
-    //      16'h0A7F        - Clear SoC Access wdata, wuser and wstrb queues
-    //      16'h0D7F        - Force DMI enable (OpenOCD requires JTAG to be active to correctly examine device)
-    //      16'h0E7F        - Set route_fatal_to_nmi
-    //      16'h0F7F        - Clear route_fatal_to_nmi
-    //      16'h107F        - Force re-enable strap write
-    //      16'h117F        - Release strap write
-    //      16'h127F        - Enable debug intent
-    //      16'h137F        - Disable debug intent
-    //      16'h147F        - Switch to Manufacturing mode
-    //      16'h157F        - Switch to Production mode
-    //      16'h167F        - Force ss_debug intent
-    //      16'h177F        - Release ss_debug intent
-    //      16'h187F        - Switch to debug unlocked
-    //      16'h197F        - Switch to debug locked
-    //      16'h1A7F        - Force re-enable fuse write
-    //      16'h1B7F        - Force unlock caliptra security state
-    //      16'h1C7F        - Release unlock caliptra security state
-    //      16'h1D7F        - Force override mailbox pointer reset value to CPTRA_GENERIC_OUTPUT_WIRES[1]
-    //      16'h1E7F        - Release override mailbox pointer reset value
-    //      16'h1F7F        - Switch to Unprovisioned mode
-    //      16'h207F        - Get UDS[0] and UDS[1] value from HW
-    //      16'h217F        - Get UDS[2] and UDS[3] value from HW
-    //      16'h227F        - Get UDS[4] and UDS[5] value from HW
-    //      16'h237F        - Get UDS[6] and UDS[7] value from HW
-    //      16'h247F        - Get UDS[8] and UDS[9] value from HW
-    //      16'h257F        - Get UDS[10] and UDS[11] value from HW
-    //      16'h267F        - Get UDS[12] and UDS[13] value from HW
-    //      16'h277F        - Get UDS[14] and UDS[15] value from HW
-    //      16'h307F        - Get FE[0] and FE[1] value from HW
-    //      16'h317F        - Get FE[2] and FE[3] value from HW
-    //      16'h327F        - Get FE[4] and FE[5] value from HW
-    //      16'h337F        - Get FE[6] and FE[7] value from HW
-    //      16'h407F        - Set OBF_KEY[0] value from generic wire 1
-    //      16'h417F        - Set OBF_KEY[1] value from generic wire 1
-    //      16'h427F        - Set OBF_KEY[2] value from generic wire 1
-    //      16'h437F        - Set OBF_KEY[3] value from generic wire 1
-    //      16'h447F        - Set OBF_KEY[4] value from generic wire 1
-    //      16'h457F        - Set OBF_KEY[5] value from generic wire 1
-    //      16'h467F        - Set OBF_KEY[6] value from generic wire 1
-    //      16'h477F        - Set OBF_KEY[7] value from generic wire 1
-    //      16'h487F        - Get OBF_KEY[0] value from HW
-    //      16'h497F        - Get OBF_KEY[1] value from HW
-    //      16'h4A7F        - Get OBF_KEY[2] value from HW
-    //      16'h4B7F        - Get OBF_KEY[3] value from HW
-    //      16'h4C7F        - Get OBF_KEY[4] value from HW
-    //      16'h4D7F        - Get OBF_KEY[5] value from HW
-    //      16'h4E7F        - Get OBF_KEY[6] value from HW
-    //      16'h4F7F        - Set OBF_KEY[7] value from HW
-    //      16'h507F        - Enable injection of single mailbox access request from SoC when TAP locks mailbox
-    //      16'h517F        - Disable injection of single mailbox access request from SoC when TAP locks mailbox
-    //      16'h527F        - Inject FIFO AXI read errors
-    //      16'h537F        - Inject FIFO AXI write errors
-    //      16'h547F        - Stop injecting FIFO AXI read errors
-    //      16'h557F        - Stop injecting FIFO AXI write errors
-    //      16'h567F        - Kill kv_hmac_tag_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
-    //      16'h577F        - Kill kv_ecc_privkey_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
-    //      16'h587F        - Enable injection of single mailbox lock request from TAP when FW locks mailbox
-    //      16'h597F        - Disable injection of single mailbox lock request from TAP when FW locks mailbox
-    //      16'h5A7F        - Enable injection of single mailbox lock request from SoC when mailbox is being unlocked
-    //      16'h5B7F        - Disable injection of single mailbox lock request from SoC when mailbox is being unlocked
-    //      16'h5C7F        - Enable injection of mailbox unlock when FW accesses mailbox SRAM directly
-    //      16'h5D7F        - Disable injection of mailbox unlock when FW accesses mailbox SRAM directly
-    //      16'h807F:'h9F7F - Inject a valid hmac_key dest and hmac512_key into Nth kv slot (where slot is encoded as (N & 0x1F) << 8)
-    //      16'hA07F:'hBF7F - Check if Nth kv slot (where slot is encoded as (N & 0x1F) << 8) is all zero
-    //      16'hC07F        - Force clear of all KV slots, when DOE FSM starts to write
     //         8'h80: 8'h87 - Inject ECC_SEED to kv_key register
     //         8'h88        - Toggle recovery interface emulation in AXI complex
     //         8'h89        - Use same msg in SHA512 digest for ECC/MLDSA PCR signing (used where both cryptos are running in parallel)
@@ -512,8 +424,96 @@ module caliptra_top_tb_services
     //         8'h9f        - Inject AES key into KV
     //         8'ha0        - Inject HMAC384_KEY to kv_key register
     //         8'ha1        - Inject zero as MLDSA_SEED/MLKEM_MSG to kv_key register (8 dwords)
-    //         8'ha2        - Randomizable KV inject: slot=[12:8], last_dword=[16:13], dest_valid=[24:17]
-    //         8'ha3: 8'ha7 - Unused
+    //         8'ha2        - RESERVED (used by 16-bit commands)
+    //      16'h01A2        - Setup SoC Access address from CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h02A2        - Push SoC Access wdata from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wdata queue
+    //      16'h03A2        - Send SoC access
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][0]     - write transaction
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][1]     - read transaction
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][2]     - write address only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][3]     - write data only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][4]     - write response only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][5]     - read address only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][6]     - read response only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][7]     - use operation ID, random otherwise
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][15:8]  - AXLEN
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][23:16] - Operation ID
+    //          If partial transfers are used, only one can be executed at any
+    //          given time, and it cannot be combined with full transfer.
+    //          ID must be specified and correct for partial transfers,
+    //          otherwise BFM will lockup
+    //      16'h04A2        - Get SoC Access status, 0-In progress, 1-Done
+    //      16'h05A2        - Pop SoC Access read response onto generic_input_wires
+    //      16'h06A2        - Push SoC Access wuser from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wuser queue
+    //      16'h07A2        - Setup SoC Access aXuser from CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h08A2        - Setup SoC Access burst from CPTRA_GENERIC_OUTPUT_WIRES[1]: (0)fixed, (1,default)incr, (2)wrap
+    //      16'h09A2        - Push SoC Access wstrb from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wstrb queue
+    //      16'h0AA2        - Clear SoC Access wdata, wuser and wstrb queues
+    //      16'h0DA2        - Force DMI enable (OpenOCD requires JTAG to be active to correctly examine device)
+    //      16'h0EA2        - Set route_fatal_to_nmi
+    //      16'h0FA2        - Clear route_fatal_to_nmi
+    //      16'h10A2        - Force re-enable strap write
+    //      16'h11A2        - Release strap write
+    //      16'h12A2        - Enable debug intent
+    //      16'h13A2        - Disable debug intent
+    //      16'h15A2        - Switch to Production mode
+    //      16'h16A2        - Force ss_debug intent
+    //      16'h17A2        - Release ss_debug intent
+    //      16'h18A2        - Switch to debug unlocked
+    //      16'h19A2        - Switch to debug locked
+    //      16'h1AA2        - Force re-enable fuse write
+    //      16'h1BA2        - Force unlock caliptra security state
+    //      16'h1CA2        - Release unlock caliptra security state
+    //      16'h1DA2        - Force override mailbox pointer reset value to CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h1EA2        - Release override mailbox pointer reset value
+    //      16'h1FA2        - Switch to Unprovisioned mode
+    //      16'h20A2        - Get UDS[0] and UDS[1] value from HW
+    //      16'h21A2        - Get UDS[2] and UDS[3] value from HW
+    //      16'h22A2        - Get UDS[4] and UDS[5] value from HW
+    //      16'h23A2        - Get UDS[6] and UDS[7] value from HW
+    //      16'h24A2        - Get UDS[8] and UDS[9] value from HW
+    //      16'h25A2        - Get UDS[10] and UDS[11] value from HW
+    //      16'h26A2        - Get UDS[12] and UDS[13] value from HW
+    //      16'h27A2        - Get UDS[14] and UDS[15] value from HW
+    //      16'h30A2        - Get FE[0] and FE[1] value from HW
+    //      16'h31A2        - Get FE[2] and FE[3] value from HW
+    //      16'h32A2        - Get FE[4] and FE[5] value from HW
+    //      16'h33A2        - Get FE[6] and FE[7] value from HW
+    //      16'h40A2        - Set OBF_KEY[0] value from generic wire 1
+    //      16'h41A2        - Set OBF_KEY[1] value from generic wire 1
+    //      16'h42A2        - Set OBF_KEY[2] value from generic wire 1
+    //      16'h43A2        - Set OBF_KEY[3] value from generic wire 1
+    //      16'h44A2        - Set OBF_KEY[4] value from generic wire 1
+    //      16'h45A2        - Set OBF_KEY[5] value from generic wire 1
+    //      16'h46A2        - Set OBF_KEY[6] value from generic wire 1
+    //      16'h47A2        - Set OBF_KEY[7] value from generic wire 1
+    //      16'h48A2        - Get OBF_KEY[0] value from HW
+    //      16'h49A2        - Get OBF_KEY[1] value from HW
+    //      16'h4AA2        - Get OBF_KEY[2] value from HW
+    //      16'h4BA2        - Get OBF_KEY[3] value from HW
+    //      16'h4CA2        - Get OBF_KEY[4] value from HW
+    //      16'h4DA2        - Get OBF_KEY[5] value from HW
+    //      16'h4EA2        - Get OBF_KEY[6] value from HW
+    //      16'h4FA2        - Set OBF_KEY[7] value from HW
+    //      16'h50A2        - Enable injection of single mailbox access request from SoC when TAP locks mailbox
+    //      16'h51A2        - Disable injection of single mailbox access request from SoC when TAP locks mailbox
+    //      16'h52A2        - Inject FIFO AXI read errors
+    //      16'h53A2        - Inject FIFO AXI write errors
+    //      16'h54A2        - Stop injecting FIFO AXI read errors
+    //      16'h55A2        - Stop injecting FIFO AXI write errors
+    //      16'h56A2        - Kill kv_hmac_tag_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
+    //      16'h57A2        - Kill kv_ecc_privkey_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
+    //      16'h58A2        - Enable injection of single mailbox lock request from TAP when FW locks mailbox
+    //      16'h59A2        - Disable injection of single mailbox lock request from TAP when FW locks mailbox
+    //      16'h5AA2        - Enable injection of single mailbox lock request from SoC when mailbox is being unlocked
+    //      16'h5BA2        - Disable injection of single mailbox lock request from SoC when mailbox is being unlocked
+    //      16'h5CA2        - Enable injection of mailbox unlock when FW accesses mailbox SRAM directly
+    //      16'h5DA2        - Disable injection of mailbox unlock when FW accesses mailbox SRAM directly
+    //      16'h80A2:'h9FA2 - Inject a valid hmac_key dest and hmac512_key into Nth kv slot (where slot is encoded as (N & 0x1F) << 8)
+    //      16'hA0A2:'hBFA2 - Check if Nth kv slot (where slot is encoded as (N & 0x1F) << 8) is all zero
+    //      16'hC0A2        - Force clear of all KV slots, when DOE FSM starts to write
+    //         8'ha3        - Randomizable KV inject: slot=[12:8], last_dword=[16:13], dest_valid=[24:17]
+    //         8'ha4: 8'ha7 - Unused
     //         8'ha8        - Inject zero as HMAC_KEY/MLKEM_SEED to kv_key register (16 dwords)
     //         8'ha9        - Inject HMAC512_KEY to kv_key register
     //         8'haa        - Inject HMAC512_BLOCK to kv_key16 register
@@ -620,11 +620,11 @@ module caliptra_top_tb_services
         axi_put_status <= 1'b0;
         axi_use_id     <= 1'b0;
         axi_put_rdata <= 1'b0;
-        if ((WriteData[15:0] == 16'h017F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h01A2) && mailbox_write) begin
             axi_addr <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
-        end else if ((WriteData[15:0] == 16'h027F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h02A2) && mailbox_write) begin
             axi_wdata.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
-        end else if ((WriteData[15:0] == 16'h037F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h03A2) && mailbox_write) begin
             axi_write      <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][0];
             axi_read       <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][1];
             axi_write_addr <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][2];
@@ -635,19 +635,19 @@ module caliptra_top_tb_services
             axi_use_id     <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][7];
             axi_len        <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][15:8];
             axi_id         <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][23:16];
-        end else if ((WriteData[15:0] == 16'h047F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h04A2) && mailbox_write) begin
             axi_put_status <= 1'b1;
-        end else if ((WriteData[15:0] == 16'h057F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h05A2) && mailbox_write) begin
             axi_put_rdata <= 1'b1;
-        end else if ((WriteData[15:0] == 16'h067F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h06A2) && mailbox_write) begin
             axi_wuser.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
-        end else if ((WriteData[15:0] == 16'h077F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h07A2) && mailbox_write) begin
             axi_axuser <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
-        end else if ((WriteData[15:0] == 16'h087F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h08A2) && mailbox_write) begin
             axi_burst <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
-        end else if ((WriteData[15:0] == 16'h097F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h09A2) && mailbox_write) begin
             axi_wstrb.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
-        end else if ((WriteData[15:0] == 16'h0A7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h0AA2) && mailbox_write) begin
             axi_wdata = {};
             axi_wuser = {};
             axi_wstrb = {};
@@ -656,14 +656,14 @@ module caliptra_top_tb_services
 
     //  Fuse re-enable access
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h107F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h10A2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value = 1'h0;
             force `CPTRA_TOP_PATH.soc_ifc_top1.strap_we = 1'h1;
             repeat (10) @(negedge clk);
             release `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value;
-        end else if ((WriteData[15:0] == 16'h117F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h11A2) && mailbox_write) begin
             release `CPTRA_TOP_PATH.soc_ifc_top1.strap_we;
-        end else if ((WriteData[15:0] == 16'h1A7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h1AA2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value = 1'h0;
             repeat (10) @(negedge clk);
             release `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value;
@@ -671,7 +671,7 @@ module caliptra_top_tb_services
     end
 
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h0D7F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h0DA2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.rvtop.dmi_core_enable = 1'h1;
             $display("Force enable JTAG/DMI to be active");
         end
@@ -682,35 +682,35 @@ module caliptra_top_tb_services
         route_fatal_to_nmi = 1'b0;
     end
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h0E7F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h0EA2) && mailbox_write) begin
             route_fatal_to_nmi <= 1'b1;
             force `CPTRA_TOP_PATH.nmi_int = `CPTRA_TOP_PATH.cptra_error_fatal;
             $display("Route fatal error to nmi pin");
-        end else if ((WriteData[15:0] == 16'h0F7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h0FA2) && mailbox_write) begin
             route_fatal_to_nmi <= 1'b0;
             release `CPTRA_TOP_PATH.nmi_int;
             $display("Return NMI to normal use");
         end
     end
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h127F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h12A2) && mailbox_write) begin
             debug_intent <= 1'b1;
             $display("Enabling debug_intent");
-        end else if ((WriteData[15:0] == 16'h137F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h13A2) && mailbox_write) begin
             debug_intent <= 1'b0;
             $display("Disabling debug_intent");
         end
     end
 
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h167F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h16A2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.soc_ifc_top1.soc_ifc_reg_hwif_in.SS_DEBUG_INTENT.debug_intent.next = 1'h1;
-        end else if ((WriteData[15:0] == 16'h177F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h17A2) && mailbox_write) begin
             release `CPTRA_TOP_PATH.soc_ifc_top1.soc_ifc_reg_hwif_in.SS_DEBUG_INTENT.debug_intent.next;
         end
-        if ((WriteData[15:0] == 16'h1B7F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h1BA2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.unlock_caliptra_security_state = 1'h1;
-        end else if ((WriteData[15:0] == 16'h1C7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h1CA2) && mailbox_write) begin
             release `CPTRA_TOP_PATH.unlock_caliptra_security_state;
         end
     end
@@ -718,7 +718,7 @@ module caliptra_top_tb_services
     // Prevent from setting ptr reset value to mailboxes max capacity
     `CALIPTRA_ASSERT_NEVER(
         no_mbox_ptr_rst_value_override_full_capacity,
-        (WriteData[15:0] == 16'h1D7F) && mailbox_write &&
+        (WriteData[15:0] == 16'h1DA2) && mailbox_write &&
         (`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1] == 32'hFFFFFFFF),
         !clk, cptra_rst_b
     )
@@ -728,12 +728,12 @@ module caliptra_top_tb_services
             force_mbox_ptr_reset_value <= 0;
             release_mbox_ptr_reset_value <= 0;
         end
-        if ((WriteData[15:0] == 16'h1D7F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h1DA2) && mailbox_write) begin
             $display("Force MBOX pointers reset value to %x\n", `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
             mbox_ptr_reset_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
             force_mbox_ptr_reset_value <= 1;
             release_mbox_ptr_reset_value <= 0;
-        end else if ((WriteData[15:0] == 16'h1E7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h1EA2) && mailbox_write) begin
             $display("Release MBOX pointers reset value\n");
             force_mbox_ptr_reset_value <= 0;
             release_mbox_ptr_reset_value <= 1;
@@ -745,7 +745,7 @@ module caliptra_top_tb_services
             get_uds_value <= 1'b0;
             uds_idx <= 3'h0;
         end
-        else if ((WriteData[15:0] inside {16'h207F, 16'h217F, 16'h227F, 16'h237F, 16'h247F, 16'h257F, 16'h267F, 16'h277F}) && mailbox_write) begin
+        else if ((WriteData[15:0] inside {16'h20A2, 16'h21A2, 16'h22A2, 16'h23A2, 16'h24A2, 16'h25A2, 16'h26A2, 16'h27A2}) && mailbox_write) begin
             get_uds_value <= 1'b1;
             uds_idx <= WriteData[10:8];
         end else begin
@@ -758,7 +758,7 @@ module caliptra_top_tb_services
             get_fe_value <= 1'b0;
             fe_idx <= 2'h0;
         end
-        else if ((WriteData[15:0] inside {16'h307F, 16'h317F, 16'h327F, 16'h337F}) && mailbox_write) begin
+        else if ((WriteData[15:0] inside {16'h30A2, 16'h31A2, 16'h32A2, 16'h33A2}) && mailbox_write) begin
             get_fe_value <= 1'b1;
             fe_idx <= WriteData[9:8];
         end else begin
@@ -771,12 +771,12 @@ module caliptra_top_tb_services
             set_obf_key <= 1'b0;
             get_obf_key <= 1'b0;
         end
-        else if ((WriteData[15:0] & 16'hF8FF) == 16'h407F  && mailbox_write) begin
+        else if ((WriteData[15:0] & 16'hF8FF) == 16'h40A2  && mailbox_write) begin
             set_obf_key   <= 1'b1;
             obf_key_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
             obf_key_idx   <= WriteData[10:8];
         end
-        else if ((WriteData[15:0] & 16'hF8FF) == 16'h487F  && mailbox_write) begin
+        else if ((WriteData[15:0] & 16'hF8FF) == 16'h48A2  && mailbox_write) begin
             get_obf_key   <= 1'b1;
             obf_key_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
             obf_key_idx   <= WriteData[10:8];
@@ -790,10 +790,10 @@ module caliptra_top_tb_services
         if (!cptra_rst_b) begin
             inject_mbox_soc_req_on_tap_lock <= 1'b0;
         end
-        else if ((WriteData[15:0] == 16'h507F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h50A2) && mailbox_write) begin
             inject_mbox_soc_req_on_tap_lock <= 1'b1;
         end
-        else if ((WriteData[15:0] == 16'h517F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h51A2) && mailbox_write) begin
             inject_mbox_soc_req_on_tap_lock <= 1'b0;
         end
     end
@@ -802,10 +802,10 @@ module caliptra_top_tb_services
         if (!cptra_rst_b) begin
             inject_mbox_tap_lock_read_on_fw_lock <= 1'b0;
         end
-        else if ((WriteData[15:0] == 16'h587F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h58A2) && mailbox_write) begin
             inject_mbox_tap_lock_read_on_fw_lock <= 1'b1;
         end
-        else if ((WriteData[15:0] == 16'h597F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h59A2) && mailbox_write) begin
             inject_mbox_tap_lock_read_on_fw_lock <= 1'b0;
         end
     end
@@ -814,10 +814,10 @@ module caliptra_top_tb_services
         if (!cptra_rst_b) begin
             inject_mbox_soc_lock_on_mbox_unlock <= 1'b0;
         end
-        else if ((WriteData[15:0] == 16'h5A7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h5AA2) && mailbox_write) begin
             inject_mbox_soc_lock_on_mbox_unlock <= 1'b1;
         end
-        else if ((WriteData[15:0] == 16'h5B7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h5BA2) && mailbox_write) begin
             inject_mbox_soc_lock_on_mbox_unlock <= 1'b0;
         end
     end
@@ -826,10 +826,10 @@ module caliptra_top_tb_services
         if (!cptra_rst_b) begin
             inject_mbox_unlock_on_dir_acc <= 1'b0;
         end
-        else if ((WriteData[15:0] == 16'h5C7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h5CA2) && mailbox_write) begin
             inject_mbox_unlock_on_dir_acc <= 1'b1;
         end
-        else if ((WriteData[15:0] == 16'h5D7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h5DA2) && mailbox_write) begin
             inject_mbox_unlock_on_dir_acc <= 1'b0;
         end
     end
@@ -918,11 +918,7 @@ module caliptra_top_tb_services
 
     initial ras_test_ctrl.error_injection_seen = 1'b0;
     always @(negedge clk) begin
-<<<<<<< HEAD
-        if (mailbox_write && WriteData[7:0] inside {8'hfd, 8'h95}) begin
-=======
         if (mailbox_write && WriteData[7:0] inside {8'he5, 8'he6, 8'hfd, 8'hfe}) begin
->>>>>>> 3c19526ab (Extend TB & services)
             ras_test_ctrl.error_injection_seen <= 1'b1;
         end
     end
@@ -965,16 +961,16 @@ module caliptra_top_tb_services
         else if((WriteData[7:0] == 8'h8f) && mailbox_write) begin
             axi_complex_ctrl.rand_delays    <= ~axi_complex_ctrl.rand_delays; // Toggle option
         end
-        else if((WriteData[15:0] == 16'h527F) && mailbox_write) begin
+        else if((WriteData[15:0] == 16'h52A2) && mailbox_write) begin
             axi_complex_ctrl.fifo_rd_error  <= 1'b1;
         end
-        else if((WriteData[15:0] == 16'h537F) && mailbox_write) begin
+        else if((WriteData[15:0] == 16'h53A2) && mailbox_write) begin
             axi_complex_ctrl.fifo_wr_error  <= 1'b1;
         end
-        else if((WriteData[15:0] == 16'h547F) && mailbox_write) begin
+        else if((WriteData[15:0] == 16'h54A2) && mailbox_write) begin
             axi_complex_ctrl.fifo_rd_error  <= 1'b0;
         end
-        else if((WriteData[15:0] == 16'h557F) && mailbox_write) begin
+        else if((WriteData[15:0] == 16'h55A2) && mailbox_write) begin
             axi_complex_ctrl.fifo_wr_error  <= 1'b0;
         end
         else begin
@@ -1029,7 +1025,7 @@ module caliptra_top_tb_services
                         kv_idx <= '0;
                         check_kv_clear <= '0;
                     end
-                    else if(((WriteData[15:0] & 16'hE07F) == 16'hA07F) && mailbox_write) begin
+                    else if(((WriteData[15:0] & 16'hE0A2) == 16'hA0A2) && mailbox_write) begin
                         kv_idx <= (WriteData[15:0] & 16'h1F00) >> 8;
                         check_kv_clear <= '1;
                     end else begin
@@ -1043,7 +1039,7 @@ module caliptra_top_tb_services
     always @(negedge clk) begin
         if (!cptra_rst_b) begin
             timed_kv_clear <= '0;
-        end else if (WriteData[15:0] == 16'hC07F) begin
+        end else if (WriteData[15:0] == 16'hC0A2) begin
             timed_kv_clear <= '1;
         end else begin
             timed_kv_clear <= '0;
@@ -1077,7 +1073,7 @@ module caliptra_top_tb_services
     always @(negedge clk) begin
         if (!cptra_rst_b) begin
             hmac_tag_mismatch_kill <= '0;
-        end else if (WriteData[15:0] == 16'h567F) begin
+        end else if (WriteData[15:0] == 16'h56A2) begin
             hmac_tag_mismatch_kill <= '1;
         end else begin
             hmac_tag_mismatch_kill <= '0;
@@ -1110,7 +1106,7 @@ module caliptra_top_tb_services
     always @(negedge clk) begin
         if (!cptra_rst_b) begin
             ecc_privkey_mismatch_kill <= '0;
-        end else if (WriteData[15:0] == 16'h577F) begin
+        end else if (WriteData[15:0] == 16'h57A2) begin
             ecc_privkey_mismatch_kill <= '1;
         end else begin
             ecc_privkey_mismatch_kill <= '0;
@@ -1146,7 +1142,7 @@ module caliptra_top_tb_services
             for (genvar dword_i=0; dword_i < 16; dword_i++) begin : inject_dword_loop
                 always @(negedge clk) begin
                     //inject valid hmac_key dest and hmac512_key value to key reg (but extend the mask to permit all 24 kv slots)
-                    if(((WriteData[15:0] & 16'hE07F) == 16'h807F) && mailbox_write) begin
+                    if(((WriteData[15:0] & 16'hE0A2) == 16'h80A2) && mailbox_write) begin
                         inject_mldsa_seed <= 1'b1;
                         if ((((WriteData[15:0] & 16'h1F00) >> 8) == slot_id)) begin
                             force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.we = 1'b1;
@@ -1267,8 +1263,8 @@ module caliptra_top_tb_services
                         end
                     end
                     //Randomizable KV inject for length-mismatch tests.
-                    //Encoding: WriteData[7:0]=0xa2, [12:8]=slot, [16:13]=last_dword, [24:17]=dest_valid.
-                    else if((WriteData[7:0] == 8'ha2) && mailbox_write) begin
+                    //Encoding: WriteData[7:0]=0xa3, [12:8]=slot, [16:13]=last_dword, [24:17]=dest_valid.
+                    else if((WriteData[7:0] == 8'ha3) && mailbox_write) begin
                         release_kv_inject_flags <= '0;
                         if (WriteData[12:8] == slot_id) begin
                             force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.we = 1'b1;
@@ -1696,17 +1692,6 @@ module caliptra_top_tb_services
 
     //TIE-OFF device lifecycle
     logic assert_ss_tran;
-<<<<<<< HEAD
-`ifdef CALIPTRA_DEBUG_UNLOCKED
-    initial security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4False}; // DebugUnlocked & Production
-`else
-    initial begin
-        if ($test$plusargs("CALIPTRA_DEBUG_UNLOCKED"))
-            security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4False}; // DebugUnlocked & Production
-        else
-            security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4True}; // DebugLocked & Production
-=======
->>>>>>> 3c19526ab (Extend TB & services)
 
     initial begin
         if (!$test$plusargs("CALIPTRA_DEBUG_UNLOCKED")) begin
@@ -1746,18 +1731,13 @@ module caliptra_top_tb_services
     end
 
     always @(negedge clk) begin
-        //Switch to Manufacturing mode mode
-        if ((WriteData[15:0] == 16'h147F) && mailbox_write) begin
-            security_state.device_lifecycle <= DEVICE_MANUFACTURING;
-            $display("Setting lifecycle to DEVICE_MANUFACTURING\n");
-        end
         //Switch to Production mode mode
-        else if ((WriteData[15:0] == 16'h157F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h15A2) && mailbox_write) begin
             security_state.device_lifecycle <= DEVICE_PRODUCTION;
             $display("Setting lifecycle to DEVICE_PRODUCTION\n");
         end
         //Switch to Unprovisioned mode mode
-        else if ((WriteData[15:0] == 16'h1F7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h1FA2) && mailbox_write) begin
             security_state.device_lifecycle <= DEVICE_UNPROVISIONED;
             $display("Setting lifecycle to DEVICE_UNPROVISIONED\n");
         end
@@ -1765,12 +1745,12 @@ module caliptra_top_tb_services
 
     always @(negedge clk) begin
         //Switch to debug unlocked
-        if ((WriteData[15:0] == 16'h187F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h18A2) && mailbox_write) begin
             security_state.debug_locked <= 1'b0;
             $display("Setting debug_locked to 0");
         end
         //Switch to debug locked
-        else if ((WriteData[15:0] == 16'h197F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h19A2) && mailbox_write) begin
             security_state.debug_locked <= 1'b1;
             $display("Setting debug_locked to 1");
         end

--- a/src/integration/tb/caliptra_top_tb_services.sv
+++ b/src/integration/tb/caliptra_top_tb_services.sv
@@ -218,6 +218,7 @@ module caliptra_top_tb_services
     logic                       timed_warm_rst;
     logic                       timed_kv_clear;
     logic                       timed_kv_clear_done;
+    logic                       kv_clear_force;
     logic                       hmac_tag_mismatch_kill;
     logic                       ecc_privkey_mismatch_kill;
     logic                       prandom_warm_rst;
@@ -1016,25 +1017,18 @@ module caliptra_top_tb_services
         end
     end
 
-    generate
-        // Check if n-th KV slot is zeroed
-        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : kv_check_zero_slot_loop
-            for (genvar dword_i=0; dword_i < 16; dword_i++) begin : kv_check_zero_dword_loop
-                always @(negedge clk or negedge cptra_rst_b) begin
-                    if (!cptra_rst_b) begin
-                        kv_idx <= '0;
-                        check_kv_clear <= '0;
-                    end
-                    else if(((WriteData[15:0] & 16'hE0A2) == 16'hA0A2) && mailbox_write) begin
-                        kv_idx <= (WriteData[15:0] & 16'h1F00) >> 8;
-                        check_kv_clear <= '1;
-                    end else begin
-                        check_kv_clear <= '0;
-                    end
-                end
-            end
+     // Check if n-th KV slot is zeroed
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            kv_idx <= '0;
+            check_kv_clear <= '0;
+        end else if (((WriteData[15:0] & 16'hE0A2) == 16'hA0A2) && mailbox_write) begin
+            kv_idx <= (WriteData[15:0] & 16'h1F00) >> 8;
+            check_kv_clear <= '1;
+        end else begin
+            check_kv_clear <= '0;
         end
-    endgenerate
+    end
 
     always @(negedge clk) begin
         if (!cptra_rst_b) begin
@@ -1046,25 +1040,29 @@ module caliptra_top_tb_services
         end
     end
 
+    assign kv_clear_force = timed_kv_clear && (`CPTRA_TOP_PATH.doe.doe_inst.doe_fsm1.kv_doe_fsm_ns == 3'b100) && !timed_kv_clear_done;
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            timed_kv_clear_done <= '0;
+        end else if (kv_clear_force) begin
+            $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[0].DOE_FE_data_check);
+            $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[1].DOE_FE_data_check);
+            $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[2].DOE_FE_data_check);
+            $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[3].DOE_FE_data_check);
+            timed_kv_clear_done <= '1;
+        end
+    end
+
     generate
-        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : kv_timed_clear_loop
+        for (genvar slot_id = 0; slot_id < 24; slot_id++) begin : kv_timed_clear_loop
             always @(negedge clk or negedge cptra_rst_b) begin
                 if (!cptra_rst_b) begin
-                    timed_kv_clear_done <= '0;
-                end else if (timed_kv_clear) begin
-                    if((`CPTRA_TOP_PATH.doe.doe_inst.doe_fsm1.kv_doe_fsm_ns == 3'b100) & ~timed_kv_clear_done) begin
-                        // Need to kill off assertion that checks whether output matches plaintext (it won't since it got cleared)
-                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[0].DOE_FE_data_check);
-                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[1].DOE_FE_data_check);
-                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[2].DOE_FE_data_check);
-                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[3].DOE_FE_data_check);
-                        force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value = '1;
-                        timed_kv_clear_done <= 'b1;
-                    end else if(timed_kv_clear_done) begin
-                        release `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value;
-                    end
-                end else begin
-                    timed_kv_clear <= '0;
+                    release `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value;
+                end else if (kv_clear_force) begin
+                    force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value = '1;
+                end else if (timed_kv_clear_done) begin
+                    release `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value;
                 end
             end
         end
@@ -1732,7 +1730,7 @@ module caliptra_top_tb_services
 
     always @(negedge clk) begin
         //Switch to Production mode mode
-        else if ((WriteData[15:0] == 16'h15A2) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h15A2) && mailbox_write) begin
             security_state.device_lifecycle <= DEVICE_PRODUCTION;
             $display("Setting lifecycle to DEVICE_PRODUCTION\n");
         end

--- a/src/integration/tb/caliptra_top_tb_services.sv
+++ b/src/integration/tb/caliptra_top_tb_services.sv
@@ -510,7 +510,6 @@ module caliptra_top_tb_services
     //      16'h5BA2        - Disable injection of single mailbox lock request from SoC when mailbox is being unlocked
     //      16'h5CA2        - Enable injection of mailbox unlock when FW accesses mailbox SRAM directly
     //      16'h5DA2        - Disable injection of mailbox unlock when FW accesses mailbox SRAM directly
-    //      16'h80A2:'h9FA2 - Inject a valid hmac_key dest and hmac512_key into Nth kv slot (where slot is encoded as (N & 0x1F) << 8)
     //      16'hA0A2:'hBFA2 - Check if Nth kv slot (where slot is encoded as (N & 0x1F) << 8) is all zero
     //      16'hC0A2        - Force clear of all KV slots, when DOE FSM starts to write
     //         8'ha3        - Randomizable KV inject: slot=[12:8], last_dword=[16:13], dest_valid=[24:17]
@@ -1139,20 +1138,8 @@ module caliptra_top_tb_services
         for (genvar slot_id=0; slot_id < 24; slot_id++) begin : inject_slot_loop
             for (genvar dword_i=0; dword_i < 16; dword_i++) begin : inject_dword_loop
                 always @(negedge clk) begin
-                    //inject valid hmac_key dest and hmac512_key value to key reg (but extend the mask to permit all 24 kv slots)
-                    if(((WriteData[15:0] & 16'hE0A2) == 16'h80A2) && mailbox_write) begin
-                        inject_mldsa_seed <= 1'b1;
-                        if ((((WriteData[15:0] & 16'h1F00) >> 8) == slot_id)) begin
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.we = 1'b1;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.next = 5'b100;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].last_dword.we = 1'b1;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].last_dword.next = 'd7;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_ENTRY[slot_id][dword_i].data.we = 1'b1;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_ENTRY[slot_id][dword_i].data.next = hmac512_key_tb[dword_i][31 : 0];
-                        end
-                    end
                     //inject valid seed dest and seed value to key reg
-                    else if(((WriteData[7:0] & 8'hf8) == 8'h80) && mailbox_write) begin
+                    if(((WriteData[7:0] & 8'hf8) == 8'h80) && mailbox_write) begin
                         release_kv_inject_flags <= '0;
                         //$system("/home/mojtabab/workspace_aha_poc/ws1/Caliptra/src/ecc/tb/ecdsa_secp384r1.exe");
                         inject_ecc_seed <= 1'b1;

--- a/src/integration/tb/caliptra_top_tb_services.sv
+++ b/src/integration/tb/caliptra_top_tb_services.sv
@@ -39,6 +39,7 @@ module caliptra_top_tb_services
     import kv_defines_pkg::*;
     import caliptra_top_tb_pkg::*;
     import caliptra_prim_mubi_pkg::*;
+    import axi_pkg::*;
 #(
     parameter UVM_TB = 0
 ) (
@@ -73,6 +74,9 @@ module caliptra_top_tb_services
     output int   cycleCnt,
     output var   axi_complex_ctrl_t axi_complex_ctrl,
 
+    // Custom event injection
+    output logic inject_mbox_soc_lock_on_mbox_unlock,
+
     //Interrupt flags
     output logic int_flag,
     output logic cycleCnt_smpl_en,
@@ -82,11 +86,52 @@ module caliptra_top_tb_services
     output logic assert_rst_flag,
     output logic deassert_hard_rst_flag,
     output logic deassert_rst_flag,
+    output logic route_fatal_to_nmi,
 
     output logic [0:`CLP_OBF_UDS_DWORDS-1][31:0] cptra_uds_tb,
     output logic [0:`CLP_OBF_FE_DWORDS-1] [31:0] cptra_fe_tb,
     output logic [0:`CLP_OBF_KEY_DWORDS-1][31:0] cptra_obf_key_tb,
     output logic [0:OCP_LOCK_HEK_NUM_DWORDS-1] [31:0] cptra_hek_tb,
+
+    // AXI SoC access
+    output logic [31:0] axi_addr,
+    output logic [31:0] axi_axuser,
+    ref    logic [31:0] axi_wuser[$],
+    ref    logic [31:0] axi_wdata[$],
+    output logic [ 7:0] axi_len,
+    ref    logic [ 3:0] axi_wstrb[$],
+    output logic [ 1:0] axi_burst,
+    output logic        axi_use_id,
+    output logic [ 7:0] axi_id,
+    output logic        axi_write,
+    output logic        axi_write_addr,
+    output logic        axi_write_data,
+    output logic        axi_write_resp,
+    output logic        axi_read,
+    output logic        axi_read_addr,
+    output logic        axi_read_resp,
+    output logic        axi_put_status,
+    output logic        axi_put_rdata,
+
+    output logic [31:0] obf_key_value,
+    output logic  [2:0] obf_key_idx,
+    output logic        set_obf_key,
+    output logic        get_obf_key,
+
+    // UDS access
+    output logic        get_uds_value,
+    output logic [2:0]  uds_idx,
+
+    // FE access
+    output logic        get_fe_value,
+    output logic [1:0]  fe_idx,
+
+    // KV check cleared
+    output logic        check_kv_clear,
+    output logic [4:0]  kv_idx,
+
+    //Control signals
+    output logic        debug_intent,
 
     output logic axi_error_inj_en
 
@@ -171,6 +216,10 @@ module caliptra_top_tb_services
     logic                       cold_rst;
     logic                       warm_rst;
     logic                       timed_warm_rst;
+    logic                       timed_kv_clear;
+    logic                       timed_kv_clear_done;
+    logic                       hmac_tag_mismatch_kill;
+    logic                       ecc_privkey_mismatch_kill;
     logic                       prandom_warm_rst;
     logic                       cold_rst_done;
 
@@ -203,6 +252,20 @@ module caliptra_top_tb_services
     //  [0] - Single bit, Mailbox Error Injection
     //  [1] - Double bit, Mailbox Error Injection
     logic [1:0]                 inject_mbox_sram_error = 2'b0;
+
+    // Inject single mailbox access request from SoC when TAP locks mailbox
+    logic                       inject_mbox_soc_req_on_tap_lock;
+
+    // Inject mailbox lock request from TAP when FW locks mailbox
+    logic                       inject_mbox_tap_lock_read_on_fw_lock;
+
+    // Inject mailbox unlock from SoC when FW accesses mailbox SRAM directly
+    logic                       inject_mbox_unlock_on_dir_acc;
+
+    // Force override for Mailbox pointers reset values
+    logic [31:0]                mbox_ptr_reset_value;
+    logic                       force_mbox_ptr_reset_value;
+    logic                       release_mbox_ptr_reset_value;
 
     logic                       set_wdt_timer1_period;
     logic                       set_wdt_timer2_period;
@@ -335,6 +398,94 @@ module caliptra_top_tb_services
     //         8'h2 : 8'h5  - Do nothing
     //         8'h6 : 8'h7E - WriteData is an ASCII character - dump to console.log
     //         8'h7F        - Switch to MANUF device lifecycle state
+    //      16'h017F        - Setup SoC Access address from CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h027F        - Push SoC Access wdata from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wdata queue
+    //      16'h037F        - Send SoC access
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][0]     - write transaction
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][1]     - read transaction
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][2]     - write address only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][3]     - write data only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][4]     - write response only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][5]     - read address only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][6]     - read response only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][7]     - use operation ID, random otherwise
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][15:8]  - AXLEN
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][23:16] - Operation ID
+    //          If partial transfers are used, only one can be executed at any
+    //          given time, and it cannot be combined with full transfer.
+    //          ID must be specified and correct for partial transfers,
+    //          otherwise BFM will lockup
+    //      16'h047F        - Get SoC Access status, 0-In progress, 1-Done
+    //      16'h057F        - Pop SoC Access read response onto generic_input_wires
+    //      16'h067F        - Push SoC Access wuser from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wuser queue
+    //      16'h077F        - Setup SoC Access aXuser from CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h087F        - Setup SoC Access burst from CPTRA_GENERIC_OUTPUT_WIRES[1]: (0)fixed, (1,default)incr, (2)wrap
+    //      16'h097F        - Push SoC Access wstrb from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wstrb queue
+    //      16'h0A7F        - Clear SoC Access wdata, wuser and wstrb queues
+    //      16'h0D7F        - Force DMI enable (OpenOCD requires JTAG to be active to correctly examine device)
+    //      16'h0E7F        - Set route_fatal_to_nmi
+    //      16'h0F7F        - Clear route_fatal_to_nmi
+    //      16'h107F        - Force re-enable strap write
+    //      16'h117F        - Release strap write
+    //      16'h127F        - Enable debug intent
+    //      16'h137F        - Disable debug intent
+    //      16'h147F        - Switch to Manufacturing mode
+    //      16'h157F        - Switch to Production mode
+    //      16'h167F        - Force ss_debug intent
+    //      16'h177F        - Release ss_debug intent
+    //      16'h187F        - Switch to debug unlocked
+    //      16'h197F        - Switch to debug locked
+    //      16'h1A7F        - Force re-enable fuse write
+    //      16'h1B7F        - Force unlock caliptra security state
+    //      16'h1C7F        - Release unlock caliptra security state
+    //      16'h1D7F        - Force override mailbox pointer reset value to CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h1E7F        - Release override mailbox pointer reset value
+    //      16'h1F7F        - Switch to Unprovisioned mode
+    //      16'h207F        - Get UDS[0] and UDS[1] value from HW
+    //      16'h217F        - Get UDS[2] and UDS[3] value from HW
+    //      16'h227F        - Get UDS[4] and UDS[5] value from HW
+    //      16'h237F        - Get UDS[6] and UDS[7] value from HW
+    //      16'h247F        - Get UDS[8] and UDS[9] value from HW
+    //      16'h257F        - Get UDS[10] and UDS[11] value from HW
+    //      16'h267F        - Get UDS[12] and UDS[13] value from HW
+    //      16'h277F        - Get UDS[14] and UDS[15] value from HW
+    //      16'h307F        - Get FE[0] and FE[1] value from HW
+    //      16'h317F        - Get FE[2] and FE[3] value from HW
+    //      16'h327F        - Get FE[4] and FE[5] value from HW
+    //      16'h337F        - Get FE[6] and FE[7] value from HW
+    //      16'h407F        - Set OBF_KEY[0] value from generic wire 1
+    //      16'h417F        - Set OBF_KEY[1] value from generic wire 1
+    //      16'h427F        - Set OBF_KEY[2] value from generic wire 1
+    //      16'h437F        - Set OBF_KEY[3] value from generic wire 1
+    //      16'h447F        - Set OBF_KEY[4] value from generic wire 1
+    //      16'h457F        - Set OBF_KEY[5] value from generic wire 1
+    //      16'h467F        - Set OBF_KEY[6] value from generic wire 1
+    //      16'h477F        - Set OBF_KEY[7] value from generic wire 1
+    //      16'h487F        - Get OBF_KEY[0] value from HW
+    //      16'h497F        - Get OBF_KEY[1] value from HW
+    //      16'h4A7F        - Get OBF_KEY[2] value from HW
+    //      16'h4B7F        - Get OBF_KEY[3] value from HW
+    //      16'h4C7F        - Get OBF_KEY[4] value from HW
+    //      16'h4D7F        - Get OBF_KEY[5] value from HW
+    //      16'h4E7F        - Get OBF_KEY[6] value from HW
+    //      16'h4F7F        - Set OBF_KEY[7] value from HW
+    //      16'h507F        - Enable injection of single mailbox access request from SoC when TAP locks mailbox
+    //      16'h517F        - Disable injection of single mailbox access request from SoC when TAP locks mailbox
+    //      16'h527F        - Inject FIFO AXI read errors
+    //      16'h537F        - Inject FIFO AXI write errors
+    //      16'h547F        - Stop injecting FIFO AXI read errors
+    //      16'h557F        - Stop injecting FIFO AXI write errors
+    //      16'h567F        - Kill kv_hmac_tag_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
+    //      16'h577F        - Kill kv_ecc_privkey_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
+    //      16'h587F        - Enable injection of single mailbox lock request from TAP when FW locks mailbox
+    //      16'h597F        - Disable injection of single mailbox lock request from TAP when FW locks mailbox
+    //      16'h5A7F        - Enable injection of single mailbox lock request from SoC when mailbox is being unlocked
+    //      16'h5B7F        - Disable injection of single mailbox lock request from SoC when mailbox is being unlocked
+    //      16'h5C7F        - Enable injection of mailbox unlock when FW accesses mailbox SRAM directly
+    //      16'h5D7F        - Disable injection of mailbox unlock when FW accesses mailbox SRAM directly
+    //      16'h807F:'h9F7F - Inject a valid hmac_key dest and hmac512_key into Nth kv slot (where slot is encoded as (N & 0x1F) << 8)
+    //      16'hA07F:'hBF7F - Check if Nth kv slot (where slot is encoded as (N & 0x1F) << 8) is all zero
+    //      16'hC07F        - Force clear of all KV slots, when DOE FSM starts to write
     //         8'h80: 8'h87 - Inject ECC_SEED to kv_key register
     //         8'h88        - Toggle recovery interface emulation in AXI complex
     //         8'h89        - Use same msg in SHA512 digest for ECC/MLDSA PCR signing (used where both cryptos are running in parallel)
@@ -453,6 +604,236 @@ module caliptra_top_tb_services
     integer j;
     string slaveLog_fileName[`CALIPTRA_AHB_SLAVES_NUM];
 
+    initial begin
+        axi_burst = AXI_BURST_INCR;
+    end
+
+    //  AXI SoC Access
+    always @(negedge clk) begin
+        axi_write <= 1'b0;
+        axi_read <= 1'b0;
+        axi_write_addr <= 1'b0;
+        axi_write_data <= 1'b0;
+        axi_write_resp <= 1'b0;
+        axi_read_addr  <= 1'b0;
+        axi_read_resp  <= 1'b0;
+        axi_put_status <= 1'b0;
+        axi_use_id     <= 1'b0;
+        axi_put_rdata <= 1'b0;
+        if ((WriteData[15:0] == 16'h017F) && mailbox_write) begin
+            axi_addr <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+        end else if ((WriteData[15:0] == 16'h027F) && mailbox_write) begin
+            axi_wdata.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
+        end else if ((WriteData[15:0] == 16'h037F) && mailbox_write) begin
+            axi_write      <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][0];
+            axi_read       <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][1];
+            axi_write_addr <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][2];
+            axi_write_data <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][3];
+            axi_write_resp <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][4];
+            axi_read_addr  <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][5];
+            axi_read_resp  <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][6];
+            axi_use_id     <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][7];
+            axi_len        <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][15:8];
+            axi_id         <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][23:16];
+        end else if ((WriteData[15:0] == 16'h047F) && mailbox_write) begin
+            axi_put_status <= 1'b1;
+        end else if ((WriteData[15:0] == 16'h057F) && mailbox_write) begin
+            axi_put_rdata <= 1'b1;
+        end else if ((WriteData[15:0] == 16'h067F) && mailbox_write) begin
+            axi_wuser.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
+        end else if ((WriteData[15:0] == 16'h077F) && mailbox_write) begin
+            axi_axuser <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+        end else if ((WriteData[15:0] == 16'h087F) && mailbox_write) begin
+            axi_burst <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+        end else if ((WriteData[15:0] == 16'h097F) && mailbox_write) begin
+            axi_wstrb.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
+        end else if ((WriteData[15:0] == 16'h0A7F) && mailbox_write) begin
+            axi_wdata = {};
+            axi_wuser = {};
+            axi_wstrb = {};
+        end
+    end
+
+    //  Fuse re-enable access
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h107F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value = 1'h0;
+            force `CPTRA_TOP_PATH.soc_ifc_top1.strap_we = 1'h1;
+            repeat (10) @(negedge clk);
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value;
+        end else if ((WriteData[15:0] == 16'h117F) && mailbox_write) begin
+            release `CPTRA_TOP_PATH.soc_ifc_top1.strap_we;
+        end else if ((WriteData[15:0] == 16'h1A7F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value = 1'h0;
+            repeat (10) @(negedge clk);
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value;
+        end
+    end
+
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h0D7F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.rvtop.dmi_core_enable = 1'h1;
+            $display("Force enable JTAG/DMI to be active");
+        end
+    end
+
+    initial begin
+        debug_intent = 1'b0;
+        route_fatal_to_nmi = 1'b0;
+    end
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h0E7F) && mailbox_write) begin
+            route_fatal_to_nmi <= 1'b1;
+            force `CPTRA_TOP_PATH.nmi_int = `CPTRA_TOP_PATH.cptra_error_fatal;
+            $display("Route fatal error to nmi pin");
+        end else if ((WriteData[15:0] == 16'h0F7F) && mailbox_write) begin
+            route_fatal_to_nmi <= 1'b0;
+            release `CPTRA_TOP_PATH.nmi_int;
+            $display("Return NMI to normal use");
+        end
+    end
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h127F) && mailbox_write) begin
+            debug_intent <= 1'b1;
+            $display("Enabling debug_intent");
+        end else if ((WriteData[15:0] == 16'h137F) && mailbox_write) begin
+            debug_intent <= 1'b0;
+            $display("Disabling debug_intent");
+        end
+    end
+
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h167F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.soc_ifc_top1.soc_ifc_reg_hwif_in.SS_DEBUG_INTENT.debug_intent.next = 1'h1;
+        end else if ((WriteData[15:0] == 16'h177F) && mailbox_write) begin
+            release `CPTRA_TOP_PATH.soc_ifc_top1.soc_ifc_reg_hwif_in.SS_DEBUG_INTENT.debug_intent.next;
+        end
+        if ((WriteData[15:0] == 16'h1B7F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.unlock_caliptra_security_state = 1'h1;
+        end else if ((WriteData[15:0] == 16'h1C7F) && mailbox_write) begin
+            release `CPTRA_TOP_PATH.unlock_caliptra_security_state;
+        end
+    end
+
+    // Prevent from setting ptr reset value to mailboxes max capacity
+    `CALIPTRA_ASSERT_NEVER(
+        no_mbox_ptr_rst_value_override_full_capacity,
+        (WriteData[15:0] == 16'h1D7F) && mailbox_write &&
+        (`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1] == 32'hFFFFFFFF),
+        !clk, cptra_rst_b
+    )
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            mbox_ptr_reset_value <= 0;
+            force_mbox_ptr_reset_value <= 0;
+            release_mbox_ptr_reset_value <= 0;
+        end
+        if ((WriteData[15:0] == 16'h1D7F) && mailbox_write) begin
+            $display("Force MBOX pointers reset value to %x\n", `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
+            mbox_ptr_reset_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+            force_mbox_ptr_reset_value <= 1;
+            release_mbox_ptr_reset_value <= 0;
+        end else if ((WriteData[15:0] == 16'h1E7F) && mailbox_write) begin
+            $display("Release MBOX pointers reset value\n");
+            force_mbox_ptr_reset_value <= 0;
+            release_mbox_ptr_reset_value <= 1;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if      (!cptra_rst_b) begin
+            get_uds_value <= 1'b0;
+            uds_idx <= 3'h0;
+        end
+        else if ((WriteData[15:0] inside {16'h207F, 16'h217F, 16'h227F, 16'h237F, 16'h247F, 16'h257F, 16'h267F, 16'h277F}) && mailbox_write) begin
+            get_uds_value <= 1'b1;
+            uds_idx <= WriteData[10:8];
+        end else begin
+            get_uds_value <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if      (!cptra_rst_b) begin
+            get_fe_value <= 1'b0;
+            fe_idx <= 2'h0;
+        end
+        else if ((WriteData[15:0] inside {16'h307F, 16'h317F, 16'h327F, 16'h337F}) && mailbox_write) begin
+            get_fe_value <= 1'b1;
+            fe_idx <= WriteData[9:8];
+        end else begin
+            get_fe_value <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if      (!cptra_rst_b) begin
+            set_obf_key <= 1'b0;
+            get_obf_key <= 1'b0;
+        end
+        else if ((WriteData[15:0] & 16'hF8FF) == 16'h407F  && mailbox_write) begin
+            set_obf_key   <= 1'b1;
+            obf_key_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+            obf_key_idx   <= WriteData[10:8];
+        end
+        else if ((WriteData[15:0] & 16'hF8FF) == 16'h487F  && mailbox_write) begin
+            get_obf_key   <= 1'b1;
+            obf_key_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+            obf_key_idx   <= WriteData[10:8];
+        end else begin
+            set_obf_key <= 1'b0;
+            get_obf_key <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            inject_mbox_soc_req_on_tap_lock <= 1'b0;
+        end
+        else if ((WriteData[15:0] == 16'h507F) && mailbox_write) begin
+            inject_mbox_soc_req_on_tap_lock <= 1'b1;
+        end
+        else if ((WriteData[15:0] == 16'h517F) && mailbox_write) begin
+            inject_mbox_soc_req_on_tap_lock <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            inject_mbox_tap_lock_read_on_fw_lock <= 1'b0;
+        end
+        else if ((WriteData[15:0] == 16'h587F) && mailbox_write) begin
+            inject_mbox_tap_lock_read_on_fw_lock <= 1'b1;
+        end
+        else if ((WriteData[15:0] == 16'h597F) && mailbox_write) begin
+            inject_mbox_tap_lock_read_on_fw_lock <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            inject_mbox_soc_lock_on_mbox_unlock <= 1'b0;
+        end
+        else if ((WriteData[15:0] == 16'h5A7F) && mailbox_write) begin
+            inject_mbox_soc_lock_on_mbox_unlock <= 1'b1;
+        end
+        else if ((WriteData[15:0] == 16'h5B7F) && mailbox_write) begin
+            inject_mbox_soc_lock_on_mbox_unlock <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            inject_mbox_unlock_on_dir_acc <= 1'b0;
+        end
+        else if ((WriteData[15:0] == 16'h5C7F) && mailbox_write) begin
+            inject_mbox_unlock_on_dir_acc <= 1'b1;
+        end
+        else if ((WriteData[15:0] == 16'h5D7F) && mailbox_write) begin
+            inject_mbox_unlock_on_dir_acc <= 1'b0;
+        end
+    end
+
     logic [7:0] isr_active = 8'h0;
     always @(negedge clk) begin
         if ((WriteData[7:0] == 8'hfc) && mailbox_write) begin
@@ -537,7 +918,11 @@ module caliptra_top_tb_services
 
     initial ras_test_ctrl.error_injection_seen = 1'b0;
     always @(negedge clk) begin
+<<<<<<< HEAD
         if (mailbox_write && WriteData[7:0] inside {8'hfd, 8'h95}) begin
+=======
+        if (mailbox_write && WriteData[7:0] inside {8'he5, 8'he6, 8'hfd, 8'hfe}) begin
+>>>>>>> 3c19526ab (Extend TB & services)
             ras_test_ctrl.error_injection_seen <= 1'b1;
         end
     end
@@ -556,6 +941,8 @@ module caliptra_top_tb_services
             axi_complex_ctrl.fifo_clear            <= 1'b0;
             axi_complex_ctrl.rand_delays           <= 1'b0;
             axi_complex_ctrl.en_recovery_emulation <= 1'b0;
+            axi_complex_ctrl.fifo_rd_error         <= 1'b0;
+            axi_complex_ctrl.fifo_wr_error         <= 1'b0;
         end
         else if((WriteData[7:0] == 8'h88) && mailbox_write) begin
             axi_complex_ctrl.en_recovery_emulation <= ~axi_complex_ctrl.en_recovery_emulation; // Toggle option
@@ -577,6 +964,18 @@ module caliptra_top_tb_services
         end
         else if((WriteData[7:0] == 8'h8f) && mailbox_write) begin
             axi_complex_ctrl.rand_delays    <= ~axi_complex_ctrl.rand_delays; // Toggle option
+        end
+        else if((WriteData[15:0] == 16'h527F) && mailbox_write) begin
+            axi_complex_ctrl.fifo_rd_error  <= 1'b1;
+        end
+        else if((WriteData[15:0] == 16'h537F) && mailbox_write) begin
+            axi_complex_ctrl.fifo_wr_error  <= 1'b1;
+        end
+        else if((WriteData[15:0] == 16'h547F) && mailbox_write) begin
+            axi_complex_ctrl.fifo_rd_error  <= 1'b0;
+        end
+        else if((WriteData[15:0] == 16'h557F) && mailbox_write) begin
+            axi_complex_ctrl.fifo_wr_error  <= 1'b0;
         end
         else begin
             axi_complex_ctrl.fifo_clear     <= 1'b0;
@@ -621,14 +1020,145 @@ module caliptra_top_tb_services
         end
     end
 
-    genvar dword_i, slot_id;
+    generate
+        // Check if n-th KV slot is zeroed
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : kv_check_zero_slot_loop
+            for (genvar dword_i=0; dword_i < 16; dword_i++) begin : kv_check_zero_dword_loop
+                always @(negedge clk or negedge cptra_rst_b) begin
+                    if (!cptra_rst_b) begin
+                        kv_idx <= '0;
+                        check_kv_clear <= '0;
+                    end
+                    else if(((WriteData[15:0] & 16'hE07F) == 16'hA07F) && mailbox_write) begin
+                        kv_idx <= (WriteData[15:0] & 16'h1F00) >> 8;
+                        check_kv_clear <= '1;
+                    end else begin
+                        check_kv_clear <= '0;
+                    end
+                end
+            end
+        end
+    endgenerate
+
+    always @(negedge clk) begin
+        if (!cptra_rst_b) begin
+            timed_kv_clear <= '0;
+        end else if (WriteData[15:0] == 16'hC07F) begin
+            timed_kv_clear <= '1;
+        end else begin
+            timed_kv_clear <= '0;
+        end
+    end
+
+    generate
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : kv_timed_clear_loop
+            always @(negedge clk or negedge cptra_rst_b) begin
+                if (!cptra_rst_b) begin
+                    timed_kv_clear_done <= '0;
+                end else if (timed_kv_clear) begin
+                    if((`CPTRA_TOP_PATH.doe.doe_inst.doe_fsm1.kv_doe_fsm_ns == 3'b100) & ~timed_kv_clear_done) begin
+                        // Need to kill off assertion that checks whether output matches plaintext (it won't since it got cleared)
+                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[0].DOE_FE_data_check);
+                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[1].DOE_FE_data_check);
+                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[2].DOE_FE_data_check);
+                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[3].DOE_FE_data_check);
+                        force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value = '1;
+                        timed_kv_clear_done <= 'b1;
+                    end else if(timed_kv_clear_done) begin
+                        release `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value;
+                    end
+                end else begin
+                    timed_kv_clear <= '0;
+                end
+            end
+        end
+    endgenerate
+
+    always @(negedge clk) begin
+        if (!cptra_rst_b) begin
+            hmac_tag_mismatch_kill <= '0;
+        end else if (WriteData[15:0] == 16'h567F) begin
+            hmac_tag_mismatch_kill <= '1;
+        end else begin
+            hmac_tag_mismatch_kill <= '0;
+        end
+    end
+
+    generate
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : hmac_tag_mismatch_kill_loop
+            always @(negedge clk) begin
+                if (hmac_tag_mismatch_kill) begin
+                    // Need to kill off assertion that checks whether output tag in HMAC matches tag written to KV
+                    // this assert is not necessary, e.g. in tests where KV is deliberately not set to be writable (locked)
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[0].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[1].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[2].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[3].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[4].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[5].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[6].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[7].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[8].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[9].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[10].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[11].genblk3.kv_hmac_tag_w_flow);
+                end
+            end
+        end
+    endgenerate
+
+    always @(negedge clk) begin
+        if (!cptra_rst_b) begin
+            ecc_privkey_mismatch_kill <= '0;
+        end else if (WriteData[15:0] == 16'h577F) begin
+            ecc_privkey_mismatch_kill <= '1;
+        end else begin
+            ecc_privkey_mismatch_kill <= '0;
+        end
+    end
+
+    generate
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : ecc_privkey_mismatch_kill_loop
+            always @(negedge clk) begin
+                if (ecc_privkey_mismatch_kill) begin
+                    // Need to kill off assertion that checks whether output tag in HMAC matches tag written to KV
+                    // this assert is not necessary, e.g. in tests where KV is deliberately not set to be writable (locked)
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[0].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[1].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[2].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[3].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[4].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[5].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[6].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[7].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[8].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[9].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[10].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[11].genblk4.kv_ecc_privkey_w_flow);
+                end
+            end
+        end
+    endgenerate
+
     generate
     if (!UVM_TB) begin : inject_kv_function
-        for (slot_id=0; slot_id < 24; slot_id++) begin : inject_slot_loop
-            for (dword_i=0; dword_i < 16; dword_i++) begin : inject_dword_loop
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : inject_slot_loop
+            for (genvar dword_i=0; dword_i < 16; dword_i++) begin : inject_dword_loop
                 always @(negedge clk) begin
+                    //inject valid hmac_key dest and hmac512_key value to key reg (but extend the mask to permit all 24 kv slots)
+                    if(((WriteData[15:0] & 16'hE07F) == 16'h807F) && mailbox_write) begin
+                        inject_mldsa_seed <= 1'b1;
+                        if ((((WriteData[15:0] & 16'h1F00) >> 8) == slot_id)) begin
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.we = 1'b1;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.next = 5'b100;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].last_dword.we = 1'b1;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].last_dword.next = 'd7;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_ENTRY[slot_id][dword_i].data.we = 1'b1;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_ENTRY[slot_id][dword_i].data.next = hmac512_key_tb[dword_i][31 : 0];
+                        end
+                    end
                     //inject valid seed dest and seed value to key reg
-                    if(((WriteData[7:0] & 8'hf8) == 8'h80) && mailbox_write) begin
+                    else if(((WriteData[7:0] & 8'hf8) == 8'h80) && mailbox_write) begin
                         release_kv_inject_flags <= '0;
                         //$system("/home/mojtabab/workspace_aha_poc/ws1/Caliptra/src/ecc/tb/ecdsa_secp384r1.exe");
                         inject_ecc_seed <= 1'b1;
@@ -1166,6 +1696,7 @@ module caliptra_top_tb_services
 
     //TIE-OFF device lifecycle
     logic assert_ss_tran;
+<<<<<<< HEAD
 `ifdef CALIPTRA_DEBUG_UNLOCKED
     initial security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4False}; // DebugUnlocked & Production
 `else
@@ -1174,10 +1705,17 @@ module caliptra_top_tb_services
             security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4False}; // DebugUnlocked & Production
         else
             security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4True}; // DebugLocked & Production
+=======
+>>>>>>> 3c19526ab (Extend TB & services)
 
-        unlock_security_state = 1'b0; // Default to not unlocking security state
+    initial begin
+        if (!$test$plusargs("CALIPTRA_DEBUG_UNLOCKED")) begin
+             security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: 1'b1}; // DebugLocked & Production
+        end else begin
+            security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: 1'b0}; // DebugUnlocked & Production
+        end
     end
-`endif
+
     always @(negedge clk) begin
         //lock debug mode
         if ((WriteData[7:0] == 8'hf9) && mailbox_write) begin
@@ -1204,6 +1742,37 @@ module caliptra_top_tb_services
         else if (unlock_security_state) begin
             unlock_security_state <= 1'b0; // Reset unlock security state
             release `CPTRA_TOP_PATH.unlock_caliptra_security_state; // Release force unlock security state
+        end
+    end
+
+    always @(negedge clk) begin
+        //Switch to Manufacturing mode mode
+        if ((WriteData[15:0] == 16'h147F) && mailbox_write) begin
+            security_state.device_lifecycle <= DEVICE_MANUFACTURING;
+            $display("Setting lifecycle to DEVICE_MANUFACTURING\n");
+        end
+        //Switch to Production mode mode
+        else if ((WriteData[15:0] == 16'h157F) && mailbox_write) begin
+            security_state.device_lifecycle <= DEVICE_PRODUCTION;
+            $display("Setting lifecycle to DEVICE_PRODUCTION\n");
+        end
+        //Switch to Unprovisioned mode mode
+        else if ((WriteData[15:0] == 16'h1F7F) && mailbox_write) begin
+            security_state.device_lifecycle <= DEVICE_UNPROVISIONED;
+            $display("Setting lifecycle to DEVICE_UNPROVISIONED\n");
+        end
+    end
+
+    always @(negedge clk) begin
+        //Switch to debug unlocked
+        if ((WriteData[15:0] == 16'h187F) && mailbox_write) begin
+            security_state.debug_locked <= 1'b0;
+            $display("Setting debug_locked to 0");
+        end
+        //Switch to debug locked
+        else if ((WriteData[15:0] == 16'h197F) && mailbox_write) begin
+            security_state.debug_locked <= 1'b1;
+            $display("Setting debug_locked to 1");
         end
     end
 
@@ -2579,6 +3148,33 @@ endgenerate //IV_NO
         //Use 'hF1 code to reset these values in the test
     end
 
+    // Force Mailbox pointers reset value override
+    always_comb begin
+        if (force_mbox_ptr_reset_value) begin
+            // Force only on pointer resets, keep regular behavior on normal accesses
+            if (`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.rst_mbox_wrptr) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_wrptr_nxt = mbox_ptr_reset_value;
+            end else begin
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_wrptr_nxt;
+            end
+
+            // Force only on pointer resets, keep regular behavior on normal accesses
+            // Reads perform preload on 0
+            if (`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.rst_mbox_rdptr) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_rdptr_nxt = mbox_ptr_reset_value + 'd1;
+                if (!`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dir_req_dv_q) begin
+                    force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.sram_rdaddr = mbox_ptr_reset_value;
+                end
+            end else begin
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_rdptr_nxt;
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.sram_rdaddr;
+            end
+        end else if (release_mbox_ptr_reset_value) begin
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_wrptr_nxt;
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_rdptr_nxt;
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.sram_rdaddr;
+        end
+    end
 
     `ifndef VERILATOR
         initial begin
@@ -2617,6 +3213,44 @@ endgenerate //IV_NO
         end
         else if(mailbox_data_val & mailbox_write) begin
             prev_mailbox_data <= WriteData;
+        end
+    end
+
+    always @(posedge clk) begin
+        if (inject_mbox_soc_req_on_tap_lock) begin
+            if (`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.arc_MBOX_IDLE_MBOX_RDY_FOR_CMD & `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_in.mbox_lock.lock.hwset) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.req_data_soc_req = 1'b1;
+                @(negedge `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.arc_MBOX_IDLE_MBOX_RDY_FOR_CMD);
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.req_data_soc_req;
+            end
+        end
+    end
+
+    always @(posedge clk) begin
+        if (inject_mbox_tap_lock_read_on_fw_lock) begin
+            if (~`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_out.mbox_lock.lock.value & `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_out.mbox_lock.lock.swmod) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dmi_reg_ren = 1'b1;  // Read enable
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dmi_reg_addr = 7'h75;  // Lock register address
+                @(posedge `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.clk);
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dmi_reg_ren;
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dmi_reg_addr;
+            end
+        end
+    end
+
+    always @(negedge clk) begin
+        if (inject_mbox_unlock_on_dir_acc) begin
+            if ((`CPTRA_TOP_PATH.soc_ifc_top1.haddr_i inside {[MBOX_DIR_START_ADDR:MBOX_DIR_END_ADDR]}) &
+                `CPTRA_TOP_PATH.soc_ifc_top1.hsel_i &
+                `CPTRA_TOP_PATH.soc_ifc_top1.hwrite_i &
+                `CPTRA_TOP_PATH.soc_ifc_top1.hready_i &
+                (`CPTRA_TOP_PATH.soc_ifc_top1.htrans_i == 2'h2) &
+                `CPTRA_TOP_PATH.soc_ifc_top1.hreadyout_o
+            ) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_out.mbox_unlock.unlock.value = 1'b1;
+                @(posedge `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.clk);
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_out.mbox_unlock.unlock.value;
+            end
         end
     end
 

--- a/src/integration/tb/caliptra_top_tb_soc_bfm.sv
+++ b/src/integration/tb/caliptra_top_tb_soc_bfm.sv
@@ -179,7 +179,7 @@ import caliptra_top_tb_pkg::*; #(
         end
     end
     // Pulse fires about 640ns after the original error interrupt occurs
-    always_comb cptra_error_fatal_dly_p     = (cptra_error_fatal_counter     == 16'h0040) && !route_fatal_to_nmi;
+    always_comb cptra_error_fatal_dly_p     = (cptra_error_fatal_counter    == 16'h0040) && !route_fatal_to_nmi;
     always_comb cptra_error_non_fatal_dly_p = cptra_error_non_fatal_counter == 16'h0040;
 
     always@(negedge core_clk) begin

--- a/src/integration/tb/caliptra_top_tb_soc_bfm.sv
+++ b/src/integration/tb/caliptra_top_tb_soc_bfm.sv
@@ -34,6 +34,10 @@ import caliptra_top_tb_pkg::*; #(
     input int                          cycleCnt,
 
     output logic [`CLP_OBF_KEY_DWORDS-1:0][31:0]          cptra_obf_key,
+    output logic [`CLP_OBF_UDS_DWORDS-1:0][31:0]          cptra_uds_strap,
+    output logic                                          cptra_uds_strap_vld,
+    output logic [`CLP_OBF_FE_DWORDS-1:0] [31:0]          cptra_fe_strap,
+    output logic                                          cptra_fe_strap_vld,
     output logic [`CLP_CSR_HMAC_KEY_DWORDS-1:0][31:0]     cptra_csr_hmac_key,
 
     input  logic [0:`CLP_OBF_UDS_DWORDS-1][31:0]          cptra_uds_rand,
@@ -79,7 +83,47 @@ import caliptra_top_tb_pkg::*; #(
     input logic assert_hard_rst_flag,
     input logic deassert_hard_rst_flag,
     input logic assert_rst_flag_from_service,
-    input logic deassert_rst_flag_from_service
+    input logic deassert_rst_flag_from_service,
+
+    input logic route_fatal_to_nmi,
+
+    // Custom event injection
+    input logic inject_mbox_soc_lock_on_mbox_unlock,
+
+    //AXI SoC
+    input logic [31:0] axi_addr,
+    input logic [31:0] axi_axuser,
+    ref   logic [31:0] axi_wuser[$],
+    ref   logic [31:0] axi_wdata[$],
+    input logic [ 7:0] axi_len,
+    ref   logic [ 3:0] axi_wstrb[$],
+    input logic [ 1:0] axi_burst,
+    input logic        axi_use_id,
+    input logic [ 7:0] axi_id,
+    input logic        axi_write,
+    input logic        axi_write_addr,
+    input logic        axi_write_data,
+    input logic        axi_write_resp,
+    input logic        axi_read,
+    input logic        axi_read_addr,
+    input logic        axi_read_resp,
+    input logic        axi_put_status,
+    input logic        axi_put_rdata,
+
+    input logic [31:0] obf_key_value,
+    input logic  [2:0] obf_key_idx,
+    input logic        set_obf_key,
+    input logic        get_obf_key,
+
+    //UDS access
+    input logic       get_uds_value,
+    input logic [2:0] uds_idx,
+    //FE access
+    input logic       get_fe_value,
+    input logic [1:0] fe_idx,
+    // KV check cleared
+    input logic        check_kv_clear,
+    input logic [4:0]  kv_idx
 
 );
     localparam FW_NUM_DWORDS         = 256;
@@ -135,7 +179,7 @@ import caliptra_top_tb_pkg::*; #(
         end
     end
     // Pulse fires about 640ns after the original error interrupt occurs
-    always_comb cptra_error_fatal_dly_p     = cptra_error_fatal_counter     == 16'h0040;
+    always_comb cptra_error_fatal_dly_p     = (cptra_error_fatal_counter     == 16'h0040) && !route_fatal_to_nmi;
     always_comb cptra_error_non_fatal_dly_p = cptra_error_non_fatal_counter == 16'h0040;
 
     always@(negedge core_clk) begin
@@ -287,6 +331,8 @@ import caliptra_top_tb_pkg::*; #(
         BootFSM_BrkPoint = $urandom_range(1,0); //Set before anything starts (drive like a const strap)
         cptra_rst_b = 1'b0;
         assert_rst_flag_from_fatal = 1'b0;
+        cptra_uds_strap_vld = 1'b0;
+        cptra_fe_strap_vld = 1'b0;
         m_axi_bfm_if.rst_mgr();
 
 `ifndef VERILATOR
@@ -304,6 +350,14 @@ import caliptra_top_tb_pkg::*; #(
 
             cptra_uds_tb = cptra_uds_rand;
             cptra_fe_tb = cptra_fe_rand;
+            for (int dword = 0; dword < $bits(cptra_uds_strap)/32; dword++) begin
+                cptra_uds_strap[dword] = cptra_uds_tb[dword];
+            end
+            cptra_uds_strap_vld = 1'b1;
+            for (int dword = 0; dword < $bits(cptra_fe_strap)/32; dword++) begin
+                cptra_fe_strap[dword] = cptra_fe_tb[dword];
+            end
+            cptra_fe_strap_vld = 1'b1;
             cptra_hek_tb = cptra_hek_rand;
         end
         else begin
@@ -328,6 +382,14 @@ import caliptra_top_tb_pkg::*; #(
             for (int dword = 0; dword < $bits(cptra_obf_key)/32; dword++) begin
                 cptra_obf_key[dword] = cptra_obfkey_tb[dword];
             end
+            for (int dword = 0; dword < $bits(cptra_uds_strap)/32; dword++) begin
+                cptra_uds_strap[dword] = cptra_uds_tb[dword];
+            end
+            cptra_uds_strap_vld = 1'b1;
+            for (int dword = 0; dword < $bits(cptra_fe_strap)/32; dword++) begin
+                cptra_fe_strap[dword] = cptra_fe_tb[dword];
+            end
+            cptra_fe_strap_vld = 1'b1;
         end
 
         for (int dword = 0; dword < `CLP_CSR_HMAC_KEY_DWORDS; dword++) begin
@@ -393,10 +455,14 @@ import caliptra_top_tb_pkg::*; #(
                         $write ("SoC: Polling Flow Status...");
                         poll_count = 0;
                         do begin
-                            m_axi_bfm_if.axi_read_single(.addr(`CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS), .data(rdata), .resp(rresp), .resp_user(buser));
+                            // Make a narrow and unaligned access
+                            automatic int size = $urandom_range(0, 1);
+                            automatic int bytes = 2**size;
+                            m_axi_bfm_if.axi_read_single(.addr(`CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS + `SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_FUSES_LOW / 8 / bytes * bytes), .size(size), .data(rdata), .resp(rresp), .resp_user(buser));
                             poll_count++;
-                        end while(rdata[`SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_FUSES_LOW] == 1);
-                        $display("\n  >>> SoC: Ready for Fuses deasserted after polling %d times\n", poll_count);
+                         end while(rdata[`SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_FUSES_LOW] == 1);
+                         $display("\n  >>> SoC: Ready for Fuses deasserted after polling %d times\n", poll_count);
+
                         $display ("SoC: Writing BootGo register\n");
                         m_axi_bfm_if.axi_write_single(.addr(`CLP_SOC_IFC_REG_CPTRA_BOOTFSM_GO), .data(32'h00000001), .resp(wresp), .resp_user(buser));
                     end
@@ -405,7 +471,6 @@ import caliptra_top_tb_pkg::*; #(
                     end
 
                     $display ("CLP: ROM Flow in progress...\n");
-
                     // Test sequence (Mailbox or error handling)
                     wait(ready_for_mb_processing || ras_test_ctrl.error_injection_seen);
 
@@ -676,6 +741,210 @@ import caliptra_top_tb_pkg::*; #(
                     m_axi_bfm_if.rst_mgr();
                 end: RESET_FLOW
             join_any
+        end
+    end
+
+    always @(posedge core_clk) begin
+        if (set_obf_key) begin
+            cptra_obf_key[obf_key_idx] <= obf_key_value;
+        end else if (get_obf_key) begin
+            generic_input_wires <= {32'h0, `CPTRA_TOP_PATH.cptra_obf_key_reg[obf_key_idx]};
+        end
+    end
+
+    logic done, read, write, read_addr, read_resp, write_addr, write_data, write_resp;
+    logic [31:0] axi_rdata[$];
+    axi_resp_e axi_bresp, axi_rresp[$];
+    logic [`CALIPTRA_AXI_USER_WIDTH  -1:0] axi_buser, axi_ruser[$];
+    always @(posedge core_clk or negedge cptra_pwrgood) begin
+        if (~cptra_pwrgood) begin
+            done <= 1'b0;
+            read <= 1'b0;
+            read_addr <= 1'b0;
+            read_resp <= 1'b0;
+            write <= 1'b0;
+            write_addr <= 1'b0;
+            write_data <= 1'b0;
+            write_resp <= 1'b0;
+            axi_bresp <= axi_pkg::axi_resp_e'(0);
+            axi_buser <= '0;
+        end else if (axi_write || axi_read || axi_write_addr || axi_write_data || axi_write_resp || axi_read_addr || axi_read_resp ) begin
+            done <= 1'b0;
+            read <= 1'b0;
+            write <= 1'b0;
+            read_addr <= 1'b0;
+            read_resp <= 1'b0;
+            write_addr <= 1'b0;
+            write_data <= 1'b0;
+            write_resp <= 1'b0;
+            fork
+                if (axi_write_addr) begin
+                    write_addr <= 1'b1;
+                    m_axi_bfm_if.send_write_addr(
+                        .addr(axi_addr),
+                        .burst(axi_pkg::axi_burst_e'(axi_burst)),
+                        .len(axi_len),
+                        .user(axi_axuser),
+                        .id(axi_id),
+                        .lock(1'b0)
+                    );
+                end
+                if (axi_write_data) begin
+                    write_data <= 1'b1;
+                    for (int beat=0; beat <= axi_len; beat++)
+                        m_axi_bfm_if.send_write_beat(
+                            .last(beat == axi_len),
+                            .data(axi_wdata[beat]),
+                            .user(axi_wuser[beat]),
+                            .strb(axi_wstrb[beat])
+                        );
+                end
+                if (axi_write_resp) begin
+                    write_resp <= 1'b1;
+                    m_axi_bfm_if.get_write_resp(
+                        .id(axi_id),
+                        .resp(axi_bresp),
+                        .user(axi_buser)
+                    );
+                end
+                if (axi_write) begin
+                    write <= 1'b1;
+                    m_axi_bfm_if.axi_write(
+                        .addr(axi_addr),
+                        .burst(axi_pkg::axi_burst_e'(axi_burst)),
+                        .len(axi_len),
+                        .user(axi_axuser),
+                        .id  (axi_use_id ? axi_id : $urandom()),
+                        .lock(1'b0),
+                        .data(axi_wdata),
+                        .use_strb(1'b1),
+                        .strb(axi_wstrb),
+                        .use_write_user(1'b1),
+                        .write_user(axi_wuser),
+                        .resp(axi_bresp),
+                        .resp_user(axi_buser)
+                    );
+                end
+                if (axi_read_addr) begin
+                    read_addr <= 1'b1;
+                    m_axi_bfm_if.send_read_address(
+                        .addr(axi_addr),
+                        .burst(axi_pkg::axi_burst_e'(axi_burst)),
+                        .len(axi_len),
+                        .user(axi_axuser),
+                        .id(axi_id),
+                        .lock(1'b0)
+                    );
+                end
+                if (axi_read_resp) begin
+                    automatic axi_resp_e   beat_resp, rresp[];
+                    automatic logic [31:0] beat_user, ruser[];
+                    automatic logic [31:0] beat_data, rdata[];
+                    read_resp <= 1'b1;
+                    rdata = new[axi_len+1];
+                    ruser = new[axi_len+1];
+                    rresp = new[axi_len+1];
+                    for (int beat=0; beat <= axi_len; beat++) begin
+                        m_axi_bfm_if.get_read_beat(
+                            .id(axi_id),
+                            .data(beat_data),
+                            .user(beat_user),
+                            .resp(beat_resp)
+                        );
+                        rdata[beat] = beat_data;
+                        ruser[beat] = beat_user;
+                        rresp[beat] = beat_resp;
+                    end
+                    axi_rdata = rdata;
+                    axi_ruser = ruser;
+                    axi_rresp = rresp;
+                end
+                if (axi_read) begin
+                    read <= 1'b1;
+                    m_axi_bfm_if.axi_read(
+                        .addr(axi_addr),
+                        .burst(axi_pkg::axi_burst_e'(axi_burst)),
+                        .len(axi_len),
+                        .id(axi_use_id ? axi_id : $urandom()),
+                        .user(axi_axuser),
+                        .data(axi_rdata),
+                        .resp(axi_rresp),
+                        .resp_user(axi_ruser)
+                    );
+                end
+            join
+        end else begin
+            done <= 1'b1;
+        end
+    end
+
+    always @(posedge core_clk) begin
+        if (axi_put_status) begin
+            if (done) begin
+                if (read && write) // Need to merge the results
+                    // only keep read response user bit
+                    // OR the status, if one is an error, the whole transaction looks like an error
+                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, (axi_rresp.pop_front() || axi_bresp), 1'b1};
+                else if (read)
+                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, axi_rresp.pop_front(), 1'b1};
+                else if (write)// write
+                    generic_input_wires <= {axi_buser, 29'b0, axi_bresp, 1'b1};
+                else if (write_addr)
+                    generic_input_wires <= {63'h0, 1'b1};
+                else if (write_data)
+                    generic_input_wires <= {63'h0, 1'b1};
+                else if (write_resp)
+                    generic_input_wires <= {axi_buser, 29'b0, axi_bresp, 1'b1};
+                else if (read_addr)
+                    generic_input_wires <= {63'h0, 1'b1};
+                else if (read_resp)
+                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, axi_rresp.pop_front(), 1'b1};
+            end else
+                generic_input_wires <= '0;
+        end else if (axi_put_rdata) begin
+            generic_input_wires <= {32'b0, axi_rdata.pop_front()};
+        end
+    end
+
+    always @(posedge core_clk) begin
+        if (inject_mbox_soc_lock_on_mbox_unlock) begin
+            if (`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_csr1.field_combo.mbox_unlock.unlock.load_next &
+                |`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_csr1.field_combo.mbox_unlock.unlock.next) begin
+                m_axi_bfm_if.axi_read_single(
+                    .addr(`CLP_MBOX_CSR_MBOX_LOCK),
+                    .user(32'hFFFF_FFFF),
+                    .data(rdata),
+                    .resp(rresp),
+                    .resp_user(buser)
+                );
+            end
+        end
+    end
+
+    logic[15:0] kv_slot_is_clear [24];
+    generate
+        for(genvar i0=0; i0<24; i0++) begin
+            for(genvar i1=0; i1<16; i1++) begin
+                assign kv_slot_is_clear[i0][i1] = |`CPTRA_TOP_PATH.key_vault1.kv_reg1.field_storage.KEY_ENTRY[i0][i1].data.value;
+            end
+        end
+    endgenerate
+
+    always @(posedge core_clk) begin
+        if (get_uds_value) begin
+            generic_input_wires <= {
+                `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.fuse_uds_seed[(4'(uds_idx) << 1)].seed.value,
+                `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.fuse_uds_seed[(4'(uds_idx) << 1) + 4'h1].seed.value
+            };
+        end
+        if (get_fe_value) begin
+            generic_input_wires <= {
+                `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.fuse_field_entropy[(3'(fe_idx) << 1)].seed.value,
+                `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.fuse_field_entropy[(3'(fe_idx) << 1) + 3'h1].seed.value
+            };
+        end
+        if (check_kv_clear) begin
+            generic_input_wires <= { {48{1'b0}}, kv_slot_is_clear[kv_idx]};
         end
     end
 

--- a/src/integration/tb/caliptra_top_tb_soc_bfm.sv
+++ b/src/integration/tb/caliptra_top_tb_soc_bfm.sv
@@ -884,7 +884,7 @@ import caliptra_top_tb_pkg::*; #(
                 if (read && write) // Need to merge the results
                     // only keep read response user bit
                     // OR the status, if one is an error, the whole transaction looks like an error
-                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, (axi_rresp.pop_front() || axi_bresp), 1'b1};
+                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, (axi_rresp.pop_front() | axi_bresp), 1'b1};
                 else if (read)
                     generic_input_wires <= {axi_ruser.pop_front(), 29'd0, axi_rresp.pop_front(), 1'b1};
                 else if (write)// write

--- a/src/integration/test_suites/libs/soc_access/soc_access.c
+++ b/src/integration/test_suites/libs/soc_access/soc_access.c
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+#include <stddef.h>
+#include "soc_access.h"
+#include "caliptra_defines.h"
+#include "riscv_hw_if.h"
+
+#define AXI_WRITE      0x1
+#define AXI_READ       0x2
+#define AXI_WRITE_ADDR 0x4
+#define AXI_WRITE_DATA 0x8
+#define AXI_WRITE_RESP 0x10
+#define AXI_READ_ADDR  0x20
+#define AXI_READ_RESP  0x40
+#define AXI_USE_ID     0x80
+#define AXI_DEFAULT_MASK 0xF
+#define AXI_DEFAULT_USER 0
+
+
+axi_resp_t soc_access_32(axi_req_t req) {
+    axi_resp_t axi_resp;
+    // Set AXI address
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+
+    // Set AXI burst
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+
+    // Set AXI aXuser
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+
+    if (req.write) {
+        // Clear SoC access queues
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0A7F);
+
+        for (int i = 0; i < req.len; i++) {
+            // Push AXI wdata
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wdata ? req.wdata[i] : 0);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x027F);
+            // Push AXI wuser
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wuser ? req.wuser[i] : AXI_DEFAULT_USER);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x067F);
+            // Push AXI wstrb
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wstrb ? (req.wstrb[i] & 0xF) : 0xF);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x097F);
+        }
+    }
+
+    uint32_t execute = (req.write ? AXI_WRITE : 0) | (req.read ? AXI_READ : 0) | (req.use_id ? AXI_USE_ID : 0) |
+            ((req.len - 1) << 8) | (req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+
+    if (req.ignore_resp)
+        return (axi_resp_t){ .resp = 0, .rdata = 0 };
+
+    while (1) {
+        axi_resp_t axi_resp;
+
+        // Check if AXI has finished
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+
+        if(axi_resp.resp & 1) {
+            axi_resp.resp = (axi_resp.resp >> 1) & 0b11;
+
+            if (req.read) {
+                for (int i = 0; i < req.len; i++) {
+                    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x057F);
+                    uint32_t rdata = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+                    if (i == 0) axi_resp.rdata = rdata;
+                    if (req.rdata) req.rdata[i] = rdata;
+                }
+            }
+            return axi_resp;
+        }
+    }
+}
+
+// intended to be used only after soc_access_32 with .ignore_resp = true
+uint8_t soc_access_await_done() {
+    while(1) {
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        uint8_t resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+        if (resp & 1)
+            return (resp >> 1) & 0b11; 
+    }
+}
+
+uint8_t soc_masked_write_32(uint32_t reg_addr, uint32_t value, uint32_t mask) {
+    axi_resp_t axi_resp;
+
+    axi_resp = soc_access_32((axi_req_t){
+        .addr = reg_addr,
+        .axuser = AXI_DEFAULT_USER,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = true,
+        .read = false,
+        .wuser = (uint32_t[]){AXI_DEFAULT_USER},
+        .wdata = (uint32_t[]){value},
+        .wstrb = (uint8_t[]){mask}
+    });
+
+    return axi_resp.resp;
+}
+
+uint8_t soc_write_user_32(uint32_t reg_addr, uint32_t value, uint32_t user) {
+    axi_resp_t axi_resp;
+
+    axi_resp = soc_access_32((axi_req_t){
+        .addr = reg_addr,
+        .axuser = user,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = true,
+        .read = false,
+        .wuser = (uint32_t[]){user},
+        .wdata = (uint32_t[]){value},
+        .wstrb = (uint8_t[]){AXI_DEFAULT_MASK}
+    });
+
+    return axi_resp.resp;
+}
+
+uint8_t soc_write_32(uint32_t reg_addr, uint32_t value) {
+    return soc_write_user_32(reg_addr, value, AXI_DEFAULT_USER);
+}
+
+axi_resp_t soc_read_user_32(uint32_t reg_addr, uint32_t user) {
+    axi_resp_t axi_resp;
+
+    axi_resp = soc_access_32((axi_req_t){
+        .addr = reg_addr,
+        .axuser = user,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = false,
+        .read = true
+    });
+
+    return axi_resp;
+}
+
+axi_resp_t soc_read_32(uint32_t reg_addr) {
+    return soc_read_user_32(reg_addr, AXI_DEFAULT_USER);
+}
+
+void soc_write_addr(axi_req_t req) {
+    if (!req.write) return;
+    // Set AXI address
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+
+    // Set AXI burst
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+
+    // Set AXI aXuser
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+
+    // Send on AW channel
+    uint32_t execute = AXI_WRITE_ADDR | AXI_USE_ID | ((req.len - 1) << 8) | (req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+}
+
+void soc_write_data(axi_req_t req) {
+    if (!req.write) return;
+    // Clear SoC access queues
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0A7F);
+
+    for (int i = 0; i < req.len; i++) {
+        // Push AXI wdata
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wdata ? req.wdata[i] : 0);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x027F);
+        // Push AXI wuser
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wuser ? req.wuser[i] : AXI_DEFAULT_USER);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x067F);
+        // Push AXI wstrb
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wstrb ? (req.wstrb[i] & 0xF) : 0xF);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x097F);
+    }
+
+    // Send on W channel
+    uint32_t execute = AXI_WRITE_DATA | ((req.len - 1) << 8);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+}
+
+axi_resp_t soc_write_resp(axi_req_t req) {
+    if (!req.write)
+        return (axi_resp_t){ .resp = 0, .rdata = 0 };
+    // Receive from B channel
+    uint32_t execute = AXI_WRITE_RESP | AXI_USE_ID | (req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    while (1) {
+        axi_resp_t axi_resp;
+
+        // Check if AXI has finished
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+
+        if(axi_resp.resp & 1) {
+            axi_resp.resp = (axi_resp.resp >> 1) & 0b11;
+            return axi_resp;
+        }
+    }
+}
+
+void soc_read_addr(axi_req_t req) {
+    if (!req.read) return;
+    // Set AXI address
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+
+    // Set AXI burst
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+
+    // Set AXI aXuser
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+
+    // Send on AR channel
+    uint32_t execute = AXI_READ_ADDR | AXI_USE_ID | ((req.len - 1) << 8) | (req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+
+}
+
+axi_resp_t soc_read_resp(axi_req_t req) {
+    if (!req.read)
+        return (axi_resp_t){ .resp = 0, .rdata = 0 };
+    // Receive from R channel
+    uint32_t execute = AXI_READ_RESP | AXI_USE_ID | ((req.len - 1) << 8) |(req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+
+    while (1) {
+        axi_resp_t axi_resp;
+
+        // Check if AXI has finished
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+
+        if(axi_resp.resp & 1) {
+            axi_resp.resp = (axi_resp.resp >> 1) & 0b11;
+            for (int i = 0; i < req.len; i++) {
+                lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x057F);
+                uint32_t rdata = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+                if (i == 0) axi_resp.rdata = rdata;
+                if (req.rdata) req.rdata[i] = rdata;
+            }
+            return axi_resp;
+        }
+    }
+}

--- a/src/integration/test_suites/libs/soc_access/soc_access.c
+++ b/src/integration/test_suites/libs/soc_access/soc_access.c
@@ -33,37 +33,37 @@ axi_resp_t soc_access_32(axi_req_t req) {
     axi_resp_t axi_resp;
     // Set AXI address
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x01A2);
 
     // Set AXI burst
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x08A2);
 
     // Set AXI aXuser
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x07A2);
 
     if (req.write) {
         // Clear SoC access queues
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0A7F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0AA2);
 
         for (int i = 0; i < req.len; i++) {
             // Push AXI wdata
             lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wdata ? req.wdata[i] : 0);
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x027F);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x02A2);
             // Push AXI wuser
             lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wuser ? req.wuser[i] : AXI_DEFAULT_USER);
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x067F);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x06A2);
             // Push AXI wstrb
             lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wstrb ? (req.wstrb[i] & 0xF) : 0xF);
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x097F);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x09A2);
         }
     }
 
     uint32_t execute = (req.write ? AXI_WRITE : 0) | (req.read ? AXI_READ : 0) | (req.use_id ? AXI_USE_ID : 0) |
             ((req.len - 1) << 8) | (req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 
     if (req.ignore_resp)
         return (axi_resp_t){ .resp = 0, .rdata = 0 };
@@ -72,7 +72,7 @@ axi_resp_t soc_access_32(axi_req_t req) {
         axi_resp_t axi_resp;
 
         // Check if AXI has finished
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x04A2);
         axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
 
         if(axi_resp.resp & 1) {
@@ -80,7 +80,7 @@ axi_resp_t soc_access_32(axi_req_t req) {
 
             if (req.read) {
                 for (int i = 0; i < req.len; i++) {
-                    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x057F);
+                    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x05A2);
                     uint32_t rdata = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
                     if (i == 0) axi_resp.rdata = rdata;
                     if (req.rdata) req.rdata[i] = rdata;
@@ -94,7 +94,7 @@ axi_resp_t soc_access_32(axi_req_t req) {
 // intended to be used only after soc_access_32 with .ignore_resp = true
 uint8_t soc_access_await_done() {
     while(1) {
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x04A2);
         uint8_t resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
         if (resp & 1)
             return (resp >> 1) & 0b11; 
@@ -164,43 +164,43 @@ void soc_write_addr(axi_req_t req) {
     if (!req.write) return;
     // Set AXI address
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x01A2);
 
     // Set AXI burst
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x08A2);
 
     // Set AXI aXuser
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x07A2);
 
     // Send on AW channel
     uint32_t execute = AXI_WRITE_ADDR | AXI_USE_ID | ((req.len - 1) << 8) | (req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 }
 
 void soc_write_data(axi_req_t req) {
     if (!req.write) return;
     // Clear SoC access queues
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0A7F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0AA2);
 
     for (int i = 0; i < req.len; i++) {
         // Push AXI wdata
         lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wdata ? req.wdata[i] : 0);
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x027F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x02A2);
         // Push AXI wuser
         lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wuser ? req.wuser[i] : AXI_DEFAULT_USER);
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x067F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x06A2);
         // Push AXI wstrb
         lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wstrb ? (req.wstrb[i] & 0xF) : 0xF);
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x097F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x09A2);
     }
 
     // Send on W channel
     uint32_t execute = AXI_WRITE_DATA | ((req.len - 1) << 8);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 }
 
 axi_resp_t soc_write_resp(axi_req_t req) {
@@ -209,12 +209,12 @@ axi_resp_t soc_write_resp(axi_req_t req) {
     // Receive from B channel
     uint32_t execute = AXI_WRITE_RESP | AXI_USE_ID | (req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
     while (1) {
         axi_resp_t axi_resp;
 
         // Check if AXI has finished
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x04A2);
         axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
 
         if(axi_resp.resp & 1) {
@@ -228,20 +228,20 @@ void soc_read_addr(axi_req_t req) {
     if (!req.read) return;
     // Set AXI address
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x01A2);
 
     // Set AXI burst
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x08A2);
 
     // Set AXI aXuser
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x07A2);
 
     // Send on AR channel
     uint32_t execute = AXI_READ_ADDR | AXI_USE_ID | ((req.len - 1) << 8) | (req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 
 }
 
@@ -251,19 +251,19 @@ axi_resp_t soc_read_resp(axi_req_t req) {
     // Receive from R channel
     uint32_t execute = AXI_READ_RESP | AXI_USE_ID | ((req.len - 1) << 8) |(req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 
     while (1) {
         axi_resp_t axi_resp;
 
         // Check if AXI has finished
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x04A2);
         axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
 
         if(axi_resp.resp & 1) {
             axi_resp.resp = (axi_resp.resp >> 1) & 0b11;
             for (int i = 0; i < req.len; i++) {
-                lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x057F);
+                lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x05A2);
                 uint32_t rdata = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
                 if (i == 0) axi_resp.rdata = rdata;
                 if (req.rdata) req.rdata[i] = rdata;

--- a/src/integration/test_suites/libs/soc_access/soc_access.h
+++ b/src/integration/test_suites/libs/soc_access/soc_access.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOC_ACCESS_LIB
+#define SOC_ACCESS_LIB
+
+#include <stdbool.h>
+#include "stdint.h"
+
+typedef enum {
+    AXI_BURST_FIXED = 0,
+    AXI_BURST_INCR = 1,
+    AXI_BURST_WRAP = 2
+} axi_burst_t;
+
+typedef struct {
+    uint32_t  rdata;
+    uint8_t   resp;
+} axi_resp_t;
+
+typedef struct {
+    uint32_t addr, axuser;
+    axi_burst_t burst;
+    uint32_t *wdata, *wuser, *rdata;
+    uint8_t *wstrb;
+    uint8_t len;
+    uint8_t id;
+    bool write, read, ignore_resp, use_id;
+} axi_req_t;
+
+axi_resp_t soc_access_32(axi_req_t req);
+uint8_t soc_access_await_done();
+uint8_t soc_masked_write_32(uint32_t reg_addr, uint32_t value, uint32_t mask);
+uint8_t soc_write_user_32(uint32_t reg_addr, uint32_t value, uint32_t user);
+uint8_t soc_write_32(uint32_t reg_addr, uint32_t value);
+axi_resp_t soc_read_user_32(uint32_t reg_addr, uint32_t user);
+axi_resp_t soc_read_32(uint32_t reg_addr);
+void       soc_write_addr(axi_req_t req);
+void       soc_write_data(axi_req_t req);
+axi_resp_t soc_write_resp(axi_req_t req);
+void       soc_read_addr(axi_req_t req);
+axi_resp_t soc_read_resp(axi_req_t req);
+
+#endif /* SOC_ACCESS_LIB */

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.c
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.c
@@ -25,7 +25,7 @@ uint32_t soc_ifc_mbox_read_dataout_single() {
 uint32_t soc_ifc_mbox_dir_read_single(uint32_t rdptr) {
     return lsu_read_32(CLP_MBOX_SRAM_BASE_ADDR + rdptr);
 }
-uint32_t soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata) {
+void soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata) {
     lsu_write_32(CLP_MBOX_SRAM_BASE_ADDR + wrptr, wrdata);
 }
 
@@ -66,6 +66,19 @@ void soc_ifc_set_mbox_status_field(enum mbox_status_e field) {
     reg = lsu_read_32(CLP_MBOX_CSR_MBOX_STATUS);
     reg = (reg & ~MBOX_CSR_MBOX_STATUS_STATUS_MASK) | (field << MBOX_CSR_MBOX_STATUS_STATUS_LOW);
     lsu_write_32(CLP_MBOX_CSR_MBOX_STATUS,reg);
+}
+
+uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_status_e exp_state) {
+    for(uint32_t ii=0; ii<attempt_count; ii++) {
+        if(((lsu_read_32(CLP_MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_MBOX_FSM_PS_MASK) >> MBOX_CSR_MBOX_STATUS_MBOX_FSM_PS_LOW) == exp_state) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+uint32_t soc_ifc_mbox_read_rdptr() {
+    return (lsu_read_32(CLP_MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_MBOX_RDPTR_MASK) >> MBOX_CSR_MBOX_STATUS_MBOX_RDPTR_LOW;
 }
 
 void soc_ifc_set_flow_status_field(uint32_t field) {
@@ -328,20 +341,20 @@ void soc_ifc_sha_accel_clr_lock() {
 }   
 
 // AXI DMA Functions
-uint8_t soc_ifc_axi_dma_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
+void soc_ifc_axi_dma_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
     soc_ifc_axi_dma_arm_send_ahb_payload(dst_addr, fixed, payload, byte_count, block_size);
     soc_ifc_axi_dma_get_send_ahb_payload(payload, byte_count);
     soc_ifc_axi_dma_wait_idle(0);
 }
 
 // AXI DMA Functions
-uint8_t soc_ifc_axi_dma_send_ahb_payload_w_error_expected(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected) {
+void soc_ifc_axi_dma_send_ahb_payload_w_error_expected(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected) {
     soc_ifc_axi_dma_arm_send_ahb_payload(dst_addr, fixed, payload, byte_count, block_size);
     soc_ifc_axi_dma_get_send_ahb_payload(payload, byte_count);
     soc_ifc_axi_dma_wait_idle_w_error_expected(0, error_expected);
 }
 
-uint8_t soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
+void soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
     uint32_t reg;
 
     // Arm the command
@@ -357,7 +370,7 @@ uint8_t soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, u
     lsu_write_32(CLP_AXI_DMA_REG_CTRL, reg);
 }
 
-uint8_t soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_count) {
+void soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_count) {
     uint16_t mdepth;
 
     // Send data
@@ -369,19 +382,19 @@ uint8_t soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_c
     }
 }
 
-uint8_t soc_ifc_axi_dma_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
+void soc_ifc_axi_dma_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
     soc_ifc_axi_dma_arm_read_ahb_payload(src_addr, fixed, payload, byte_count, block_size);
     soc_ifc_axi_dma_get_read_ahb_payload(payload, byte_count);
     soc_ifc_axi_dma_wait_idle(0);
 }
 
-uint8_t soc_ifc_axi_dma_read_ahb_payload_w_error_expected(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected) {
+void soc_ifc_axi_dma_read_ahb_payload_w_error_expected(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected) {
     soc_ifc_axi_dma_arm_read_ahb_payload(src_addr, fixed, payload, byte_count, block_size);
     soc_ifc_axi_dma_get_read_ahb_payload(payload, byte_count);
     soc_ifc_axi_dma_wait_idle_w_error_expected(0, error_expected);
 }
 
-uint8_t soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
+void soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
     uint32_t reg;
 
     // Arm the command
@@ -398,7 +411,7 @@ uint8_t soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, u
 
 }
 
-uint8_t soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_count) {
+void soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_count) {
     uint16_t mdepth;
     // Read data
     mdepth = (lsu_read_32(CLP_AXI_DMA_REG_CAP) & AXI_DMA_REG_CAP_FIFO_MAX_DEPTH_MASK) >> AXI_DMA_REG_CAP_FIFO_MAX_DEPTH_LOW;
@@ -410,6 +423,17 @@ uint8_t soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_c
 }
 
 uint8_t soc_ifc_axi_dma_send_mbox_payload(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size) {
+    uint8_t res;
+
+    res = soc_ifc_axi_dma_send_mbox_payload_no_wait(src_addr, dst_addr, fixed, byte_count, block_size);
+
+    if (res == 0)
+        soc_ifc_axi_dma_wait_idle(1);
+
+    return res;
+}
+
+uint8_t soc_ifc_axi_dma_send_mbox_payload_no_wait(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size) {
     uint32_t reg;
 
     // Acquire the mailbox lock
@@ -444,26 +468,18 @@ uint8_t soc_ifc_axi_dma_send_mbox_payload(uint64_t src_addr, uint64_t dst_addr, 
           (fixed ? AXI_DMA_REG_CTRL_WR_FIXED_MASK : 0);
     lsu_write_32(CLP_AXI_DMA_REG_CTRL, reg);
 
-    // Check completion
-    reg = lsu_read_32(CLP_AXI_DMA_REG_STATUS0);
-    while ((reg & AXI_DMA_REG_STATUS0_BUSY_MASK) && !(reg & AXI_DMA_REG_STATUS0_ERROR_MASK)) {
-        reg = lsu_read_32(CLP_AXI_DMA_REG_STATUS0);
-    }
-
-    // Check status
-    if (reg & AXI_DMA_REG_STATUS0_ERROR_MASK) {
-        VPRINTF(FATAL, "FATAL: AXI DMA reports error status for MBOX-to-AXI xfer\n");
-        lsu_write_32(CLP_AXI_DMA_REG_CTRL, AXI_DMA_REG_CTRL_FLUSH_MASK);
-        SEND_STDOUT_CTRL(0x1);
-    }
-
-    lsu_write_32(CLP_MBOX_CSR_MBOX_UNLOCK, MBOX_CSR_MBOX_UNLOCK_UNLOCK_MASK);
     return 0;
 }
 
 uint8_t soc_ifc_axi_dma_read_mbox_payload(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size) {
-    soc_ifc_axi_dma_read_mbox_payload_no_wait(src_addr, dst_addr, fixed, byte_count, block_size);
-    soc_ifc_axi_dma_wait_idle(1);
+    uint8_t res;
+
+    res = soc_ifc_axi_dma_read_mbox_payload_no_wait(src_addr, dst_addr, fixed, byte_count, block_size);
+
+    if (res == 0)
+        soc_ifc_axi_dma_wait_idle(1);
+
+    return res;
 }
 
 uint8_t soc_ifc_axi_dma_read_mbox_payload_no_wait(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size) {
@@ -504,7 +520,7 @@ uint8_t soc_ifc_axi_dma_read_mbox_payload_no_wait(uint64_t src_addr, uint64_t ds
     return 0;
 }
 
-uint8_t soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_count) {
+void soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_count) {
     uint32_t reg;
     VPRINTF(LOW, "FW: Sending KV to AXI with ERR\n");
     reg = lsu_read_32(CLP_AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R);
@@ -516,13 +532,13 @@ uint8_t soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_co
     lsu_write_32(CLP_AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R, reg | AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R_NOTIF_TXN_DONE_EN_MASK);
 }
 
-uint8_t soc_ifc_axi_dma_send_kv_to_axi(uint64_t dst_addr, uint32_t byte_count) {
+void soc_ifc_axi_dma_send_kv_to_axi(uint64_t dst_addr, uint32_t byte_count) {
     VPRINTF(LOW, "FW: Sending KV to AXI\n");
     soc_ifc_axi_dma_send_kv_to_axi_no_wait(dst_addr, byte_count);
     soc_ifc_axi_dma_wait_idle(0);
 }
 
-uint8_t soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_count) {
+void soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_count) {
     uint32_t reg;
 
     // Arm the command
@@ -537,22 +553,22 @@ uint8_t soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_
 
 }
 
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_error(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
+void soc_ifc_axi_dma_send_axi_to_axi_error(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
     soc_ifc_axi_dma_send_axi_to_axi_no_wait(src_addr, src_fixed, dst_addr, dst_fixed, byte_count, block_size,  aes_mode, aes_gcm_mode);
     soc_ifc_axi_dma_wait_error(0);
 }
 
-uint8_t soc_ifc_axi_dma_send_axi_to_axi(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
+void soc_ifc_axi_dma_send_axi_to_axi(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
     soc_ifc_axi_dma_send_axi_to_axi_no_wait(src_addr, src_fixed, dst_addr, dst_fixed, byte_count, block_size,  aes_mode, aes_gcm_mode);
     soc_ifc_axi_dma_wait_idle(0);
 }
 
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_w_error_expected(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode, uint8_t error_expected) {
+void soc_ifc_axi_dma_send_axi_to_axi_w_error_expected(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode, uint8_t error_expected) {
     soc_ifc_axi_dma_send_axi_to_axi_no_wait(src_addr, src_fixed, dst_addr, dst_fixed, byte_count, block_size,  aes_mode, aes_gcm_mode);
     soc_ifc_axi_dma_wait_idle_w_error_expected(0, error_expected);
 }
 
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
+void soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
     uint32_t reg;
 
     // Arm the command
@@ -574,7 +590,7 @@ uint8_t soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_f
 
 }
 
-uint8_t soc_ifc_axi_dma_wait_idle(uint8_t clr_lock) {
+void soc_ifc_axi_dma_wait_idle(uint8_t clr_lock) {
     uint32_t reg;
 
     // Check completion
@@ -595,7 +611,7 @@ uint8_t soc_ifc_axi_dma_wait_idle(uint8_t clr_lock) {
     }
 }
 
-uint8_t soc_ifc_axi_dma_wait_error(uint8_t clr_lock) {
+void soc_ifc_axi_dma_wait_error(uint8_t clr_lock) {
     uint32_t reg;
 
     // Check completion
@@ -747,7 +763,7 @@ uint8_t soc_ifc_axi_dma_inject_inv_error(enum err_inj_type err_type) {
 }
 
 
-uint8_t soc_ifc_axi_dma_wait_idle_w_error_expected(uint8_t clr_lock, uint8_t error_expected) {
+void soc_ifc_axi_dma_wait_idle_w_error_expected(uint8_t clr_lock, uint8_t error_expected) {
     
     uint32_t reg;
     uint32_t error_observed = 0;

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.c
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.c
@@ -68,7 +68,7 @@ void soc_ifc_set_mbox_status_field(enum mbox_status_e field) {
     lsu_write_32(CLP_MBOX_CSR_MBOX_STATUS,reg);
 }
 
-uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_status_e exp_state) {
+uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_fsm_e exp_state) {
     for(uint32_t ii=0; ii<attempt_count; ii++) {
         if(((lsu_read_32(CLP_MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_MBOX_FSM_PS_MASK) >> MBOX_CSR_MBOX_STATUS_MBOX_FSM_PS_LOW) == exp_state) {
             return 0;

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
@@ -38,8 +38,9 @@ enum mbox_fsm_e {
     MBOX_RDY_FOR_CMD  = 0x1,
     MBOX_RDY_FOR_DATA = 0x2,
     MBOX_RDY_FOR_DLEN = 0x3,
-    MBOX_EXECUTE_UC   = 0x6,
     MBOX_EXECUTE_SOC  = 0x4,
+    MBOX_EXECUTE_TAP  = 0x5,
+    MBOX_EXECUTE_UC   = 0x6,
     MBOX_ERROR        = 0x7
 };
 
@@ -146,10 +147,12 @@ enum sha_accel_mode_e {
 // Simple reg accesses
 uint32_t soc_ifc_mbox_read_dataout_single();
 uint32_t soc_ifc_mbox_dir_read_single(uint32_t rdptr);
-uint32_t soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata);
+void soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata);
 void soc_ifc_clear_execute_reg();
 uint8_t soc_ifc_chk_execute_uc();
 void soc_ifc_set_mbox_status_field(enum mbox_status_e field);
+uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_status_e exp_state);
+uint32_t soc_ifc_mbox_read_rdptr();
 void soc_ifc_set_flow_status_field(uint32_t field);
 void soc_ifc_clr_flow_status_field(uint32_t field);
 void soc_ifc_set_fw_update_reset(uint8_t wait_cycles);
@@ -170,28 +173,29 @@ void soc_ifc_sha_accel_clr_lock();
 void soc_ifc_w1clr_sha_lock_field(uint32_t field);
 
 // AXI DMA Functions
-uint8_t soc_ifc_axi_dma_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_count);
-uint8_t soc_ifc_axi_dma_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_count);
+void soc_ifc_axi_dma_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
+void soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
+void soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_count);
+void soc_ifc_axi_dma_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
+void soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
+void soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_count);
 uint8_t soc_ifc_axi_dma_send_mbox_payload(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size);
+uint8_t soc_ifc_axi_dma_send_mbox_payload_no_wait(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size);
 uint8_t soc_ifc_axi_dma_read_mbox_payload(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size);
 uint8_t soc_ifc_axi_dma_read_mbox_payload_no_wait(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_send_axi_to_axi(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_error(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
-uint8_t soc_ifc_axi_dma_send_kv_to_axi(uint64_t dst_addr, uint32_t byte_count);
-uint8_t soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_count);
-uint8_t soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_count);
-uint8_t soc_ifc_axi_dma_wait_idle      (uint8_t clr_lock);
-uint8_t soc_ifc_axi_dma_wait_error     (uint8_t clr_lock);
+void soc_ifc_axi_dma_send_axi_to_axi(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
+void soc_ifc_axi_dma_send_axi_to_axi_error(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
+void soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
+void soc_ifc_axi_dma_send_kv_to_axi(uint64_t dst_addr, uint32_t byte_count);
+void soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_count);
+void soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_count);
+void soc_ifc_axi_dma_wait_idle      (uint8_t clr_lock);
+void soc_ifc_axi_dma_wait_error     (uint8_t clr_lock);
 uint8_t soc_ifc_axi_dma_inject_inv_error(enum err_inj_type err_type);
 
-uint8_t soc_ifc_axi_dma_read_ahb_payload_w_error_expected(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected);
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_w_error_expected(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode, uint8_t error_expected);
-uint8_t soc_ifc_axi_dma_send_ahb_payload_w_error_expected(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected);
-uint8_t soc_ifc_axi_dma_wait_idle_w_error_expected(uint8_t clr_lock, uint8_t error_expected);
+void soc_ifc_axi_dma_read_ahb_payload_w_error_expected(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected);
+void soc_ifc_axi_dma_send_axi_to_axi_w_error_expected(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode, uint8_t error_expected);
+void soc_ifc_axi_dma_send_ahb_payload_w_error_expected(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected);
+void soc_ifc_axi_dma_wait_idle_w_error_expected(uint8_t clr_lock, uint8_t error_expected);
 
 #endif

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
@@ -151,7 +151,7 @@ void soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata);
 void soc_ifc_clear_execute_reg();
 uint8_t soc_ifc_chk_execute_uc();
 void soc_ifc_set_mbox_status_field(enum mbox_status_e field);
-uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_status_e exp_state);
+uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_fsm_e exp_state);
 uint32_t soc_ifc_mbox_read_rdptr();
 void soc_ifc_set_flow_status_field(uint32_t field);
 void soc_ifc_clr_flow_status_field(uint32_t field);

--- a/src/integration/test_suites/smoke_test_kv_len_mismatch_abr/smoke_test_kv_len_mismatch_abr.c
+++ b/src/integration/test_suites/smoke_test_kv_len_mismatch_abr/smoke_test_kv_len_mismatch_abr.c
@@ -68,7 +68,7 @@ static void fail_test(const char* m){
 }
 
 static inline void kv_inject(uint8_t slot, uint8_t last_dword, uint8_t dest_valid) {
-    uint32_t cmd = 0xa2u
+    uint32_t cmd = 0xa3u
                  | ((uint32_t)(slot & 0x1Fu) << 8)
                  | ((uint32_t)(last_dword & 0xFu) << 13)
                  | ((uint32_t)dest_valid << 17);

--- a/src/integration/test_suites/smoke_test_kv_len_mismatch_aes/smoke_test_kv_len_mismatch_aes.c
+++ b/src/integration/test_suites/smoke_test_kv_len_mismatch_aes/smoke_test_kv_len_mismatch_aes.c
@@ -88,7 +88,7 @@ static void fail_test(const char* m){
 }
 
 static inline void kv_inject(uint8_t slot, uint8_t last_dword, uint8_t dest_valid) {
-    uint32_t cmd = 0xa2u
+    uint32_t cmd = 0xa3u
                  | ((uint32_t)(slot & 0x1Fu) << 8)
                  | ((uint32_t)(last_dword & 0xFu) << 13)
                  | ((uint32_t)dest_valid << 17);

--- a/src/integration/test_suites/smoke_test_kv_len_mismatch_ecc/smoke_test_kv_len_mismatch_ecc.c
+++ b/src/integration/test_suites/smoke_test_kv_len_mismatch_ecc/smoke_test_kv_len_mismatch_ecc.c
@@ -61,7 +61,7 @@ static void fail_test(const char* m){
 }
 
 static inline void kv_inject(uint8_t slot, uint8_t last_dword, uint8_t dest_valid) {
-    uint32_t cmd = 0xa2u
+    uint32_t cmd = 0xa3u
                  | ((uint32_t)(slot & 0x1Fu) << 8)
                  | ((uint32_t)(last_dword & 0xFu) << 13)
                  | ((uint32_t)dest_valid << 17);

--- a/src/integration/test_suites/smoke_test_kv_len_mismatch_hmac/smoke_test_kv_len_mismatch_hmac.c
+++ b/src/integration/test_suites/smoke_test_kv_len_mismatch_hmac/smoke_test_kv_len_mismatch_hmac.c
@@ -76,9 +76,9 @@ static void fail_test(const char* m){
     while(1);
 }
 
-// TB inject cmd 0xa2 — arbitrary slot/last_dword/dest_valid.
+// TB inject cmd 0xa3 — arbitrary slot/last_dword/dest_valid.
 static inline void kv_inject(uint8_t slot, uint8_t last_dword, uint8_t dest_valid) {
-    uint32_t cmd = 0xa2u
+    uint32_t cmd = 0xa3u
                  | ((uint32_t)(slot & 0x1Fu) << 8)
                  | ((uint32_t)(last_dword & 0xFu) << 13)
                  | ((uint32_t)dest_valid << 17);


### PR DESCRIPTION
* Extends testbench infrastructure necessary for the linked PRs
* Adds functionality to drive SoC AXI from the Caliptra FW using the generic
* Connects FE/UDS signals & adds services to access them
* Extends AXI SRAM to allow DMA stressing
* Adds services for injecting errors, simulating concurrent accesses or simulating other edge-cases that are difficult to achieve with regular usage

Logic introduced in this PR is verified mostly within the PRs dependent on it, this PR serves mostly to improve the review process.