### PR TITLE
[VAL] Add register testing infrastructure and ifc_reg tests

### DIFF
--- a/src/axi/rtl/axi_if.sv
+++ b/src/axi/rtl/axi_if.sv
@@ -239,38 +239,14 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             bready  `EQ__ '0;
         endtask
 
-        // TODO: handle IDs?
-        task get_read_beat(output logic [DW-1:0] data,
-                        output logic [UW-1:0] user,
-                        output axi_resp_e     resp);
-            `TIME_ALGN
-            rready `EQ__ 1;
-            do
-                @(posedge clk);
-            while (!rvalid);
-            data   `EQ__ rdata;
-            user   `EQ__ ruser;
-            resp   `EQ__ axi_resp_e'(rresp);
-            `TIME_ALGN
-            rready `EQ__ 0;
-            wait(!rready);
-        endtask
-
-        // Read: default to single beat of native data width
-        task axi_read(input  logic [AW-1:0] addr,
-                    input  axi_burst_e    burst = AXI_BURST_INCR,
-                    input  logic [2:0]    size  = $clog2(DW/8),
-                    input  logic [7:0]    len   = 0,
-                    input  logic [UW-1:0] user  = UW'(0),
-                    input  logic [IW-1:0] id    = IW'(0),
-                    input  logic          lock  = 1'b0,
-                    output logic [DW-1:0] data [],
-                    output logic [UW-1:0] resp_user [],
-                    output axi_resp_e     resp []);
-            axi_resp_e     beat_resp;
-            logic [UW-1:0] beat_user;
-            logic [DW-1:0] beat_data;
-            while(!rst_n) @(posedge clk);
+        task send_read_address(
+                        input  logic [AW-1:0] addr,
+                        input  axi_burst_e    burst = AXI_BURST_INCR,
+                        input  logic [2:0]    size  = $clog2(DW/8),
+                        input  logic [7:0]    len   = 0,
+                        input  logic [UW-1:0] user  = UW'(0),
+                        input  logic [IW-1:0] id    = IW'(0),
+                        input  logic          lock  = 1'b0);
             do begin
                 `TIME_ALGN
                 araddr  `EQ__ addr;
@@ -300,10 +276,57 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             arqos   `EQ__ '0;
             arregion `EQ__ '0;
             arvalid `EQ__ '0;
+        endtask
+
+        task get_read_beat(
+                        input  logic [IW-1:0] id    = IW'(0),
+                        output logic [DW-1:0] data,
+                        output logic [UW-1:0] user,
+                        output axi_resp_e     resp);
+            logic [IW-1:0] resp_id;
+            do begin
+                `TIME_ALGN
+                rready `EQ__ 1;
+                do
+                    @(posedge clk);
+                while (!rvalid);
+                data    `EQ__ rdata;
+                user    `EQ__ ruser;
+                resp    `EQ__ axi_resp_e'(rresp);
+                resp_id `EQ__ rid;
+                `TIME_ALGN
+                rready `EQ__ 0;
+                wait(!rready);
+            end while (id != resp_id);
+        endtask
+
+        // Read: default to single beat of native data width
+        task axi_read(input  logic [AW-1:0] addr,
+                    input  axi_burst_e    burst = AXI_BURST_INCR,
+                    input  logic [2:0]    size  = $clog2(DW/8),
+                    input  logic [7:0]    len   = 0,
+                    input  logic [UW-1:0] user  = UW'(0),
+                    input  logic [IW-1:0] id    = IW'(0),
+                    input  logic          lock  = 1'b0,
+                    input  int            stall = 0,
+                    output logic [DW-1:0] data [],
+                    output logic [UW-1:0] resp_user [],
+                    output axi_resp_e     resp []);
+            axi_resp_e     beat_resp;
+            logic [UW-1:0] beat_user;
+            logic [DW-1:0] beat_data;
+            while(!rst_n) @(posedge clk);
+            send_read_address(addr, burst, size, len, user, id, lock);
             data = new[len+1];
+            resp_user = new[len+1];
             resp = new[len+1];
             for (int beat=0; beat <= len; beat++) begin
-                get_read_beat(beat_data, beat_user, beat_resp);
+                if (stall > 0)
+                    $display($sformatf("[%t] Stalling RREADY for %d clock cycles, AXI id 0x%x", $time, stall, id));
+                repeat (stall) begin
+                    @(posedge clk);
+                end
+                get_read_beat(id, beat_data, beat_user, beat_resp);
                 data[beat]      = beat_data;
                 resp_user[beat] = beat_user;
                 resp[beat]      = beat_resp;
@@ -311,6 +334,7 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
         endtask
 
         task axi_read_single(input  logic [AW-1:0] addr,
+                            input  logic [2:0]    size  = $clog2(DW/8),
                             input  logic [UW-1:0] user  = UW'(0),
                             input  logic [IW-1:0] id    = IW'(0),
                             input  logic          lock  = 1'b0,
@@ -320,7 +344,8 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             automatic axi_resp_e     burst_resp[];
             automatic logic [UW-1:0] burst_ruser[];
             automatic logic [DW-1:0] burst_data[];
-            axi_read(.addr     (addr       ),
+            axi_read(.addr    (addr       ),
+                    .size     (size       ),
                     .user     (user       ),
                     .id       (id         ),
                     .lock     (lock       ),
@@ -332,58 +357,13 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             resp      = burst_resp[0];
         endtask
 
-        task send_write_beat(input logic last,
-                            input logic [DW-1:0] data,
-                            input logic [UW-1:0] user,
-                            input logic [DW/8-1:0] strb);
-            `TIME_ALGN
-            wvalid `EQ__ 1;
-            wlast  `EQ__ last;
-            wdata  `EQ__ data;
-            wstrb  `EQ__ strb;
-            wuser  `EQ__ user;
-            do
-                @(posedge clk);
-            while (!wready);
-            `TIME_ALGN
-            wvalid `EQ__ '0;
-            wlast  `EQ__ '0;
-            wdata  `EQ__ '0;
-            wstrb  `EQ__ '0;
-            wuser  `EQ__ '0;
-            wait(!wvalid);
-        endtask
-
-        // TODO handle ID
-        task get_write_resp(output axi_resp_e     resp,
-                            output logic [UW-1:0] user);
-            `TIME_ALGN
-            bready `EQ__ 1;
-            do
-                @(posedge clk);
-            while(!bvalid);
-            resp `EQ__ axi_resp_e'(bresp);
-            user `EQ__ buser;
-            `TIME_ALGN
-            bready `EQ__ 0;
-            wait(!bready);
-        endtask
-
-        task axi_write(input  logic [AW-1:0]   addr,
+        task send_write_addr(input  logic [AW-1:0]   addr,
                     input  axi_burst_e      burst = AXI_BURST_INCR,
                     input  logic [2:0]      size  = $clog2(DW/8),
                     input  logic [7:0]      len   = 0,
                     input  logic [UW-1:0]   user  = UW'(0),
                     input  logic [IW-1:0]   id    = IW'(0),
-                    input  logic            lock  = 1'b0,
-                    input  logic [DW-1:0]   data [],
-                    input  logic            use_strb = 0,
-                    input  logic [DW/8-1:0] strb [],
-                    input  logic            use_write_user = 0,
-                    input  logic [UW-1:0]   write_user [],
-                    output axi_resp_e       resp,
-                    output logic [UW-1:0]   resp_user);
-            while(!rst_n) @(posedge clk);
+                    input  logic            lock  = 1'b0);
             do begin
                 `TIME_ALGN
                 awaddr  `EQ__ addr;
@@ -413,10 +393,77 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
             awqos   `EQ__ '0;
             awregion `EQ__ '0;
             awvalid `EQ__ '0;
+        endtask
+
+        task send_write_beat(input logic last,
+                            input logic [DW-1:0] data,
+                            input logic [UW-1:0] user,
+                            input logic [DW/8-1:0] strb);
+            `TIME_ALGN
+            wvalid `EQ__ 1;
+            wlast  `EQ__ last;
+            wdata  `EQ__ data;
+            wstrb  `EQ__ strb;
+            wuser  `EQ__ user;
+            do
+                @(posedge clk);
+            while (!wready);
+            `TIME_ALGN
+            wvalid `EQ__ '0;
+            wlast  `EQ__ '0;
+            wdata  `EQ__ '0;
+            wstrb  `EQ__ '0;
+            wuser  `EQ__ '0;
+            wait(!wvalid);
+        endtask
+
+        task get_write_resp(input  logic [IW-1:0] id    = IW'(0),
+                            output axi_resp_e     resp,
+                            output logic [UW-1:0] user);
+            logic [IW-1:0] resp_id;
+            do begin
+                `TIME_ALGN
+                bready `EQ__ 1;
+                do
+                    @(posedge clk);
+                while(!bvalid);
+                resp    `EQ__ axi_resp_e'(bresp);
+                user    `EQ__ buser;
+                resp_id `EQ__ bid;
+                `TIME_ALGN
+                bready `EQ__ 0;
+                wait(!bready);
+            end while(resp_id != id);
+        endtask
+
+        task axi_write(input  logic [AW-1:0]   addr,
+                    input  axi_burst_e      burst = AXI_BURST_INCR,
+                    input  logic [2:0]      size  = $clog2(DW/8),
+                    input  logic [7:0]      len   = 0,
+                    input  logic [UW-1:0]   user  = UW'(0),
+                    input  logic [IW-1:0]   id    = IW'(0),
+                    input  logic            lock  = 1'b0,
+                    input  logic [DW-1:0]   data [],
+                    input  logic            use_strb = 0,
+                    input  logic [DW/8-1:0] strb [],
+                    input  logic            use_write_user = 0,
+                    input  logic [UW-1:0]   write_user [],
+                    input  int unsigned     stall = 0,
+                    output axi_resp_e       resp,
+                    output logic [UW-1:0]   resp_user);
+            while(!rst_n) @(posedge clk);
+            send_write_addr(addr, burst, size, len, user, id, lock);
             fork
                 for (int beat=0; beat <= len; beat++)
                     send_write_beat(beat == len, data[beat], use_write_user ? write_user[beat] : UW'(0), use_strb ? strb[beat] : {DW/8{1'b1}});
-                get_write_resp(resp, resp_user);
+                begin
+                    if (stall > 0)
+                        $display($sformatf("[%t] Stalling BREADY for %d clock cycles, AXI id 0x%x", $time, stall, id));
+                    repeat (stall) begin
+                        @(posedge clk);
+                    end
+                    get_write_resp(id, resp, resp_user);
+                end
             join
         endtask
 

--- a/src/axi/rtl/axi_if.sv
+++ b/src/axi/rtl/axi_if.sv
@@ -201,7 +201,30 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
 
     `ifndef SYNTHESIS
     `ifndef XCELIUM
+        typedef struct packed {
+            logic [DW-1:0] data;
+            logic [UW-1:0] user;
+            axi_resp_e     resp;
+            logic          last;
+        } axi_read_beat_t;
+
+        typedef struct packed {
+            logic [UW-1:0] user;
+            axi_resp_e     resp;
+        } axi_write_resp_t;
+
+        localparam int unsigned AxiIDCount = 2**IW;
+        axi_read_beat_t  pending_read_beat [AxiIDCount][$];
+        axi_write_resp_t pending_write_resp[AxiIDCount][$];
+        semaphore read_response_lock  = new(1);
+        semaphore write_response_lock = new(1);
+
         task rst_mgr();
+            for (int unsigned id = 0; id < AxiIDCount; id++) begin
+                pending_read_beat[id].delete();
+                pending_write_resp[id].delete();
+            end
+
             araddr  `EQ__ '0;
             arburst `EQ__ AXI_BURST_FIXED;
             arsize  `EQ__ '0;
@@ -283,21 +306,33 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
                         output logic [DW-1:0] data,
                         output logic [UW-1:0] user,
                         output axi_resp_e     resp);
+            axi_read_beat_t beat;
             logic [IW-1:0] resp_id;
-            do begin
-                `TIME_ALGN
-                rready `EQ__ 1;
-                do
-                    @(posedge clk);
-                while (!rvalid);
-                data    `EQ__ rdata;
-                user    `EQ__ ruser;
-                resp    `EQ__ axi_resp_e'(rresp);
-                resp_id `EQ__ rid;
-                `TIME_ALGN
-                rready `EQ__ 0;
-                wait(!rready);
-            end while (id != resp_id);
+            read_response_lock.get(1);
+            if (pending_read_beat[int'(id)].size() != 0) begin
+                beat = pending_read_beat[int'(id)].pop_front();
+            end else begin
+                do begin
+                    `TIME_ALGN
+                    rready `EQ__ 1;
+                    do
+                        @(posedge clk);
+                    while (!rvalid);
+                    beat.data = rdata;
+                    beat.user = ruser;
+                    beat.resp = axi_resp_e'(rresp);
+                    beat.last = rlast;
+                    resp_id   = rid;
+                    `TIME_ALGN
+                    rready `EQ__ 0;
+                    wait(!rready);
+                    if (resp_id != id) pending_read_beat[int'(resp_id)].push_back(beat);
+                end while (resp_id != id);
+            end
+            read_response_lock.put(1);
+            data = beat.data;
+            user = beat.user;
+            resp = beat.resp;
         endtask
 
         // Read: default to single beat of native data width
@@ -420,20 +455,31 @@ interface axi_if #(parameter integer AW = 32, parameter integer DW = 32, paramet
         task get_write_resp(input  logic [IW-1:0] id    = IW'(0),
                             output axi_resp_e     resp,
                             output logic [UW-1:0] user);
+            axi_write_resp_t write_resp;
             logic [IW-1:0] resp_id;
-            do begin
-                `TIME_ALGN
-                bready `EQ__ 1;
-                do
-                    @(posedge clk);
-                while(!bvalid);
-                resp    `EQ__ axi_resp_e'(bresp);
-                user    `EQ__ buser;
-                resp_id `EQ__ bid;
-                `TIME_ALGN
-                bready `EQ__ 0;
-                wait(!bready);
-            end while(resp_id != id);
+            write_response_lock.get(1);
+            if (pending_write_resp[int'(id)].size() != 0) begin
+                write_resp = pending_write_resp[int'(id)].pop_front();
+            end else begin
+                do begin
+                    `TIME_ALGN
+                    bready `EQ__ 1;
+                    do
+                        @(posedge clk);
+                    while (!bvalid);
+                    write_resp.resp = axi_resp_e'(bresp);
+                    write_resp.user = buser;
+                    resp_id         = bid;
+                    `TIME_ALGN
+                    bready `EQ__ 0;
+                    wait(!bready);
+                    if (resp_id != id) pending_write_resp[int'(resp_id)].push_back(write_resp);
+                end while (resp_id != id);
+            end
+
+            write_response_lock.put(1);
+            resp = write_resp.resp;
+            user = write_resp.user;
         endtask
 
         task axi_write(input  logic [AW-1:0]   addr,

--- a/src/integration/asserts/caliptra_top_sva.sv
+++ b/src/integration/asserts/caliptra_top_sva.sv
@@ -345,7 +345,7 @@ module caliptra_top_sva
   endgenerate
 
   generate
-    for(genvar dword = 0; dword < KV_NUM_DWORDS; dword++) begin
+    for(genvar dword = 0; dword < KV_NUM_DWORDS; dword++) begin : KV_check
       if (dword < MLDSA_SEED_NUM_DWORDS) begin
       //mldsa seed read
       kv_mldsa_seed_r_flow:   assert property (

--- a/src/integration/stimulus/testsuites/caliptra_top_nightly_directed_regression.yml
+++ b/src/integration/stimulus/testsuites/caliptra_top_nightly_directed_regression.yml
@@ -25,6 +25,17 @@ contents:
         - ${CALIPTRA_ROOT}/src/integration/test_suites/memCpy_dccm_to_iccm/memCpy_dccm_to_iccm.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/hello_world_iccm/hello_world_iccm.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/iccm_lock/iccm_lock.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_intr_test/ifc_reg_intr_test.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_invalid_access/ifc_reg_invalid_access.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_ro_reg_rand_test/ifc_reg_ro_reg_rand_test.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.yml
+        - ${CALIPTRA_ROOT}/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/c_intr_handler/c_intr_handler.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_ecc_keygen/smoke_test_ecc_keygen.yml
         - ${CALIPTRA_ROOT}/src/integration/test_suites/smoke_test_ecc_sign/smoke_test_ecc_sign.yml

--- a/src/integration/tb/caliptra_top_tb.sv
+++ b/src/integration/tb/caliptra_top_tb.sv
@@ -158,7 +158,7 @@ module caliptra_top_tb (
     logic [ 3:0] wstrb[$];
     logic [ 1:0] burst;
     logic        use_id;
-    logic        id;
+    logic [ 7:0] id;
     logic        write;
     logic        write_addr;
     logic        write_data;

--- a/src/integration/tb/caliptra_top_tb.sv
+++ b/src/integration/tb/caliptra_top_tb.sv
@@ -61,13 +61,17 @@ module caliptra_top_tb (
     logic                       recovery_data_avail;
 
     logic [`CLP_OBF_KEY_DWORDS-1:0][31:0]          cptra_obf_key;
-    
+
     logic [`CLP_CSR_HMAC_KEY_DWORDS-1:0][31:0]     cptra_csr_hmac_key;
 
     logic [0:`CLP_OBF_UDS_DWORDS-1][31:0]          cptra_uds_rand;
     logic [0:`CLP_OBF_FE_DWORDS-1][31:0]           cptra_fe_rand;
     logic [0:OCP_LOCK_HEK_NUM_DWORDS-1][31:0]      cptra_hek_rand;
     logic [0:`CLP_OBF_KEY_DWORDS-1][31:0]          cptra_obf_key_tb;
+    logic [`CLP_OBF_UDS_DWORDS-1:0][31:0]          cptra_uds_strap;
+    logic                                          cptra_uds_strap_vld;
+    logic [`CLP_OBF_FE_DWORDS-1:0] [31:0]          cptra_fe_strap;
+    logic                                          cptra_fe_strap_vld;
 
     //jtag interface
     logic                       jtag_tck;    // JTAG clk
@@ -140,6 +144,51 @@ module caliptra_top_tb (
     logic deassert_hard_rst_flag;
     logic assert_rst_flag_from_service;
     logic deassert_rst_flag_from_service;
+    logic route_fatal_to_nmi;
+
+    // Custom event injection
+    logic inject_mbox_soc_lock_on_mbox_unlock;
+
+    //AXI
+    logic [31:0] address;
+    logic [31:0] axuser;
+    logic [31:0] wuser[$];
+    logic [31:0] wdata[$];
+    logic [ 7:0] len;
+    logic [ 3:0] wstrb[$];
+    logic [ 1:0] burst;
+    logic        use_id;
+    logic        id;
+    logic        write;
+    logic        write_addr;
+    logic        write_data;
+    logic        write_resp;
+    logic        read;
+    logic        read_addr;
+    logic        read_resp;
+    logic        put_status;
+    logic        put_rdata;
+
+    logic [31:0] obf_key_value;
+    logic  [2:0] obf_key_idx;
+    logic        set_obf_key;
+    logic        get_obf_key;
+
+
+    // UDS access
+    logic       get_uds_value;
+    logic [2:0] uds_idx;
+
+    // FE access
+    logic       get_fe_value;
+    logic [1:0] fe_idx;
+
+    // KV check cleared
+    logic        check_kv_clear;
+    logic [4:0]  kv_idx;
+
+    //Control singlas
+    logic debug_intent;
 
     el2_mem_if el2_mem_export ();
     abr_mem_if abr_memory_export();
@@ -162,6 +211,10 @@ caliptra_top_tb_soc_bfm soc_bfm_inst (
     .cycleCnt        (cycleCnt        ),
 
     .cptra_obf_key      (cptra_obf_key   ),
+    .cptra_uds_strap    (cptra_uds_strap    ),
+    .cptra_uds_strap_vld(cptra_uds_strap_vld),
+    .cptra_fe_strap     (cptra_fe_strap     ),
+    .cptra_fe_strap_vld (cptra_fe_strap_vld ),
     .cptra_csr_hmac_key (cptra_csr_hmac_key),
 
     .strap_ss_key_release_key_size,
@@ -200,8 +253,49 @@ caliptra_top_tb_soc_bfm soc_bfm_inst (
     .assert_hard_rst_flag(assert_hard_rst_flag),
     .deassert_hard_rst_flag(deassert_hard_rst_flag),
     .assert_rst_flag_from_service(assert_rst_flag_from_service),
-    .deassert_rst_flag_from_service(deassert_rst_flag_from_service)
+    .deassert_rst_flag_from_service(deassert_rst_flag_from_service),
 
+    .route_fatal_to_nmi(route_fatal_to_nmi),
+
+    // Custom event injection
+    .inject_mbox_soc_lock_on_mbox_unlock(inject_mbox_soc_lock_on_mbox_unlock),
+
+    //AXI SoC
+    .axi_addr(address),
+    .axi_axuser(axuser),
+    .axi_wuser(wuser),
+    .axi_wdata(wdata),
+    .axi_len(len),
+    .axi_wstrb(wstrb),
+    .axi_burst(burst),
+    .axi_use_id(use_id),
+    .axi_id(id),
+    .axi_write(write),
+    .axi_write_addr(write_addr),
+    .axi_write_data(write_data),
+    .axi_write_resp(write_resp),
+    .axi_read(read),
+    .axi_read_addr(read_addr),
+    .axi_read_resp(read_resp),
+    .axi_put_status(put_status),
+    .axi_put_rdata(put_rdata),
+
+    .obf_key_value(obf_key_value),
+    .obf_key_idx(obf_key_idx),
+    .set_obf_key(set_obf_key),
+    .get_obf_key(get_obf_key),
+
+    // UDS access
+    .get_uds_value(get_uds_value),
+    .uds_idx(uds_idx),
+
+    // FE access
+    .get_fe_value(get_fe_value),
+    .fe_idx(fe_idx),
+
+    // KV check cleared
+    .check_kv_clear(check_kv_clear),
+    .kv_idx(kv_idx)
 );
     
 // JTAG DPI
@@ -228,10 +322,10 @@ caliptra_top caliptra_top_dut (
     .clk                        (core_clk),
 
     .cptra_obf_key              (cptra_obf_key),
-    .cptra_obf_uds_seed_vld     ('0), //validated at caliptra-ss
-    .cptra_obf_uds_seed         ('0), //validated at caliptra-ss
-    .cptra_obf_field_entropy_vld('0), //validated at caliptra-ss
-    .cptra_obf_field_entropy    ('0), //validated at caliptra-ss
+    .cptra_obf_uds_seed_vld     (cptra_uds_strap_vld),
+    .cptra_obf_uds_seed         (cptra_uds_strap),
+    .cptra_obf_field_entropy_vld(cptra_fe_strap_vld),
+    .cptra_obf_field_entropy    (cptra_fe_strap),
     .cptra_csr_hmac_key         (cptra_csr_hmac_key),
 
     .jtag_tck(jtag_tck),
@@ -311,7 +405,7 @@ caliptra_top caliptra_top_dut (
     .strap_ss_strap_generic_1                               (strap_ss_strap_generic_1),
     .strap_ss_strap_generic_2                               (strap_ss_strap_generic_2),
     .strap_ss_strap_generic_3                               (strap_ss_strap_generic_3),
-    .ss_debug_intent                                        ( 1'b0),
+    .ss_debug_intent                                        (debug_intent),
 
     // Subsystem mode constant strap input indicating OCP LOCK configuration is enabled
     .ss_ocp_lock_en                                         (ss_ocp_lock_en),
@@ -441,6 +535,9 @@ caliptra_top_tb_services #(
     .cycleCnt(cycleCnt),
     .axi_complex_ctrl(axi_complex_ctrl),
 
+    // Custom event injection
+    .inject_mbox_soc_lock_on_mbox_unlock(inject_mbox_soc_lock_on_mbox_unlock),
+
     //Interrupt flags
     .int_flag(int_flag),
     .cycleCnt_smpl_en(cycleCnt_smpl_en),
@@ -451,11 +548,53 @@ caliptra_top_tb_services #(
 
     .assert_rst_flag(assert_rst_flag_from_service),
     .deassert_rst_flag(deassert_rst_flag_from_service),
-    
+
+    .route_fatal_to_nmi(route_fatal_to_nmi),
+
     .cptra_uds_tb(cptra_uds_rand),
     .cptra_fe_tb(cptra_fe_rand),
     .cptra_obf_key_tb(cptra_obf_key_tb),
     .cptra_hek_tb(cptra_hek_rand),
+
+    //AXI SoC
+    .axi_addr(address),
+    .axi_axuser(axuser),
+    .axi_wuser(wuser),
+    .axi_wdata(wdata),
+    .axi_len(len),
+    .axi_wstrb(wstrb),
+    .axi_burst(burst),
+    .axi_use_id(use_id),
+    .axi_id(id),
+    .axi_write(write),
+    .axi_write_addr(write_addr),
+    .axi_write_data(write_data),
+    .axi_write_resp(write_resp),
+    .axi_read(read),
+    .axi_read_addr(read_addr),
+    .axi_read_resp(read_resp),
+    .axi_put_status(put_status),
+    .axi_put_rdata(put_rdata),
+
+    .obf_key_value(obf_key_value),
+    .obf_key_idx(obf_key_idx),
+    .set_obf_key(set_obf_key),
+    .get_obf_key(get_obf_key),
+
+    // UDS access
+    .get_uds_value(get_uds_value),
+    .uds_idx(uds_idx),
+
+    // FE access
+    .get_fe_value(get_fe_value),
+    .fe_idx(fe_idx),
+
+    // KV check cleared
+    .check_kv_clear(check_kv_clear),
+    .kv_idx(kv_idx),
+
+    //Control signals
+    .debug_intent(debug_intent),
 
     .axi_error_inj_en(axi_error_inj_en)
 

--- a/src/integration/tb/caliptra_top_tb_axi_complex.sv
+++ b/src/integration/tb/caliptra_top_tb_axi_complex.sv
@@ -672,7 +672,9 @@ module caliptra_top_tb_axi_complex import caliptra_top_tb_pkg::*; (
         .en_recovery_emulation(ctrl.en_recovery_emulation),
         .recovery_data_avail  (recovery_data_avail       ),
         .dma_gen_done         (ctrl.dma_gen_done         ),
-        .dma_gen_block_size   (ctrl.dma_gen_block_size   )
+        .dma_gen_block_size   (ctrl.dma_gen_block_size   ),
+        .inject_rd_error      (ctrl.fifo_rd_error        ),
+        .inject_wr_error      (ctrl.fifo_wr_error        )
     );
 
     // --------------------- REG Endpoint TODO ---------------------

--- a/src/integration/tb/caliptra_top_tb_axi_fifo.sv
+++ b/src/integration/tb/caliptra_top_tb_axi_fifo.sv
@@ -38,7 +38,9 @@ module caliptra_top_tb_axi_fifo #(
     input  logic en_recovery_emulation,
     output logic recovery_data_avail,
     input  logic dma_gen_done,
-    input  logic [99:0] [11:0] dma_gen_block_size
+    input  logic [99:0] [11:0] dma_gen_block_size,
+    input  logic inject_rd_error,
+    input  logic inject_wr_error
 );
 
     // --------------------------------------- //
@@ -113,8 +115,8 @@ module caliptra_top_tb_axi_fifo #(
     `CALIPTRA_ASSERT(AXI_FIFO_WR_FIXED_ONLY, s_axi_w_if.awvalid && s_axi_w_if.awready |-> s_axi_w_if.awburst == AXI_BURST_FIXED, clk, !rst_n)
     `CALIPTRA_ASSERT(AXI_FIFO_RD_FIXED_ONLY, s_axi_r_if.arvalid && s_axi_r_if.arready |-> s_axi_r_if.arburst == AXI_BURST_FIXED, clk, !rst_n)
 
-    assign rd_error = 1'b0;
-    assign wr_error = 1'b0;
+    assign rd_error = inject_rd_error;
+    assign wr_error = inject_wr_error;
 
     // --------------------------------------- //
     // Data FIFO                               //

--- a/src/integration/tb/caliptra_top_tb_pkg.sv
+++ b/src/integration/tb/caliptra_top_tb_pkg.sv
@@ -81,6 +81,8 @@ typedef struct packed {
     logic en_recovery_emulation;
     logic dma_gen_done;
     logic [99:0] [11:0] dma_gen_block_size;
+    logic fifo_rd_error;
+    logic fifo_wr_error;
 } axi_complex_ctrl_t;
 
 // Transfer types enum
@@ -105,10 +107,11 @@ localparam DMA_ERROR_OBSERVED              = 32'hfadebadd;
 localparam ERROR_NONE_SET                  = 32'hba5eba11; /* default value for a test with no activity observed by TB */
 
 // AXI SRAM config
-localparam AXI_SRAM_SIZE_BYTES   = 262144;
+localparam AXI_SRAM_SIZE_BYTES   = 1048576;
 localparam AXI_SRAM_ADDR_WIDTH   = $clog2(AXI_SRAM_SIZE_BYTES);
 localparam AXI_SRAM_DEPTH        = AXI_SRAM_SIZE_BYTES / (CPTRA_AXI_DMA_DATA_WIDTH/8);
-localparam logic [`CALIPTRA_AXI_DMA_ADDR_WIDTH-1:0] AXI_SRAM_BASE_ADDR = `CALIPTRA_AXI_DMA_ADDR_WIDTH'h0001_2344_0000; 
+localparam logic [`CALIPTRA_AXI_DMA_ADDR_WIDTH-1:0] AXI_SRAM_BASE_ADDR = `CALIPTRA_AXI_DMA_ADDR_WIDTH'h0001_2340_0000; 
+
 
 // AXI FIFO config
 localparam AXI_FIFO_SIZE_BYTES   = 65536;

--- a/src/integration/tb/caliptra_top_tb_services.sv
+++ b/src/integration/tb/caliptra_top_tb_services.sv
@@ -398,94 +398,6 @@ module caliptra_top_tb_services
     //         8'h2 : 8'h5  - Do nothing
     //         8'h6 : 8'h7E - WriteData is an ASCII character - dump to console.log
     //         8'h7F        - Switch to MANUF device lifecycle state
-    //      16'h017F        - Setup SoC Access address from CPTRA_GENERIC_OUTPUT_WIRES[1]
-    //      16'h027F        - Push SoC Access wdata from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wdata queue
-    //      16'h037F        - Send SoC access
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][0]     - write transaction
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][1]     - read transaction
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][2]     - write address only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][3]     - write data only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][4]     - write response only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][5]     - read address only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][6]     - read response only
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][7]     - use operation ID, random otherwise
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][15:8]  - AXLEN
-    //          CPTRA_GENERIC_OUTPUT_WIRES[1][23:16] - Operation ID
-    //          If partial transfers are used, only one can be executed at any
-    //          given time, and it cannot be combined with full transfer.
-    //          ID must be specified and correct for partial transfers,
-    //          otherwise BFM will lockup
-    //      16'h047F        - Get SoC Access status, 0-In progress, 1-Done
-    //      16'h057F        - Pop SoC Access read response onto generic_input_wires
-    //      16'h067F        - Push SoC Access wuser from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wuser queue
-    //      16'h077F        - Setup SoC Access aXuser from CPTRA_GENERIC_OUTPUT_WIRES[1]
-    //      16'h087F        - Setup SoC Access burst from CPTRA_GENERIC_OUTPUT_WIRES[1]: (0)fixed, (1,default)incr, (2)wrap
-    //      16'h097F        - Push SoC Access wstrb from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wstrb queue
-    //      16'h0A7F        - Clear SoC Access wdata, wuser and wstrb queues
-    //      16'h0D7F        - Force DMI enable (OpenOCD requires JTAG to be active to correctly examine device)
-    //      16'h0E7F        - Set route_fatal_to_nmi
-    //      16'h0F7F        - Clear route_fatal_to_nmi
-    //      16'h107F        - Force re-enable strap write
-    //      16'h117F        - Release strap write
-    //      16'h127F        - Enable debug intent
-    //      16'h137F        - Disable debug intent
-    //      16'h147F        - Switch to Manufacturing mode
-    //      16'h157F        - Switch to Production mode
-    //      16'h167F        - Force ss_debug intent
-    //      16'h177F        - Release ss_debug intent
-    //      16'h187F        - Switch to debug unlocked
-    //      16'h197F        - Switch to debug locked
-    //      16'h1A7F        - Force re-enable fuse write
-    //      16'h1B7F        - Force unlock caliptra security state
-    //      16'h1C7F        - Release unlock caliptra security state
-    //      16'h1D7F        - Force override mailbox pointer reset value to CPTRA_GENERIC_OUTPUT_WIRES[1]
-    //      16'h1E7F        - Release override mailbox pointer reset value
-    //      16'h1F7F        - Switch to Unprovisioned mode
-    //      16'h207F        - Get UDS[0] and UDS[1] value from HW
-    //      16'h217F        - Get UDS[2] and UDS[3] value from HW
-    //      16'h227F        - Get UDS[4] and UDS[5] value from HW
-    //      16'h237F        - Get UDS[6] and UDS[7] value from HW
-    //      16'h247F        - Get UDS[8] and UDS[9] value from HW
-    //      16'h257F        - Get UDS[10] and UDS[11] value from HW
-    //      16'h267F        - Get UDS[12] and UDS[13] value from HW
-    //      16'h277F        - Get UDS[14] and UDS[15] value from HW
-    //      16'h307F        - Get FE[0] and FE[1] value from HW
-    //      16'h317F        - Get FE[2] and FE[3] value from HW
-    //      16'h327F        - Get FE[4] and FE[5] value from HW
-    //      16'h337F        - Get FE[6] and FE[7] value from HW
-    //      16'h407F        - Set OBF_KEY[0] value from generic wire 1
-    //      16'h417F        - Set OBF_KEY[1] value from generic wire 1
-    //      16'h427F        - Set OBF_KEY[2] value from generic wire 1
-    //      16'h437F        - Set OBF_KEY[3] value from generic wire 1
-    //      16'h447F        - Set OBF_KEY[4] value from generic wire 1
-    //      16'h457F        - Set OBF_KEY[5] value from generic wire 1
-    //      16'h467F        - Set OBF_KEY[6] value from generic wire 1
-    //      16'h477F        - Set OBF_KEY[7] value from generic wire 1
-    //      16'h487F        - Get OBF_KEY[0] value from HW
-    //      16'h497F        - Get OBF_KEY[1] value from HW
-    //      16'h4A7F        - Get OBF_KEY[2] value from HW
-    //      16'h4B7F        - Get OBF_KEY[3] value from HW
-    //      16'h4C7F        - Get OBF_KEY[4] value from HW
-    //      16'h4D7F        - Get OBF_KEY[5] value from HW
-    //      16'h4E7F        - Get OBF_KEY[6] value from HW
-    //      16'h4F7F        - Set OBF_KEY[7] value from HW
-    //      16'h507F        - Enable injection of single mailbox access request from SoC when TAP locks mailbox
-    //      16'h517F        - Disable injection of single mailbox access request from SoC when TAP locks mailbox
-    //      16'h527F        - Inject FIFO AXI read errors
-    //      16'h537F        - Inject FIFO AXI write errors
-    //      16'h547F        - Stop injecting FIFO AXI read errors
-    //      16'h557F        - Stop injecting FIFO AXI write errors
-    //      16'h567F        - Kill kv_hmac_tag_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
-    //      16'h577F        - Kill kv_ecc_privkey_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
-    //      16'h587F        - Enable injection of single mailbox lock request from TAP when FW locks mailbox
-    //      16'h597F        - Disable injection of single mailbox lock request from TAP when FW locks mailbox
-    //      16'h5A7F        - Enable injection of single mailbox lock request from SoC when mailbox is being unlocked
-    //      16'h5B7F        - Disable injection of single mailbox lock request from SoC when mailbox is being unlocked
-    //      16'h5C7F        - Enable injection of mailbox unlock when FW accesses mailbox SRAM directly
-    //      16'h5D7F        - Disable injection of mailbox unlock when FW accesses mailbox SRAM directly
-    //      16'h807F:'h9F7F - Inject a valid hmac_key dest and hmac512_key into Nth kv slot (where slot is encoded as (N & 0x1F) << 8)
-    //      16'hA07F:'hBF7F - Check if Nth kv slot (where slot is encoded as (N & 0x1F) << 8) is all zero
-    //      16'hC07F        - Force clear of all KV slots, when DOE FSM starts to write
     //         8'h80: 8'h87 - Inject ECC_SEED to kv_key register
     //         8'h88        - Toggle recovery interface emulation in AXI complex
     //         8'h89        - Use same msg in SHA512 digest for ECC/MLDSA PCR signing (used where both cryptos are running in parallel)
@@ -512,8 +424,96 @@ module caliptra_top_tb_services
     //         8'h9f        - Inject AES key into KV
     //         8'ha0        - Inject HMAC384_KEY to kv_key register
     //         8'ha1        - Inject zero as MLDSA_SEED/MLKEM_MSG to kv_key register (8 dwords)
-    //         8'ha2        - Randomizable KV inject: slot=[12:8], last_dword=[16:13], dest_valid=[24:17]
-    //         8'ha3: 8'ha7 - Unused
+    //         8'ha2        - RESERVED (used by 16-bit commands)
+    //      16'h01A2        - Setup SoC Access address from CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h02A2        - Push SoC Access wdata from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wdata queue
+    //      16'h03A2        - Send SoC access
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][0]     - write transaction
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][1]     - read transaction
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][2]     - write address only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][3]     - write data only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][4]     - write response only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][5]     - read address only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][6]     - read response only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][7]     - use operation ID, random otherwise
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][15:8]  - AXLEN
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][23:16] - Operation ID
+    //          If partial transfers are used, only one can be executed at any
+    //          given time, and it cannot be combined with full transfer.
+    //          ID must be specified and correct for partial transfers,
+    //          otherwise BFM will lockup
+    //      16'h04A2        - Get SoC Access status, 0-In progress, 1-Done
+    //      16'h05A2        - Pop SoC Access read response onto generic_input_wires
+    //      16'h06A2        - Push SoC Access wuser from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wuser queue
+    //      16'h07A2        - Setup SoC Access aXuser from CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h08A2        - Setup SoC Access burst from CPTRA_GENERIC_OUTPUT_WIRES[1]: (0)fixed, (1,default)incr, (2)wrap
+    //      16'h09A2        - Push SoC Access wstrb from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wstrb queue
+    //      16'h0AA2        - Clear SoC Access wdata, wuser and wstrb queues
+    //      16'h0DA2        - Force DMI enable (OpenOCD requires JTAG to be active to correctly examine device)
+    //      16'h0EA2        - Set route_fatal_to_nmi
+    //      16'h0FA2        - Clear route_fatal_to_nmi
+    //      16'h10A2        - Force re-enable strap write
+    //      16'h11A2        - Release strap write
+    //      16'h12A2        - Enable debug intent
+    //      16'h13A2        - Disable debug intent
+    //      16'h15A2        - Switch to Production mode
+    //      16'h16A2        - Force ss_debug intent
+    //      16'h17A2        - Release ss_debug intent
+    //      16'h18A2        - Switch to debug unlocked
+    //      16'h19A2        - Switch to debug locked
+    //      16'h1AA2        - Force re-enable fuse write
+    //      16'h1BA2        - Force unlock caliptra security state
+    //      16'h1CA2        - Release unlock caliptra security state
+    //      16'h1DA2        - Force override mailbox pointer reset value to CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h1EA2        - Release override mailbox pointer reset value
+    //      16'h1FA2        - Switch to Unprovisioned mode
+    //      16'h20A2        - Get UDS[0] and UDS[1] value from HW
+    //      16'h21A2        - Get UDS[2] and UDS[3] value from HW
+    //      16'h22A2        - Get UDS[4] and UDS[5] value from HW
+    //      16'h23A2        - Get UDS[6] and UDS[7] value from HW
+    //      16'h24A2        - Get UDS[8] and UDS[9] value from HW
+    //      16'h25A2        - Get UDS[10] and UDS[11] value from HW
+    //      16'h26A2        - Get UDS[12] and UDS[13] value from HW
+    //      16'h27A2        - Get UDS[14] and UDS[15] value from HW
+    //      16'h30A2        - Get FE[0] and FE[1] value from HW
+    //      16'h31A2        - Get FE[2] and FE[3] value from HW
+    //      16'h32A2        - Get FE[4] and FE[5] value from HW
+    //      16'h33A2        - Get FE[6] and FE[7] value from HW
+    //      16'h40A2        - Set OBF_KEY[0] value from generic wire 1
+    //      16'h41A2        - Set OBF_KEY[1] value from generic wire 1
+    //      16'h42A2        - Set OBF_KEY[2] value from generic wire 1
+    //      16'h43A2        - Set OBF_KEY[3] value from generic wire 1
+    //      16'h44A2        - Set OBF_KEY[4] value from generic wire 1
+    //      16'h45A2        - Set OBF_KEY[5] value from generic wire 1
+    //      16'h46A2        - Set OBF_KEY[6] value from generic wire 1
+    //      16'h47A2        - Set OBF_KEY[7] value from generic wire 1
+    //      16'h48A2        - Get OBF_KEY[0] value from HW
+    //      16'h49A2        - Get OBF_KEY[1] value from HW
+    //      16'h4AA2        - Get OBF_KEY[2] value from HW
+    //      16'h4BA2        - Get OBF_KEY[3] value from HW
+    //      16'h4CA2        - Get OBF_KEY[4] value from HW
+    //      16'h4DA2        - Get OBF_KEY[5] value from HW
+    //      16'h4EA2        - Get OBF_KEY[6] value from HW
+    //      16'h4FA2        - Set OBF_KEY[7] value from HW
+    //      16'h50A2        - Enable injection of single mailbox access request from SoC when TAP locks mailbox
+    //      16'h51A2        - Disable injection of single mailbox access request from SoC when TAP locks mailbox
+    //      16'h52A2        - Inject FIFO AXI read errors
+    //      16'h53A2        - Inject FIFO AXI write errors
+    //      16'h54A2        - Stop injecting FIFO AXI read errors
+    //      16'h55A2        - Stop injecting FIFO AXI write errors
+    //      16'h56A2        - Kill kv_hmac_tag_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
+    //      16'h57A2        - Kill kv_ecc_privkey_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
+    //      16'h58A2        - Enable injection of single mailbox lock request from TAP when FW locks mailbox
+    //      16'h59A2        - Disable injection of single mailbox lock request from TAP when FW locks mailbox
+    //      16'h5AA2        - Enable injection of single mailbox lock request from SoC when mailbox is being unlocked
+    //      16'h5BA2        - Disable injection of single mailbox lock request from SoC when mailbox is being unlocked
+    //      16'h5CA2        - Enable injection of mailbox unlock when FW accesses mailbox SRAM directly
+    //      16'h5DA2        - Disable injection of mailbox unlock when FW accesses mailbox SRAM directly
+    //      16'h80A2:'h9FA2 - Inject a valid hmac_key dest and hmac512_key into Nth kv slot (where slot is encoded as (N & 0x1F) << 8)
+    //      16'hA0A2:'hBFA2 - Check if Nth kv slot (where slot is encoded as (N & 0x1F) << 8) is all zero
+    //      16'hC0A2        - Force clear of all KV slots, when DOE FSM starts to write
+    //         8'ha3        - Randomizable KV inject: slot=[12:8], last_dword=[16:13], dest_valid=[24:17]
+    //         8'ha4: 8'ha7 - Unused
     //         8'ha8        - Inject zero as HMAC_KEY/MLKEM_SEED to kv_key register (16 dwords)
     //         8'ha9        - Inject HMAC512_KEY to kv_key register
     //         8'haa        - Inject HMAC512_BLOCK to kv_key16 register
@@ -620,11 +620,11 @@ module caliptra_top_tb_services
         axi_put_status <= 1'b0;
         axi_use_id     <= 1'b0;
         axi_put_rdata <= 1'b0;
-        if ((WriteData[15:0] == 16'h017F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h01A2) && mailbox_write) begin
             axi_addr <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
-        end else if ((WriteData[15:0] == 16'h027F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h02A2) && mailbox_write) begin
             axi_wdata.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
-        end else if ((WriteData[15:0] == 16'h037F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h03A2) && mailbox_write) begin
             axi_write      <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][0];
             axi_read       <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][1];
             axi_write_addr <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][2];
@@ -635,19 +635,19 @@ module caliptra_top_tb_services
             axi_use_id     <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][7];
             axi_len        <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][15:8];
             axi_id         <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][23:16];
-        end else if ((WriteData[15:0] == 16'h047F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h04A2) && mailbox_write) begin
             axi_put_status <= 1'b1;
-        end else if ((WriteData[15:0] == 16'h057F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h05A2) && mailbox_write) begin
             axi_put_rdata <= 1'b1;
-        end else if ((WriteData[15:0] == 16'h067F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h06A2) && mailbox_write) begin
             axi_wuser.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
-        end else if ((WriteData[15:0] == 16'h077F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h07A2) && mailbox_write) begin
             axi_axuser <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
-        end else if ((WriteData[15:0] == 16'h087F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h08A2) && mailbox_write) begin
             axi_burst <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
-        end else if ((WriteData[15:0] == 16'h097F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h09A2) && mailbox_write) begin
             axi_wstrb.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
-        end else if ((WriteData[15:0] == 16'h0A7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h0AA2) && mailbox_write) begin
             axi_wdata = {};
             axi_wuser = {};
             axi_wstrb = {};
@@ -656,14 +656,14 @@ module caliptra_top_tb_services
 
     //  Fuse re-enable access
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h107F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h10A2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value = 1'h0;
             force `CPTRA_TOP_PATH.soc_ifc_top1.strap_we = 1'h1;
             repeat (10) @(negedge clk);
             release `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value;
-        end else if ((WriteData[15:0] == 16'h117F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h11A2) && mailbox_write) begin
             release `CPTRA_TOP_PATH.soc_ifc_top1.strap_we;
-        end else if ((WriteData[15:0] == 16'h1A7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h1AA2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value = 1'h0;
             repeat (10) @(negedge clk);
             release `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value;
@@ -671,7 +671,7 @@ module caliptra_top_tb_services
     end
 
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h0D7F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h0DA2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.rvtop.dmi_core_enable = 1'h1;
             $display("Force enable JTAG/DMI to be active");
         end
@@ -682,35 +682,35 @@ module caliptra_top_tb_services
         route_fatal_to_nmi = 1'b0;
     end
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h0E7F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h0EA2) && mailbox_write) begin
             route_fatal_to_nmi <= 1'b1;
             force `CPTRA_TOP_PATH.nmi_int = `CPTRA_TOP_PATH.cptra_error_fatal;
             $display("Route fatal error to nmi pin");
-        end else if ((WriteData[15:0] == 16'h0F7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h0FA2) && mailbox_write) begin
             route_fatal_to_nmi <= 1'b0;
             release `CPTRA_TOP_PATH.nmi_int;
             $display("Return NMI to normal use");
         end
     end
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h127F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h12A2) && mailbox_write) begin
             debug_intent <= 1'b1;
             $display("Enabling debug_intent");
-        end else if ((WriteData[15:0] == 16'h137F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h13A2) && mailbox_write) begin
             debug_intent <= 1'b0;
             $display("Disabling debug_intent");
         end
     end
 
     always @(negedge clk) begin
-        if ((WriteData[15:0] == 16'h167F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h16A2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.soc_ifc_top1.soc_ifc_reg_hwif_in.SS_DEBUG_INTENT.debug_intent.next = 1'h1;
-        end else if ((WriteData[15:0] == 16'h177F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h17A2) && mailbox_write) begin
             release `CPTRA_TOP_PATH.soc_ifc_top1.soc_ifc_reg_hwif_in.SS_DEBUG_INTENT.debug_intent.next;
         end
-        if ((WriteData[15:0] == 16'h1B7F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h1BA2) && mailbox_write) begin
             force `CPTRA_TOP_PATH.unlock_caliptra_security_state = 1'h1;
-        end else if ((WriteData[15:0] == 16'h1C7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h1CA2) && mailbox_write) begin
             release `CPTRA_TOP_PATH.unlock_caliptra_security_state;
         end
     end
@@ -718,7 +718,7 @@ module caliptra_top_tb_services
     // Prevent from setting ptr reset value to mailboxes max capacity
     `CALIPTRA_ASSERT_NEVER(
         no_mbox_ptr_rst_value_override_full_capacity,
-        (WriteData[15:0] == 16'h1D7F) && mailbox_write &&
+        (WriteData[15:0] == 16'h1DA2) && mailbox_write &&
         (`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1] == 32'hFFFFFFFF),
         !clk, cptra_rst_b
     )
@@ -728,12 +728,12 @@ module caliptra_top_tb_services
             force_mbox_ptr_reset_value <= 0;
             release_mbox_ptr_reset_value <= 0;
         end
-        if ((WriteData[15:0] == 16'h1D7F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h1DA2) && mailbox_write) begin
             $display("Force MBOX pointers reset value to %x\n", `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
             mbox_ptr_reset_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
             force_mbox_ptr_reset_value <= 1;
             release_mbox_ptr_reset_value <= 0;
-        end else if ((WriteData[15:0] == 16'h1E7F) && mailbox_write) begin
+        end else if ((WriteData[15:0] == 16'h1EA2) && mailbox_write) begin
             $display("Release MBOX pointers reset value\n");
             force_mbox_ptr_reset_value <= 0;
             release_mbox_ptr_reset_value <= 1;
@@ -745,7 +745,7 @@ module caliptra_top_tb_services
             get_uds_value <= 1'b0;
             uds_idx <= 3'h0;
         end
-        else if ((WriteData[15:0] inside {16'h207F, 16'h217F, 16'h227F, 16'h237F, 16'h247F, 16'h257F, 16'h267F, 16'h277F}) && mailbox_write) begin
+        else if ((WriteData[15:0] inside {16'h20A2, 16'h21A2, 16'h22A2, 16'h23A2, 16'h24A2, 16'h25A2, 16'h26A2, 16'h27A2}) && mailbox_write) begin
             get_uds_value <= 1'b1;
             uds_idx <= WriteData[10:8];
         end else begin
@@ -758,7 +758,7 @@ module caliptra_top_tb_services
             get_fe_value <= 1'b0;
             fe_idx <= 2'h0;
         end
-        else if ((WriteData[15:0] inside {16'h307F, 16'h317F, 16'h327F, 16'h337F}) && mailbox_write) begin
+        else if ((WriteData[15:0] inside {16'h30A2, 16'h31A2, 16'h32A2, 16'h33A2}) && mailbox_write) begin
             get_fe_value <= 1'b1;
             fe_idx <= WriteData[9:8];
         end else begin
@@ -771,12 +771,12 @@ module caliptra_top_tb_services
             set_obf_key <= 1'b0;
             get_obf_key <= 1'b0;
         end
-        else if ((WriteData[15:0] & 16'hF8FF) == 16'h407F  && mailbox_write) begin
+        else if ((WriteData[15:0] & 16'hF8FF) == 16'h40A2  && mailbox_write) begin
             set_obf_key   <= 1'b1;
             obf_key_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
             obf_key_idx   <= WriteData[10:8];
         end
-        else if ((WriteData[15:0] & 16'hF8FF) == 16'h487F  && mailbox_write) begin
+        else if ((WriteData[15:0] & 16'hF8FF) == 16'h48A2  && mailbox_write) begin
             get_obf_key   <= 1'b1;
             obf_key_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
             obf_key_idx   <= WriteData[10:8];
@@ -790,10 +790,10 @@ module caliptra_top_tb_services
         if (!cptra_rst_b) begin
             inject_mbox_soc_req_on_tap_lock <= 1'b0;
         end
-        else if ((WriteData[15:0] == 16'h507F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h50A2) && mailbox_write) begin
             inject_mbox_soc_req_on_tap_lock <= 1'b1;
         end
-        else if ((WriteData[15:0] == 16'h517F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h51A2) && mailbox_write) begin
             inject_mbox_soc_req_on_tap_lock <= 1'b0;
         end
     end
@@ -802,10 +802,10 @@ module caliptra_top_tb_services
         if (!cptra_rst_b) begin
             inject_mbox_tap_lock_read_on_fw_lock <= 1'b0;
         end
-        else if ((WriteData[15:0] == 16'h587F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h58A2) && mailbox_write) begin
             inject_mbox_tap_lock_read_on_fw_lock <= 1'b1;
         end
-        else if ((WriteData[15:0] == 16'h597F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h59A2) && mailbox_write) begin
             inject_mbox_tap_lock_read_on_fw_lock <= 1'b0;
         end
     end
@@ -814,10 +814,10 @@ module caliptra_top_tb_services
         if (!cptra_rst_b) begin
             inject_mbox_soc_lock_on_mbox_unlock <= 1'b0;
         end
-        else if ((WriteData[15:0] == 16'h5A7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h5AA2) && mailbox_write) begin
             inject_mbox_soc_lock_on_mbox_unlock <= 1'b1;
         end
-        else if ((WriteData[15:0] == 16'h5B7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h5BA2) && mailbox_write) begin
             inject_mbox_soc_lock_on_mbox_unlock <= 1'b0;
         end
     end
@@ -826,10 +826,10 @@ module caliptra_top_tb_services
         if (!cptra_rst_b) begin
             inject_mbox_unlock_on_dir_acc <= 1'b0;
         end
-        else if ((WriteData[15:0] == 16'h5C7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h5CA2) && mailbox_write) begin
             inject_mbox_unlock_on_dir_acc <= 1'b1;
         end
-        else if ((WriteData[15:0] == 16'h5D7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h5DA2) && mailbox_write) begin
             inject_mbox_unlock_on_dir_acc <= 1'b0;
         end
     end
@@ -918,11 +918,7 @@ module caliptra_top_tb_services
 
     initial ras_test_ctrl.error_injection_seen = 1'b0;
     always @(negedge clk) begin
-<<<<<<< HEAD
-        if (mailbox_write && WriteData[7:0] inside {8'hfd, 8'h95}) begin
-=======
         if (mailbox_write && WriteData[7:0] inside {8'he5, 8'he6, 8'hfd, 8'hfe}) begin
->>>>>>> 3c19526ab (Extend TB & services)
             ras_test_ctrl.error_injection_seen <= 1'b1;
         end
     end
@@ -965,16 +961,16 @@ module caliptra_top_tb_services
         else if((WriteData[7:0] == 8'h8f) && mailbox_write) begin
             axi_complex_ctrl.rand_delays    <= ~axi_complex_ctrl.rand_delays; // Toggle option
         end
-        else if((WriteData[15:0] == 16'h527F) && mailbox_write) begin
+        else if((WriteData[15:0] == 16'h52A2) && mailbox_write) begin
             axi_complex_ctrl.fifo_rd_error  <= 1'b1;
         end
-        else if((WriteData[15:0] == 16'h537F) && mailbox_write) begin
+        else if((WriteData[15:0] == 16'h53A2) && mailbox_write) begin
             axi_complex_ctrl.fifo_wr_error  <= 1'b1;
         end
-        else if((WriteData[15:0] == 16'h547F) && mailbox_write) begin
+        else if((WriteData[15:0] == 16'h54A2) && mailbox_write) begin
             axi_complex_ctrl.fifo_rd_error  <= 1'b0;
         end
-        else if((WriteData[15:0] == 16'h557F) && mailbox_write) begin
+        else if((WriteData[15:0] == 16'h55A2) && mailbox_write) begin
             axi_complex_ctrl.fifo_wr_error  <= 1'b0;
         end
         else begin
@@ -1029,7 +1025,7 @@ module caliptra_top_tb_services
                         kv_idx <= '0;
                         check_kv_clear <= '0;
                     end
-                    else if(((WriteData[15:0] & 16'hE07F) == 16'hA07F) && mailbox_write) begin
+                    else if(((WriteData[15:0] & 16'hE0A2) == 16'hA0A2) && mailbox_write) begin
                         kv_idx <= (WriteData[15:0] & 16'h1F00) >> 8;
                         check_kv_clear <= '1;
                     end else begin
@@ -1043,7 +1039,7 @@ module caliptra_top_tb_services
     always @(negedge clk) begin
         if (!cptra_rst_b) begin
             timed_kv_clear <= '0;
-        end else if (WriteData[15:0] == 16'hC07F) begin
+        end else if (WriteData[15:0] == 16'hC0A2) begin
             timed_kv_clear <= '1;
         end else begin
             timed_kv_clear <= '0;
@@ -1077,7 +1073,7 @@ module caliptra_top_tb_services
     always @(negedge clk) begin
         if (!cptra_rst_b) begin
             hmac_tag_mismatch_kill <= '0;
-        end else if (WriteData[15:0] == 16'h567F) begin
+        end else if (WriteData[15:0] == 16'h56A2) begin
             hmac_tag_mismatch_kill <= '1;
         end else begin
             hmac_tag_mismatch_kill <= '0;
@@ -1110,7 +1106,7 @@ module caliptra_top_tb_services
     always @(negedge clk) begin
         if (!cptra_rst_b) begin
             ecc_privkey_mismatch_kill <= '0;
-        end else if (WriteData[15:0] == 16'h577F) begin
+        end else if (WriteData[15:0] == 16'h57A2) begin
             ecc_privkey_mismatch_kill <= '1;
         end else begin
             ecc_privkey_mismatch_kill <= '0;
@@ -1146,7 +1142,7 @@ module caliptra_top_tb_services
             for (genvar dword_i=0; dword_i < 16; dword_i++) begin : inject_dword_loop
                 always @(negedge clk) begin
                     //inject valid hmac_key dest and hmac512_key value to key reg (but extend the mask to permit all 24 kv slots)
-                    if(((WriteData[15:0] & 16'hE07F) == 16'h807F) && mailbox_write) begin
+                    if(((WriteData[15:0] & 16'hE0A2) == 16'h80A2) && mailbox_write) begin
                         inject_mldsa_seed <= 1'b1;
                         if ((((WriteData[15:0] & 16'h1F00) >> 8) == slot_id)) begin
                             force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.we = 1'b1;
@@ -1267,8 +1263,8 @@ module caliptra_top_tb_services
                         end
                     end
                     //Randomizable KV inject for length-mismatch tests.
-                    //Encoding: WriteData[7:0]=0xa2, [12:8]=slot, [16:13]=last_dword, [24:17]=dest_valid.
-                    else if((WriteData[7:0] == 8'ha2) && mailbox_write) begin
+                    //Encoding: WriteData[7:0]=0xa3, [12:8]=slot, [16:13]=last_dword, [24:17]=dest_valid.
+                    else if((WriteData[7:0] == 8'ha3) && mailbox_write) begin
                         release_kv_inject_flags <= '0;
                         if (WriteData[12:8] == slot_id) begin
                             force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.we = 1'b1;
@@ -1696,17 +1692,6 @@ module caliptra_top_tb_services
 
     //TIE-OFF device lifecycle
     logic assert_ss_tran;
-<<<<<<< HEAD
-`ifdef CALIPTRA_DEBUG_UNLOCKED
-    initial security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4False}; // DebugUnlocked & Production
-`else
-    initial begin
-        if ($test$plusargs("CALIPTRA_DEBUG_UNLOCKED"))
-            security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4False}; // DebugUnlocked & Production
-        else
-            security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4True}; // DebugLocked & Production
-=======
->>>>>>> 3c19526ab (Extend TB & services)
 
     initial begin
         if (!$test$plusargs("CALIPTRA_DEBUG_UNLOCKED")) begin
@@ -1746,18 +1731,13 @@ module caliptra_top_tb_services
     end
 
     always @(negedge clk) begin
-        //Switch to Manufacturing mode mode
-        if ((WriteData[15:0] == 16'h147F) && mailbox_write) begin
-            security_state.device_lifecycle <= DEVICE_MANUFACTURING;
-            $display("Setting lifecycle to DEVICE_MANUFACTURING\n");
-        end
         //Switch to Production mode mode
-        else if ((WriteData[15:0] == 16'h157F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h15A2) && mailbox_write) begin
             security_state.device_lifecycle <= DEVICE_PRODUCTION;
             $display("Setting lifecycle to DEVICE_PRODUCTION\n");
         end
         //Switch to Unprovisioned mode mode
-        else if ((WriteData[15:0] == 16'h1F7F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h1FA2) && mailbox_write) begin
             security_state.device_lifecycle <= DEVICE_UNPROVISIONED;
             $display("Setting lifecycle to DEVICE_UNPROVISIONED\n");
         end
@@ -1765,12 +1745,12 @@ module caliptra_top_tb_services
 
     always @(negedge clk) begin
         //Switch to debug unlocked
-        if ((WriteData[15:0] == 16'h187F) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h18A2) && mailbox_write) begin
             security_state.debug_locked <= 1'b0;
             $display("Setting debug_locked to 0");
         end
         //Switch to debug locked
-        else if ((WriteData[15:0] == 16'h197F) && mailbox_write) begin
+        else if ((WriteData[15:0] == 16'h19A2) && mailbox_write) begin
             security_state.debug_locked <= 1'b1;
             $display("Setting debug_locked to 1");
         end

--- a/src/integration/tb/caliptra_top_tb_services.sv
+++ b/src/integration/tb/caliptra_top_tb_services.sv
@@ -218,6 +218,7 @@ module caliptra_top_tb_services
     logic                       timed_warm_rst;
     logic                       timed_kv_clear;
     logic                       timed_kv_clear_done;
+    logic                       kv_clear_force;
     logic                       hmac_tag_mismatch_kill;
     logic                       ecc_privkey_mismatch_kill;
     logic                       prandom_warm_rst;
@@ -1016,25 +1017,18 @@ module caliptra_top_tb_services
         end
     end
 
-    generate
-        // Check if n-th KV slot is zeroed
-        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : kv_check_zero_slot_loop
-            for (genvar dword_i=0; dword_i < 16; dword_i++) begin : kv_check_zero_dword_loop
-                always @(negedge clk or negedge cptra_rst_b) begin
-                    if (!cptra_rst_b) begin
-                        kv_idx <= '0;
-                        check_kv_clear <= '0;
-                    end
-                    else if(((WriteData[15:0] & 16'hE0A2) == 16'hA0A2) && mailbox_write) begin
-                        kv_idx <= (WriteData[15:0] & 16'h1F00) >> 8;
-                        check_kv_clear <= '1;
-                    end else begin
-                        check_kv_clear <= '0;
-                    end
-                end
-            end
+     // Check if n-th KV slot is zeroed
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            kv_idx <= '0;
+            check_kv_clear <= '0;
+        end else if (((WriteData[15:0] & 16'hE0A2) == 16'hA0A2) && mailbox_write) begin
+            kv_idx <= (WriteData[15:0] & 16'h1F00) >> 8;
+            check_kv_clear <= '1;
+        end else begin
+            check_kv_clear <= '0;
         end
-    endgenerate
+    end
 
     always @(negedge clk) begin
         if (!cptra_rst_b) begin
@@ -1046,25 +1040,29 @@ module caliptra_top_tb_services
         end
     end
 
+    assign kv_clear_force = timed_kv_clear && (`CPTRA_TOP_PATH.doe.doe_inst.doe_fsm1.kv_doe_fsm_ns == 3'b100) && !timed_kv_clear_done;
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            timed_kv_clear_done <= '0;
+        end else if (kv_clear_force) begin
+            $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[0].DOE_FE_data_check);
+            $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[1].DOE_FE_data_check);
+            $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[2].DOE_FE_data_check);
+            $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[3].DOE_FE_data_check);
+            timed_kv_clear_done <= '1;
+        end
+    end
+
     generate
-        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : kv_timed_clear_loop
+        for (genvar slot_id = 0; slot_id < 24; slot_id++) begin : kv_timed_clear_loop
             always @(negedge clk or negedge cptra_rst_b) begin
                 if (!cptra_rst_b) begin
-                    timed_kv_clear_done <= '0;
-                end else if (timed_kv_clear) begin
-                    if((`CPTRA_TOP_PATH.doe.doe_inst.doe_fsm1.kv_doe_fsm_ns == 3'b100) & ~timed_kv_clear_done) begin
-                        // Need to kill off assertion that checks whether output matches plaintext (it won't since it got cleared)
-                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[0].DOE_FE_data_check);
-                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[1].DOE_FE_data_check);
-                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[2].DOE_FE_data_check);
-                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[3].DOE_FE_data_check);
-                        force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value = '1;
-                        timed_kv_clear_done <= 'b1;
-                    end else if(timed_kv_clear_done) begin
-                        release `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value;
-                    end
-                end else begin
-                    timed_kv_clear <= '0;
+                    release `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value;
+                end else if (kv_clear_force) begin
+                    force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value = '1;
+                end else if (timed_kv_clear_done) begin
+                    release `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value;
                 end
             end
         end
@@ -1732,7 +1730,7 @@ module caliptra_top_tb_services
 
     always @(negedge clk) begin
         //Switch to Production mode mode
-        else if ((WriteData[15:0] == 16'h15A2) && mailbox_write) begin
+        if ((WriteData[15:0] == 16'h15A2) && mailbox_write) begin
             security_state.device_lifecycle <= DEVICE_PRODUCTION;
             $display("Setting lifecycle to DEVICE_PRODUCTION\n");
         end

--- a/src/integration/tb/caliptra_top_tb_services.sv
+++ b/src/integration/tb/caliptra_top_tb_services.sv
@@ -510,7 +510,6 @@ module caliptra_top_tb_services
     //      16'h5BA2        - Disable injection of single mailbox lock request from SoC when mailbox is being unlocked
     //      16'h5CA2        - Enable injection of mailbox unlock when FW accesses mailbox SRAM directly
     //      16'h5DA2        - Disable injection of mailbox unlock when FW accesses mailbox SRAM directly
-    //      16'h80A2:'h9FA2 - Inject a valid hmac_key dest and hmac512_key into Nth kv slot (where slot is encoded as (N & 0x1F) << 8)
     //      16'hA0A2:'hBFA2 - Check if Nth kv slot (where slot is encoded as (N & 0x1F) << 8) is all zero
     //      16'hC0A2        - Force clear of all KV slots, when DOE FSM starts to write
     //         8'ha3        - Randomizable KV inject: slot=[12:8], last_dword=[16:13], dest_valid=[24:17]
@@ -1139,20 +1138,8 @@ module caliptra_top_tb_services
         for (genvar slot_id=0; slot_id < 24; slot_id++) begin : inject_slot_loop
             for (genvar dword_i=0; dword_i < 16; dword_i++) begin : inject_dword_loop
                 always @(negedge clk) begin
-                    //inject valid hmac_key dest and hmac512_key value to key reg (but extend the mask to permit all 24 kv slots)
-                    if(((WriteData[15:0] & 16'hE0A2) == 16'h80A2) && mailbox_write) begin
-                        inject_mldsa_seed <= 1'b1;
-                        if ((((WriteData[15:0] & 16'h1F00) >> 8) == slot_id)) begin
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.we = 1'b1;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.next = 5'b100;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].last_dword.we = 1'b1;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].last_dword.next = 'd7;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_ENTRY[slot_id][dword_i].data.we = 1'b1;
-                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_ENTRY[slot_id][dword_i].data.next = hmac512_key_tb[dword_i][31 : 0];
-                        end
-                    end
                     //inject valid seed dest and seed value to key reg
-                    else if(((WriteData[7:0] & 8'hf8) == 8'h80) && mailbox_write) begin
+                    if(((WriteData[7:0] & 8'hf8) == 8'h80) && mailbox_write) begin
                         release_kv_inject_flags <= '0;
                         //$system("/home/mojtabab/workspace_aha_poc/ws1/Caliptra/src/ecc/tb/ecdsa_secp384r1.exe");
                         inject_ecc_seed <= 1'b1;

--- a/src/integration/tb/caliptra_top_tb_services.sv
+++ b/src/integration/tb/caliptra_top_tb_services.sv
@@ -39,6 +39,7 @@ module caliptra_top_tb_services
     import kv_defines_pkg::*;
     import caliptra_top_tb_pkg::*;
     import caliptra_prim_mubi_pkg::*;
+    import axi_pkg::*;
 #(
     parameter UVM_TB = 0
 ) (
@@ -73,6 +74,9 @@ module caliptra_top_tb_services
     output int   cycleCnt,
     output var   axi_complex_ctrl_t axi_complex_ctrl,
 
+    // Custom event injection
+    output logic inject_mbox_soc_lock_on_mbox_unlock,
+
     //Interrupt flags
     output logic int_flag,
     output logic cycleCnt_smpl_en,
@@ -82,11 +86,52 @@ module caliptra_top_tb_services
     output logic assert_rst_flag,
     output logic deassert_hard_rst_flag,
     output logic deassert_rst_flag,
+    output logic route_fatal_to_nmi,
 
     output logic [0:`CLP_OBF_UDS_DWORDS-1][31:0] cptra_uds_tb,
     output logic [0:`CLP_OBF_FE_DWORDS-1] [31:0] cptra_fe_tb,
     output logic [0:`CLP_OBF_KEY_DWORDS-1][31:0] cptra_obf_key_tb,
     output logic [0:OCP_LOCK_HEK_NUM_DWORDS-1] [31:0] cptra_hek_tb,
+
+    // AXI SoC access
+    output logic [31:0] axi_addr,
+    output logic [31:0] axi_axuser,
+    ref    logic [31:0] axi_wuser[$],
+    ref    logic [31:0] axi_wdata[$],
+    output logic [ 7:0] axi_len,
+    ref    logic [ 3:0] axi_wstrb[$],
+    output logic [ 1:0] axi_burst,
+    output logic        axi_use_id,
+    output logic [ 7:0] axi_id,
+    output logic        axi_write,
+    output logic        axi_write_addr,
+    output logic        axi_write_data,
+    output logic        axi_write_resp,
+    output logic        axi_read,
+    output logic        axi_read_addr,
+    output logic        axi_read_resp,
+    output logic        axi_put_status,
+    output logic        axi_put_rdata,
+
+    output logic [31:0] obf_key_value,
+    output logic  [2:0] obf_key_idx,
+    output logic        set_obf_key,
+    output logic        get_obf_key,
+
+    // UDS access
+    output logic        get_uds_value,
+    output logic [2:0]  uds_idx,
+
+    // FE access
+    output logic        get_fe_value,
+    output logic [1:0]  fe_idx,
+
+    // KV check cleared
+    output logic        check_kv_clear,
+    output logic [4:0]  kv_idx,
+
+    //Control signals
+    output logic        debug_intent,
 
     output logic axi_error_inj_en
 
@@ -171,6 +216,10 @@ module caliptra_top_tb_services
     logic                       cold_rst;
     logic                       warm_rst;
     logic                       timed_warm_rst;
+    logic                       timed_kv_clear;
+    logic                       timed_kv_clear_done;
+    logic                       hmac_tag_mismatch_kill;
+    logic                       ecc_privkey_mismatch_kill;
     logic                       prandom_warm_rst;
     logic                       cold_rst_done;
 
@@ -203,6 +252,20 @@ module caliptra_top_tb_services
     //  [0] - Single bit, Mailbox Error Injection
     //  [1] - Double bit, Mailbox Error Injection
     logic [1:0]                 inject_mbox_sram_error = 2'b0;
+
+    // Inject single mailbox access request from SoC when TAP locks mailbox
+    logic                       inject_mbox_soc_req_on_tap_lock;
+
+    // Inject mailbox lock request from TAP when FW locks mailbox
+    logic                       inject_mbox_tap_lock_read_on_fw_lock;
+
+    // Inject mailbox unlock from SoC when FW accesses mailbox SRAM directly
+    logic                       inject_mbox_unlock_on_dir_acc;
+
+    // Force override for Mailbox pointers reset values
+    logic [31:0]                mbox_ptr_reset_value;
+    logic                       force_mbox_ptr_reset_value;
+    logic                       release_mbox_ptr_reset_value;
 
     logic                       set_wdt_timer1_period;
     logic                       set_wdt_timer2_period;
@@ -335,6 +398,94 @@ module caliptra_top_tb_services
     //         8'h2 : 8'h5  - Do nothing
     //         8'h6 : 8'h7E - WriteData is an ASCII character - dump to console.log
     //         8'h7F        - Switch to MANUF device lifecycle state
+    //      16'h017F        - Setup SoC Access address from CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h027F        - Push SoC Access wdata from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wdata queue
+    //      16'h037F        - Send SoC access
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][0]     - write transaction
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][1]     - read transaction
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][2]     - write address only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][3]     - write data only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][4]     - write response only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][5]     - read address only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][6]     - read response only
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][7]     - use operation ID, random otherwise
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][15:8]  - AXLEN
+    //          CPTRA_GENERIC_OUTPUT_WIRES[1][23:16] - Operation ID
+    //          If partial transfers are used, only one can be executed at any
+    //          given time, and it cannot be combined with full transfer.
+    //          ID must be specified and correct for partial transfers,
+    //          otherwise BFM will lockup
+    //      16'h047F        - Get SoC Access status, 0-In progress, 1-Done
+    //      16'h057F        - Pop SoC Access read response onto generic_input_wires
+    //      16'h067F        - Push SoC Access wuser from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wuser queue
+    //      16'h077F        - Setup SoC Access aXuser from CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h087F        - Setup SoC Access burst from CPTRA_GENERIC_OUTPUT_WIRES[1]: (0)fixed, (1,default)incr, (2)wrap
+    //      16'h097F        - Push SoC Access wstrb from CPTRA_GENERIC_OUTPUT_WIRES[1] into a wstrb queue
+    //      16'h0A7F        - Clear SoC Access wdata, wuser and wstrb queues
+    //      16'h0D7F        - Force DMI enable (OpenOCD requires JTAG to be active to correctly examine device)
+    //      16'h0E7F        - Set route_fatal_to_nmi
+    //      16'h0F7F        - Clear route_fatal_to_nmi
+    //      16'h107F        - Force re-enable strap write
+    //      16'h117F        - Release strap write
+    //      16'h127F        - Enable debug intent
+    //      16'h137F        - Disable debug intent
+    //      16'h147F        - Switch to Manufacturing mode
+    //      16'h157F        - Switch to Production mode
+    //      16'h167F        - Force ss_debug intent
+    //      16'h177F        - Release ss_debug intent
+    //      16'h187F        - Switch to debug unlocked
+    //      16'h197F        - Switch to debug locked
+    //      16'h1A7F        - Force re-enable fuse write
+    //      16'h1B7F        - Force unlock caliptra security state
+    //      16'h1C7F        - Release unlock caliptra security state
+    //      16'h1D7F        - Force override mailbox pointer reset value to CPTRA_GENERIC_OUTPUT_WIRES[1]
+    //      16'h1E7F        - Release override mailbox pointer reset value
+    //      16'h1F7F        - Switch to Unprovisioned mode
+    //      16'h207F        - Get UDS[0] and UDS[1] value from HW
+    //      16'h217F        - Get UDS[2] and UDS[3] value from HW
+    //      16'h227F        - Get UDS[4] and UDS[5] value from HW
+    //      16'h237F        - Get UDS[6] and UDS[7] value from HW
+    //      16'h247F        - Get UDS[8] and UDS[9] value from HW
+    //      16'h257F        - Get UDS[10] and UDS[11] value from HW
+    //      16'h267F        - Get UDS[12] and UDS[13] value from HW
+    //      16'h277F        - Get UDS[14] and UDS[15] value from HW
+    //      16'h307F        - Get FE[0] and FE[1] value from HW
+    //      16'h317F        - Get FE[2] and FE[3] value from HW
+    //      16'h327F        - Get FE[4] and FE[5] value from HW
+    //      16'h337F        - Get FE[6] and FE[7] value from HW
+    //      16'h407F        - Set OBF_KEY[0] value from generic wire 1
+    //      16'h417F        - Set OBF_KEY[1] value from generic wire 1
+    //      16'h427F        - Set OBF_KEY[2] value from generic wire 1
+    //      16'h437F        - Set OBF_KEY[3] value from generic wire 1
+    //      16'h447F        - Set OBF_KEY[4] value from generic wire 1
+    //      16'h457F        - Set OBF_KEY[5] value from generic wire 1
+    //      16'h467F        - Set OBF_KEY[6] value from generic wire 1
+    //      16'h477F        - Set OBF_KEY[7] value from generic wire 1
+    //      16'h487F        - Get OBF_KEY[0] value from HW
+    //      16'h497F        - Get OBF_KEY[1] value from HW
+    //      16'h4A7F        - Get OBF_KEY[2] value from HW
+    //      16'h4B7F        - Get OBF_KEY[3] value from HW
+    //      16'h4C7F        - Get OBF_KEY[4] value from HW
+    //      16'h4D7F        - Get OBF_KEY[5] value from HW
+    //      16'h4E7F        - Get OBF_KEY[6] value from HW
+    //      16'h4F7F        - Set OBF_KEY[7] value from HW
+    //      16'h507F        - Enable injection of single mailbox access request from SoC when TAP locks mailbox
+    //      16'h517F        - Disable injection of single mailbox access request from SoC when TAP locks mailbox
+    //      16'h527F        - Inject FIFO AXI read errors
+    //      16'h537F        - Inject FIFO AXI write errors
+    //      16'h547F        - Stop injecting FIFO AXI read errors
+    //      16'h557F        - Stop injecting FIFO AXI write errors
+    //      16'h567F        - Kill kv_hmac_tag_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
+    //      16'h577F        - Kill kv_ecc_privkey_w_flow assertions (e.g. when write into KV doesn't succeed deliberately)
+    //      16'h587F        - Enable injection of single mailbox lock request from TAP when FW locks mailbox
+    //      16'h597F        - Disable injection of single mailbox lock request from TAP when FW locks mailbox
+    //      16'h5A7F        - Enable injection of single mailbox lock request from SoC when mailbox is being unlocked
+    //      16'h5B7F        - Disable injection of single mailbox lock request from SoC when mailbox is being unlocked
+    //      16'h5C7F        - Enable injection of mailbox unlock when FW accesses mailbox SRAM directly
+    //      16'h5D7F        - Disable injection of mailbox unlock when FW accesses mailbox SRAM directly
+    //      16'h807F:'h9F7F - Inject a valid hmac_key dest and hmac512_key into Nth kv slot (where slot is encoded as (N & 0x1F) << 8)
+    //      16'hA07F:'hBF7F - Check if Nth kv slot (where slot is encoded as (N & 0x1F) << 8) is all zero
+    //      16'hC07F        - Force clear of all KV slots, when DOE FSM starts to write
     //         8'h80: 8'h87 - Inject ECC_SEED to kv_key register
     //         8'h88        - Toggle recovery interface emulation in AXI complex
     //         8'h89        - Use same msg in SHA512 digest for ECC/MLDSA PCR signing (used where both cryptos are running in parallel)
@@ -453,6 +604,236 @@ module caliptra_top_tb_services
     integer j;
     string slaveLog_fileName[`CALIPTRA_AHB_SLAVES_NUM];
 
+    initial begin
+        axi_burst = AXI_BURST_INCR;
+    end
+
+    //  AXI SoC Access
+    always @(negedge clk) begin
+        axi_write <= 1'b0;
+        axi_read <= 1'b0;
+        axi_write_addr <= 1'b0;
+        axi_write_data <= 1'b0;
+        axi_write_resp <= 1'b0;
+        axi_read_addr  <= 1'b0;
+        axi_read_resp  <= 1'b0;
+        axi_put_status <= 1'b0;
+        axi_use_id     <= 1'b0;
+        axi_put_rdata <= 1'b0;
+        if ((WriteData[15:0] == 16'h017F) && mailbox_write) begin
+            axi_addr <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+        end else if ((WriteData[15:0] == 16'h027F) && mailbox_write) begin
+            axi_wdata.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
+        end else if ((WriteData[15:0] == 16'h037F) && mailbox_write) begin
+            axi_write      <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][0];
+            axi_read       <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][1];
+            axi_write_addr <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][2];
+            axi_write_data <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][3];
+            axi_write_resp <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][4];
+            axi_read_addr  <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][5];
+            axi_read_resp  <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][6];
+            axi_use_id     <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][7];
+            axi_len        <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][15:8];
+            axi_id         <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1][23:16];
+        end else if ((WriteData[15:0] == 16'h047F) && mailbox_write) begin
+            axi_put_status <= 1'b1;
+        end else if ((WriteData[15:0] == 16'h057F) && mailbox_write) begin
+            axi_put_rdata <= 1'b1;
+        end else if ((WriteData[15:0] == 16'h067F) && mailbox_write) begin
+            axi_wuser.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
+        end else if ((WriteData[15:0] == 16'h077F) && mailbox_write) begin
+            axi_axuser <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+        end else if ((WriteData[15:0] == 16'h087F) && mailbox_write) begin
+            axi_burst <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+        end else if ((WriteData[15:0] == 16'h097F) && mailbox_write) begin
+            axi_wstrb.push_back(`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
+        end else if ((WriteData[15:0] == 16'h0A7F) && mailbox_write) begin
+            axi_wdata = {};
+            axi_wuser = {};
+            axi_wstrb = {};
+        end
+    end
+
+    //  Fuse re-enable access
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h107F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value = 1'h0;
+            force `CPTRA_TOP_PATH.soc_ifc_top1.strap_we = 1'h1;
+            repeat (10) @(negedge clk);
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value;
+        end else if ((WriteData[15:0] == 16'h117F) && mailbox_write) begin
+            release `CPTRA_TOP_PATH.soc_ifc_top1.strap_we;
+        end else if ((WriteData[15:0] == 16'h1A7F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value = 1'h0;
+            repeat (10) @(negedge clk);
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_FUSE_WR_DONE.done.value;
+        end
+    end
+
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h0D7F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.rvtop.dmi_core_enable = 1'h1;
+            $display("Force enable JTAG/DMI to be active");
+        end
+    end
+
+    initial begin
+        debug_intent = 1'b0;
+        route_fatal_to_nmi = 1'b0;
+    end
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h0E7F) && mailbox_write) begin
+            route_fatal_to_nmi <= 1'b1;
+            force `CPTRA_TOP_PATH.nmi_int = `CPTRA_TOP_PATH.cptra_error_fatal;
+            $display("Route fatal error to nmi pin");
+        end else if ((WriteData[15:0] == 16'h0F7F) && mailbox_write) begin
+            route_fatal_to_nmi <= 1'b0;
+            release `CPTRA_TOP_PATH.nmi_int;
+            $display("Return NMI to normal use");
+        end
+    end
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h127F) && mailbox_write) begin
+            debug_intent <= 1'b1;
+            $display("Enabling debug_intent");
+        end else if ((WriteData[15:0] == 16'h137F) && mailbox_write) begin
+            debug_intent <= 1'b0;
+            $display("Disabling debug_intent");
+        end
+    end
+
+    always @(negedge clk) begin
+        if ((WriteData[15:0] == 16'h167F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.soc_ifc_top1.soc_ifc_reg_hwif_in.SS_DEBUG_INTENT.debug_intent.next = 1'h1;
+        end else if ((WriteData[15:0] == 16'h177F) && mailbox_write) begin
+            release `CPTRA_TOP_PATH.soc_ifc_top1.soc_ifc_reg_hwif_in.SS_DEBUG_INTENT.debug_intent.next;
+        end
+        if ((WriteData[15:0] == 16'h1B7F) && mailbox_write) begin
+            force `CPTRA_TOP_PATH.unlock_caliptra_security_state = 1'h1;
+        end else if ((WriteData[15:0] == 16'h1C7F) && mailbox_write) begin
+            release `CPTRA_TOP_PATH.unlock_caliptra_security_state;
+        end
+    end
+
+    // Prevent from setting ptr reset value to mailboxes max capacity
+    `CALIPTRA_ASSERT_NEVER(
+        no_mbox_ptr_rst_value_override_full_capacity,
+        (WriteData[15:0] == 16'h1D7F) && mailbox_write &&
+        (`CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1] == 32'hFFFFFFFF),
+        !clk, cptra_rst_b
+    )
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            mbox_ptr_reset_value <= 0;
+            force_mbox_ptr_reset_value <= 0;
+            release_mbox_ptr_reset_value <= 0;
+        end
+        if ((WriteData[15:0] == 16'h1D7F) && mailbox_write) begin
+            $display("Force MBOX pointers reset value to %x\n", `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1]);
+            mbox_ptr_reset_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+            force_mbox_ptr_reset_value <= 1;
+            release_mbox_ptr_reset_value <= 0;
+        end else if ((WriteData[15:0] == 16'h1E7F) && mailbox_write) begin
+            $display("Release MBOX pointers reset value\n");
+            force_mbox_ptr_reset_value <= 0;
+            release_mbox_ptr_reset_value <= 1;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if      (!cptra_rst_b) begin
+            get_uds_value <= 1'b0;
+            uds_idx <= 3'h0;
+        end
+        else if ((WriteData[15:0] inside {16'h207F, 16'h217F, 16'h227F, 16'h237F, 16'h247F, 16'h257F, 16'h267F, 16'h277F}) && mailbox_write) begin
+            get_uds_value <= 1'b1;
+            uds_idx <= WriteData[10:8];
+        end else begin
+            get_uds_value <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if      (!cptra_rst_b) begin
+            get_fe_value <= 1'b0;
+            fe_idx <= 2'h0;
+        end
+        else if ((WriteData[15:0] inside {16'h307F, 16'h317F, 16'h327F, 16'h337F}) && mailbox_write) begin
+            get_fe_value <= 1'b1;
+            fe_idx <= WriteData[9:8];
+        end else begin
+            get_fe_value <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if      (!cptra_rst_b) begin
+            set_obf_key <= 1'b0;
+            get_obf_key <= 1'b0;
+        end
+        else if ((WriteData[15:0] & 16'hF8FF) == 16'h407F  && mailbox_write) begin
+            set_obf_key   <= 1'b1;
+            obf_key_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+            obf_key_idx   <= WriteData[10:8];
+        end
+        else if ((WriteData[15:0] & 16'hF8FF) == 16'h487F  && mailbox_write) begin
+            get_obf_key   <= 1'b1;
+            obf_key_value <= `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.CPTRA_GENERIC_OUTPUT_WIRES[1];
+            obf_key_idx   <= WriteData[10:8];
+        end else begin
+            set_obf_key <= 1'b0;
+            get_obf_key <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            inject_mbox_soc_req_on_tap_lock <= 1'b0;
+        end
+        else if ((WriteData[15:0] == 16'h507F) && mailbox_write) begin
+            inject_mbox_soc_req_on_tap_lock <= 1'b1;
+        end
+        else if ((WriteData[15:0] == 16'h517F) && mailbox_write) begin
+            inject_mbox_soc_req_on_tap_lock <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            inject_mbox_tap_lock_read_on_fw_lock <= 1'b0;
+        end
+        else if ((WriteData[15:0] == 16'h587F) && mailbox_write) begin
+            inject_mbox_tap_lock_read_on_fw_lock <= 1'b1;
+        end
+        else if ((WriteData[15:0] == 16'h597F) && mailbox_write) begin
+            inject_mbox_tap_lock_read_on_fw_lock <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            inject_mbox_soc_lock_on_mbox_unlock <= 1'b0;
+        end
+        else if ((WriteData[15:0] == 16'h5A7F) && mailbox_write) begin
+            inject_mbox_soc_lock_on_mbox_unlock <= 1'b1;
+        end
+        else if ((WriteData[15:0] == 16'h5B7F) && mailbox_write) begin
+            inject_mbox_soc_lock_on_mbox_unlock <= 1'b0;
+        end
+    end
+
+    always @(negedge clk or negedge cptra_rst_b) begin
+        if (!cptra_rst_b) begin
+            inject_mbox_unlock_on_dir_acc <= 1'b0;
+        end
+        else if ((WriteData[15:0] == 16'h5C7F) && mailbox_write) begin
+            inject_mbox_unlock_on_dir_acc <= 1'b1;
+        end
+        else if ((WriteData[15:0] == 16'h5D7F) && mailbox_write) begin
+            inject_mbox_unlock_on_dir_acc <= 1'b0;
+        end
+    end
+
     logic [7:0] isr_active = 8'h0;
     always @(negedge clk) begin
         if ((WriteData[7:0] == 8'hfc) && mailbox_write) begin
@@ -537,7 +918,11 @@ module caliptra_top_tb_services
 
     initial ras_test_ctrl.error_injection_seen = 1'b0;
     always @(negedge clk) begin
+<<<<<<< HEAD
         if (mailbox_write && WriteData[7:0] inside {8'hfd, 8'h95}) begin
+=======
+        if (mailbox_write && WriteData[7:0] inside {8'he5, 8'he6, 8'hfd, 8'hfe}) begin
+>>>>>>> 3c19526ab (Extend TB & services)
             ras_test_ctrl.error_injection_seen <= 1'b1;
         end
     end
@@ -556,6 +941,8 @@ module caliptra_top_tb_services
             axi_complex_ctrl.fifo_clear            <= 1'b0;
             axi_complex_ctrl.rand_delays           <= 1'b0;
             axi_complex_ctrl.en_recovery_emulation <= 1'b0;
+            axi_complex_ctrl.fifo_rd_error         <= 1'b0;
+            axi_complex_ctrl.fifo_wr_error         <= 1'b0;
         end
         else if((WriteData[7:0] == 8'h88) && mailbox_write) begin
             axi_complex_ctrl.en_recovery_emulation <= ~axi_complex_ctrl.en_recovery_emulation; // Toggle option
@@ -577,6 +964,18 @@ module caliptra_top_tb_services
         end
         else if((WriteData[7:0] == 8'h8f) && mailbox_write) begin
             axi_complex_ctrl.rand_delays    <= ~axi_complex_ctrl.rand_delays; // Toggle option
+        end
+        else if((WriteData[15:0] == 16'h527F) && mailbox_write) begin
+            axi_complex_ctrl.fifo_rd_error  <= 1'b1;
+        end
+        else if((WriteData[15:0] == 16'h537F) && mailbox_write) begin
+            axi_complex_ctrl.fifo_wr_error  <= 1'b1;
+        end
+        else if((WriteData[15:0] == 16'h547F) && mailbox_write) begin
+            axi_complex_ctrl.fifo_rd_error  <= 1'b0;
+        end
+        else if((WriteData[15:0] == 16'h557F) && mailbox_write) begin
+            axi_complex_ctrl.fifo_wr_error  <= 1'b0;
         end
         else begin
             axi_complex_ctrl.fifo_clear     <= 1'b0;
@@ -621,14 +1020,145 @@ module caliptra_top_tb_services
         end
     end
 
-    genvar dword_i, slot_id;
+    generate
+        // Check if n-th KV slot is zeroed
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : kv_check_zero_slot_loop
+            for (genvar dword_i=0; dword_i < 16; dword_i++) begin : kv_check_zero_dword_loop
+                always @(negedge clk or negedge cptra_rst_b) begin
+                    if (!cptra_rst_b) begin
+                        kv_idx <= '0;
+                        check_kv_clear <= '0;
+                    end
+                    else if(((WriteData[15:0] & 16'hE07F) == 16'hA07F) && mailbox_write) begin
+                        kv_idx <= (WriteData[15:0] & 16'h1F00) >> 8;
+                        check_kv_clear <= '1;
+                    end else begin
+                        check_kv_clear <= '0;
+                    end
+                end
+            end
+        end
+    endgenerate
+
+    always @(negedge clk) begin
+        if (!cptra_rst_b) begin
+            timed_kv_clear <= '0;
+        end else if (WriteData[15:0] == 16'hC07F) begin
+            timed_kv_clear <= '1;
+        end else begin
+            timed_kv_clear <= '0;
+        end
+    end
+
+    generate
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : kv_timed_clear_loop
+            always @(negedge clk or negedge cptra_rst_b) begin
+                if (!cptra_rst_b) begin
+                    timed_kv_clear_done <= '0;
+                end else if (timed_kv_clear) begin
+                    if((`CPTRA_TOP_PATH.doe.doe_inst.doe_fsm1.kv_doe_fsm_ns == 3'b100) & ~timed_kv_clear_done) begin
+                        // Need to kill off assertion that checks whether output matches plaintext (it won't since it got cleared)
+                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[0].DOE_FE_data_check);
+                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[1].DOE_FE_data_check);
+                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[2].DOE_FE_data_check);
+                        $assertkill(0, `CPTRA_TB_TOP_NAME.sva.FE_data_check.genblk1[3].DOE_FE_data_check);
+                        force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value = '1;
+                        timed_kv_clear_done <= 'b1;
+                    end else if(timed_kv_clear_done) begin
+                        release `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_out.KEY_CTRL[slot_id].clear.value;
+                    end
+                end else begin
+                    timed_kv_clear <= '0;
+                end
+            end
+        end
+    endgenerate
+
+    always @(negedge clk) begin
+        if (!cptra_rst_b) begin
+            hmac_tag_mismatch_kill <= '0;
+        end else if (WriteData[15:0] == 16'h567F) begin
+            hmac_tag_mismatch_kill <= '1;
+        end else begin
+            hmac_tag_mismatch_kill <= '0;
+        end
+    end
+
+    generate
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : hmac_tag_mismatch_kill_loop
+            always @(negedge clk) begin
+                if (hmac_tag_mismatch_kill) begin
+                    // Need to kill off assertion that checks whether output tag in HMAC matches tag written to KV
+                    // this assert is not necessary, e.g. in tests where KV is deliberately not set to be writable (locked)
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[0].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[1].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[2].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[3].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[4].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[5].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[6].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[7].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[8].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[9].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[10].genblk3.kv_hmac_tag_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[11].genblk3.kv_hmac_tag_w_flow);
+                end
+            end
+        end
+    endgenerate
+
+    always @(negedge clk) begin
+        if (!cptra_rst_b) begin
+            ecc_privkey_mismatch_kill <= '0;
+        end else if (WriteData[15:0] == 16'h577F) begin
+            ecc_privkey_mismatch_kill <= '1;
+        end else begin
+            ecc_privkey_mismatch_kill <= '0;
+        end
+    end
+
+    generate
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : ecc_privkey_mismatch_kill_loop
+            always @(negedge clk) begin
+                if (ecc_privkey_mismatch_kill) begin
+                    // Need to kill off assertion that checks whether output tag in HMAC matches tag written to KV
+                    // this assert is not necessary, e.g. in tests where KV is deliberately not set to be writable (locked)
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[0].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[1].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[2].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[3].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[4].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[5].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[6].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[7].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[8].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[9].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[10].genblk4.kv_ecc_privkey_w_flow);
+                    $assertkill(0, `CPTRA_TB_TOP_NAME.sva.KV_check[11].genblk4.kv_ecc_privkey_w_flow);
+                end
+            end
+        end
+    endgenerate
+
     generate
     if (!UVM_TB) begin : inject_kv_function
-        for (slot_id=0; slot_id < 24; slot_id++) begin : inject_slot_loop
-            for (dword_i=0; dword_i < 16; dword_i++) begin : inject_dword_loop
+        for (genvar slot_id=0; slot_id < 24; slot_id++) begin : inject_slot_loop
+            for (genvar dword_i=0; dword_i < 16; dword_i++) begin : inject_dword_loop
                 always @(negedge clk) begin
+                    //inject valid hmac_key dest and hmac512_key value to key reg (but extend the mask to permit all 24 kv slots)
+                    if(((WriteData[15:0] & 16'hE07F) == 16'h807F) && mailbox_write) begin
+                        inject_mldsa_seed <= 1'b1;
+                        if ((((WriteData[15:0] & 16'h1F00) >> 8) == slot_id)) begin
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.we = 1'b1;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].dest_valid.next = 5'b100;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].last_dword.we = 1'b1;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_CTRL[slot_id].last_dword.next = 'd7;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_ENTRY[slot_id][dword_i].data.we = 1'b1;
+                            force `CPTRA_TOP_PATH.key_vault1.kv_reg_hwif_in.KEY_ENTRY[slot_id][dword_i].data.next = hmac512_key_tb[dword_i][31 : 0];
+                        end
+                    end
                     //inject valid seed dest and seed value to key reg
-                    if(((WriteData[7:0] & 8'hf8) == 8'h80) && mailbox_write) begin
+                    else if(((WriteData[7:0] & 8'hf8) == 8'h80) && mailbox_write) begin
                         release_kv_inject_flags <= '0;
                         //$system("/home/mojtabab/workspace_aha_poc/ws1/Caliptra/src/ecc/tb/ecdsa_secp384r1.exe");
                         inject_ecc_seed <= 1'b1;
@@ -1166,6 +1696,7 @@ module caliptra_top_tb_services
 
     //TIE-OFF device lifecycle
     logic assert_ss_tran;
+<<<<<<< HEAD
 `ifdef CALIPTRA_DEBUG_UNLOCKED
     initial security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4False}; // DebugUnlocked & Production
 `else
@@ -1174,10 +1705,17 @@ module caliptra_top_tb_services
             security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4False}; // DebugUnlocked & Production
         else
             security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: MuBi4True}; // DebugLocked & Production
+=======
+>>>>>>> 3c19526ab (Extend TB & services)
 
-        unlock_security_state = 1'b0; // Default to not unlocking security state
+    initial begin
+        if (!$test$plusargs("CALIPTRA_DEBUG_UNLOCKED")) begin
+             security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: 1'b1}; // DebugLocked & Production
+        end else begin
+            security_state = '{device_lifecycle: DEVICE_PRODUCTION, debug_locked: 1'b0}; // DebugUnlocked & Production
+        end
     end
-`endif
+
     always @(negedge clk) begin
         //lock debug mode
         if ((WriteData[7:0] == 8'hf9) && mailbox_write) begin
@@ -1204,6 +1742,37 @@ module caliptra_top_tb_services
         else if (unlock_security_state) begin
             unlock_security_state <= 1'b0; // Reset unlock security state
             release `CPTRA_TOP_PATH.unlock_caliptra_security_state; // Release force unlock security state
+        end
+    end
+
+    always @(negedge clk) begin
+        //Switch to Manufacturing mode mode
+        if ((WriteData[15:0] == 16'h147F) && mailbox_write) begin
+            security_state.device_lifecycle <= DEVICE_MANUFACTURING;
+            $display("Setting lifecycle to DEVICE_MANUFACTURING\n");
+        end
+        //Switch to Production mode mode
+        else if ((WriteData[15:0] == 16'h157F) && mailbox_write) begin
+            security_state.device_lifecycle <= DEVICE_PRODUCTION;
+            $display("Setting lifecycle to DEVICE_PRODUCTION\n");
+        end
+        //Switch to Unprovisioned mode mode
+        else if ((WriteData[15:0] == 16'h1F7F) && mailbox_write) begin
+            security_state.device_lifecycle <= DEVICE_UNPROVISIONED;
+            $display("Setting lifecycle to DEVICE_UNPROVISIONED\n");
+        end
+    end
+
+    always @(negedge clk) begin
+        //Switch to debug unlocked
+        if ((WriteData[15:0] == 16'h187F) && mailbox_write) begin
+            security_state.debug_locked <= 1'b0;
+            $display("Setting debug_locked to 0");
+        end
+        //Switch to debug locked
+        else if ((WriteData[15:0] == 16'h197F) && mailbox_write) begin
+            security_state.debug_locked <= 1'b1;
+            $display("Setting debug_locked to 1");
         end
     end
 
@@ -2579,6 +3148,33 @@ endgenerate //IV_NO
         //Use 'hF1 code to reset these values in the test
     end
 
+    // Force Mailbox pointers reset value override
+    always_comb begin
+        if (force_mbox_ptr_reset_value) begin
+            // Force only on pointer resets, keep regular behavior on normal accesses
+            if (`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.rst_mbox_wrptr) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_wrptr_nxt = mbox_ptr_reset_value;
+            end else begin
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_wrptr_nxt;
+            end
+
+            // Force only on pointer resets, keep regular behavior on normal accesses
+            // Reads perform preload on 0
+            if (`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.rst_mbox_rdptr) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_rdptr_nxt = mbox_ptr_reset_value + 'd1;
+                if (!`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dir_req_dv_q) begin
+                    force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.sram_rdaddr = mbox_ptr_reset_value;
+                end
+            end else begin
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_rdptr_nxt;
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.sram_rdaddr;
+            end
+        end else if (release_mbox_ptr_reset_value) begin
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_wrptr_nxt;
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_rdptr_nxt;
+            release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.sram_rdaddr;
+        end
+    end
 
     `ifndef VERILATOR
         initial begin
@@ -2617,6 +3213,44 @@ endgenerate //IV_NO
         end
         else if(mailbox_data_val & mailbox_write) begin
             prev_mailbox_data <= WriteData;
+        end
+    end
+
+    always @(posedge clk) begin
+        if (inject_mbox_soc_req_on_tap_lock) begin
+            if (`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.arc_MBOX_IDLE_MBOX_RDY_FOR_CMD & `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_in.mbox_lock.lock.hwset) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.req_data_soc_req = 1'b1;
+                @(negedge `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.arc_MBOX_IDLE_MBOX_RDY_FOR_CMD);
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.req_data_soc_req;
+            end
+        end
+    end
+
+    always @(posedge clk) begin
+        if (inject_mbox_tap_lock_read_on_fw_lock) begin
+            if (~`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_out.mbox_lock.lock.value & `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_out.mbox_lock.lock.swmod) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dmi_reg_ren = 1'b1;  // Read enable
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dmi_reg_addr = 7'h75;  // Lock register address
+                @(posedge `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.clk);
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dmi_reg_ren;
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.dmi_reg_addr;
+            end
+        end
+    end
+
+    always @(negedge clk) begin
+        if (inject_mbox_unlock_on_dir_acc) begin
+            if ((`CPTRA_TOP_PATH.soc_ifc_top1.haddr_i inside {[MBOX_DIR_START_ADDR:MBOX_DIR_END_ADDR]}) &
+                `CPTRA_TOP_PATH.soc_ifc_top1.hsel_i &
+                `CPTRA_TOP_PATH.soc_ifc_top1.hwrite_i &
+                `CPTRA_TOP_PATH.soc_ifc_top1.hready_i &
+                (`CPTRA_TOP_PATH.soc_ifc_top1.htrans_i == 2'h2) &
+                `CPTRA_TOP_PATH.soc_ifc_top1.hreadyout_o
+            ) begin
+                force `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_out.mbox_unlock.unlock.value = 1'b1;
+                @(posedge `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.clk);
+                release `CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.hwif_out.mbox_unlock.unlock.value;
+            end
         end
     end
 

--- a/src/integration/tb/caliptra_top_tb_soc_bfm.sv
+++ b/src/integration/tb/caliptra_top_tb_soc_bfm.sv
@@ -179,7 +179,7 @@ import caliptra_top_tb_pkg::*; #(
         end
     end
     // Pulse fires about 640ns after the original error interrupt occurs
-    always_comb cptra_error_fatal_dly_p     = (cptra_error_fatal_counter     == 16'h0040) && !route_fatal_to_nmi;
+    always_comb cptra_error_fatal_dly_p     = (cptra_error_fatal_counter    == 16'h0040) && !route_fatal_to_nmi;
     always_comb cptra_error_non_fatal_dly_p = cptra_error_non_fatal_counter == 16'h0040;
 
     always@(negedge core_clk) begin

--- a/src/integration/tb/caliptra_top_tb_soc_bfm.sv
+++ b/src/integration/tb/caliptra_top_tb_soc_bfm.sv
@@ -34,6 +34,10 @@ import caliptra_top_tb_pkg::*; #(
     input int                          cycleCnt,
 
     output logic [`CLP_OBF_KEY_DWORDS-1:0][31:0]          cptra_obf_key,
+    output logic [`CLP_OBF_UDS_DWORDS-1:0][31:0]          cptra_uds_strap,
+    output logic                                          cptra_uds_strap_vld,
+    output logic [`CLP_OBF_FE_DWORDS-1:0] [31:0]          cptra_fe_strap,
+    output logic                                          cptra_fe_strap_vld,
     output logic [`CLP_CSR_HMAC_KEY_DWORDS-1:0][31:0]     cptra_csr_hmac_key,
 
     input  logic [0:`CLP_OBF_UDS_DWORDS-1][31:0]          cptra_uds_rand,
@@ -79,7 +83,47 @@ import caliptra_top_tb_pkg::*; #(
     input logic assert_hard_rst_flag,
     input logic deassert_hard_rst_flag,
     input logic assert_rst_flag_from_service,
-    input logic deassert_rst_flag_from_service
+    input logic deassert_rst_flag_from_service,
+
+    input logic route_fatal_to_nmi,
+
+    // Custom event injection
+    input logic inject_mbox_soc_lock_on_mbox_unlock,
+
+    //AXI SoC
+    input logic [31:0] axi_addr,
+    input logic [31:0] axi_axuser,
+    ref   logic [31:0] axi_wuser[$],
+    ref   logic [31:0] axi_wdata[$],
+    input logic [ 7:0] axi_len,
+    ref   logic [ 3:0] axi_wstrb[$],
+    input logic [ 1:0] axi_burst,
+    input logic        axi_use_id,
+    input logic [ 7:0] axi_id,
+    input logic        axi_write,
+    input logic        axi_write_addr,
+    input logic        axi_write_data,
+    input logic        axi_write_resp,
+    input logic        axi_read,
+    input logic        axi_read_addr,
+    input logic        axi_read_resp,
+    input logic        axi_put_status,
+    input logic        axi_put_rdata,
+
+    input logic [31:0] obf_key_value,
+    input logic  [2:0] obf_key_idx,
+    input logic        set_obf_key,
+    input logic        get_obf_key,
+
+    //UDS access
+    input logic       get_uds_value,
+    input logic [2:0] uds_idx,
+    //FE access
+    input logic       get_fe_value,
+    input logic [1:0] fe_idx,
+    // KV check cleared
+    input logic        check_kv_clear,
+    input logic [4:0]  kv_idx
 
 );
     localparam FW_NUM_DWORDS         = 256;
@@ -135,7 +179,7 @@ import caliptra_top_tb_pkg::*; #(
         end
     end
     // Pulse fires about 640ns after the original error interrupt occurs
-    always_comb cptra_error_fatal_dly_p     = cptra_error_fatal_counter     == 16'h0040;
+    always_comb cptra_error_fatal_dly_p     = (cptra_error_fatal_counter     == 16'h0040) && !route_fatal_to_nmi;
     always_comb cptra_error_non_fatal_dly_p = cptra_error_non_fatal_counter == 16'h0040;
 
     always@(negedge core_clk) begin
@@ -287,6 +331,8 @@ import caliptra_top_tb_pkg::*; #(
         BootFSM_BrkPoint = $urandom_range(1,0); //Set before anything starts (drive like a const strap)
         cptra_rst_b = 1'b0;
         assert_rst_flag_from_fatal = 1'b0;
+        cptra_uds_strap_vld = 1'b0;
+        cptra_fe_strap_vld = 1'b0;
         m_axi_bfm_if.rst_mgr();
 
 `ifndef VERILATOR
@@ -304,6 +350,14 @@ import caliptra_top_tb_pkg::*; #(
 
             cptra_uds_tb = cptra_uds_rand;
             cptra_fe_tb = cptra_fe_rand;
+            for (int dword = 0; dword < $bits(cptra_uds_strap)/32; dword++) begin
+                cptra_uds_strap[dword] = cptra_uds_tb[dword];
+            end
+            cptra_uds_strap_vld = 1'b1;
+            for (int dword = 0; dword < $bits(cptra_fe_strap)/32; dword++) begin
+                cptra_fe_strap[dword] = cptra_fe_tb[dword];
+            end
+            cptra_fe_strap_vld = 1'b1;
             cptra_hek_tb = cptra_hek_rand;
         end
         else begin
@@ -328,6 +382,14 @@ import caliptra_top_tb_pkg::*; #(
             for (int dword = 0; dword < $bits(cptra_obf_key)/32; dword++) begin
                 cptra_obf_key[dword] = cptra_obfkey_tb[dword];
             end
+            for (int dword = 0; dword < $bits(cptra_uds_strap)/32; dword++) begin
+                cptra_uds_strap[dword] = cptra_uds_tb[dword];
+            end
+            cptra_uds_strap_vld = 1'b1;
+            for (int dword = 0; dword < $bits(cptra_fe_strap)/32; dword++) begin
+                cptra_fe_strap[dword] = cptra_fe_tb[dword];
+            end
+            cptra_fe_strap_vld = 1'b1;
         end
 
         for (int dword = 0; dword < `CLP_CSR_HMAC_KEY_DWORDS; dword++) begin
@@ -393,10 +455,14 @@ import caliptra_top_tb_pkg::*; #(
                         $write ("SoC: Polling Flow Status...");
                         poll_count = 0;
                         do begin
-                            m_axi_bfm_if.axi_read_single(.addr(`CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS), .data(rdata), .resp(rresp), .resp_user(buser));
+                            // Make a narrow and unaligned access
+                            automatic int size = $urandom_range(0, 1);
+                            automatic int bytes = 2**size;
+                            m_axi_bfm_if.axi_read_single(.addr(`CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS + `SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_FUSES_LOW / 8 / bytes * bytes), .size(size), .data(rdata), .resp(rresp), .resp_user(buser));
                             poll_count++;
-                        end while(rdata[`SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_FUSES_LOW] == 1);
-                        $display("\n  >>> SoC: Ready for Fuses deasserted after polling %d times\n", poll_count);
+                         end while(rdata[`SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_FUSES_LOW] == 1);
+                         $display("\n  >>> SoC: Ready for Fuses deasserted after polling %d times\n", poll_count);
+
                         $display ("SoC: Writing BootGo register\n");
                         m_axi_bfm_if.axi_write_single(.addr(`CLP_SOC_IFC_REG_CPTRA_BOOTFSM_GO), .data(32'h00000001), .resp(wresp), .resp_user(buser));
                     end
@@ -405,7 +471,6 @@ import caliptra_top_tb_pkg::*; #(
                     end
 
                     $display ("CLP: ROM Flow in progress...\n");
-
                     // Test sequence (Mailbox or error handling)
                     wait(ready_for_mb_processing || ras_test_ctrl.error_injection_seen);
 
@@ -676,6 +741,210 @@ import caliptra_top_tb_pkg::*; #(
                     m_axi_bfm_if.rst_mgr();
                 end: RESET_FLOW
             join_any
+        end
+    end
+
+    always @(posedge core_clk) begin
+        if (set_obf_key) begin
+            cptra_obf_key[obf_key_idx] <= obf_key_value;
+        end else if (get_obf_key) begin
+            generic_input_wires <= {32'h0, `CPTRA_TOP_PATH.cptra_obf_key_reg[obf_key_idx]};
+        end
+    end
+
+    logic done, read, write, read_addr, read_resp, write_addr, write_data, write_resp;
+    logic [31:0] axi_rdata[$];
+    axi_resp_e axi_bresp, axi_rresp[$];
+    logic [`CALIPTRA_AXI_USER_WIDTH  -1:0] axi_buser, axi_ruser[$];
+    always @(posedge core_clk or negedge cptra_pwrgood) begin
+        if (~cptra_pwrgood) begin
+            done <= 1'b0;
+            read <= 1'b0;
+            read_addr <= 1'b0;
+            read_resp <= 1'b0;
+            write <= 1'b0;
+            write_addr <= 1'b0;
+            write_data <= 1'b0;
+            write_resp <= 1'b0;
+            axi_bresp <= axi_pkg::axi_resp_e'(0);
+            axi_buser <= '0;
+        end else if (axi_write || axi_read || axi_write_addr || axi_write_data || axi_write_resp || axi_read_addr || axi_read_resp ) begin
+            done <= 1'b0;
+            read <= 1'b0;
+            write <= 1'b0;
+            read_addr <= 1'b0;
+            read_resp <= 1'b0;
+            write_addr <= 1'b0;
+            write_data <= 1'b0;
+            write_resp <= 1'b0;
+            fork
+                if (axi_write_addr) begin
+                    write_addr <= 1'b1;
+                    m_axi_bfm_if.send_write_addr(
+                        .addr(axi_addr),
+                        .burst(axi_pkg::axi_burst_e'(axi_burst)),
+                        .len(axi_len),
+                        .user(axi_axuser),
+                        .id(axi_id),
+                        .lock(1'b0)
+                    );
+                end
+                if (axi_write_data) begin
+                    write_data <= 1'b1;
+                    for (int beat=0; beat <= axi_len; beat++)
+                        m_axi_bfm_if.send_write_beat(
+                            .last(beat == axi_len),
+                            .data(axi_wdata[beat]),
+                            .user(axi_wuser[beat]),
+                            .strb(axi_wstrb[beat])
+                        );
+                end
+                if (axi_write_resp) begin
+                    write_resp <= 1'b1;
+                    m_axi_bfm_if.get_write_resp(
+                        .id(axi_id),
+                        .resp(axi_bresp),
+                        .user(axi_buser)
+                    );
+                end
+                if (axi_write) begin
+                    write <= 1'b1;
+                    m_axi_bfm_if.axi_write(
+                        .addr(axi_addr),
+                        .burst(axi_pkg::axi_burst_e'(axi_burst)),
+                        .len(axi_len),
+                        .user(axi_axuser),
+                        .id  (axi_use_id ? axi_id : $urandom()),
+                        .lock(1'b0),
+                        .data(axi_wdata),
+                        .use_strb(1'b1),
+                        .strb(axi_wstrb),
+                        .use_write_user(1'b1),
+                        .write_user(axi_wuser),
+                        .resp(axi_bresp),
+                        .resp_user(axi_buser)
+                    );
+                end
+                if (axi_read_addr) begin
+                    read_addr <= 1'b1;
+                    m_axi_bfm_if.send_read_address(
+                        .addr(axi_addr),
+                        .burst(axi_pkg::axi_burst_e'(axi_burst)),
+                        .len(axi_len),
+                        .user(axi_axuser),
+                        .id(axi_id),
+                        .lock(1'b0)
+                    );
+                end
+                if (axi_read_resp) begin
+                    automatic axi_resp_e   beat_resp, rresp[];
+                    automatic logic [31:0] beat_user, ruser[];
+                    automatic logic [31:0] beat_data, rdata[];
+                    read_resp <= 1'b1;
+                    rdata = new[axi_len+1];
+                    ruser = new[axi_len+1];
+                    rresp = new[axi_len+1];
+                    for (int beat=0; beat <= axi_len; beat++) begin
+                        m_axi_bfm_if.get_read_beat(
+                            .id(axi_id),
+                            .data(beat_data),
+                            .user(beat_user),
+                            .resp(beat_resp)
+                        );
+                        rdata[beat] = beat_data;
+                        ruser[beat] = beat_user;
+                        rresp[beat] = beat_resp;
+                    end
+                    axi_rdata = rdata;
+                    axi_ruser = ruser;
+                    axi_rresp = rresp;
+                end
+                if (axi_read) begin
+                    read <= 1'b1;
+                    m_axi_bfm_if.axi_read(
+                        .addr(axi_addr),
+                        .burst(axi_pkg::axi_burst_e'(axi_burst)),
+                        .len(axi_len),
+                        .id(axi_use_id ? axi_id : $urandom()),
+                        .user(axi_axuser),
+                        .data(axi_rdata),
+                        .resp(axi_rresp),
+                        .resp_user(axi_ruser)
+                    );
+                end
+            join
+        end else begin
+            done <= 1'b1;
+        end
+    end
+
+    always @(posedge core_clk) begin
+        if (axi_put_status) begin
+            if (done) begin
+                if (read && write) // Need to merge the results
+                    // only keep read response user bit
+                    // OR the status, if one is an error, the whole transaction looks like an error
+                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, (axi_rresp.pop_front() || axi_bresp), 1'b1};
+                else if (read)
+                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, axi_rresp.pop_front(), 1'b1};
+                else if (write)// write
+                    generic_input_wires <= {axi_buser, 29'b0, axi_bresp, 1'b1};
+                else if (write_addr)
+                    generic_input_wires <= {63'h0, 1'b1};
+                else if (write_data)
+                    generic_input_wires <= {63'h0, 1'b1};
+                else if (write_resp)
+                    generic_input_wires <= {axi_buser, 29'b0, axi_bresp, 1'b1};
+                else if (read_addr)
+                    generic_input_wires <= {63'h0, 1'b1};
+                else if (read_resp)
+                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, axi_rresp.pop_front(), 1'b1};
+            end else
+                generic_input_wires <= '0;
+        end else if (axi_put_rdata) begin
+            generic_input_wires <= {32'b0, axi_rdata.pop_front()};
+        end
+    end
+
+    always @(posedge core_clk) begin
+        if (inject_mbox_soc_lock_on_mbox_unlock) begin
+            if (`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_csr1.field_combo.mbox_unlock.unlock.load_next &
+                |`CPTRA_TOP_PATH.soc_ifc_top1.i_mbox.mbox_csr1.field_combo.mbox_unlock.unlock.next) begin
+                m_axi_bfm_if.axi_read_single(
+                    .addr(`CLP_MBOX_CSR_MBOX_LOCK),
+                    .user(32'hFFFF_FFFF),
+                    .data(rdata),
+                    .resp(rresp),
+                    .resp_user(buser)
+                );
+            end
+        end
+    end
+
+    logic[15:0] kv_slot_is_clear [24];
+    generate
+        for(genvar i0=0; i0<24; i0++) begin
+            for(genvar i1=0; i1<16; i1++) begin
+                assign kv_slot_is_clear[i0][i1] = |`CPTRA_TOP_PATH.key_vault1.kv_reg1.field_storage.KEY_ENTRY[i0][i1].data.value;
+            end
+        end
+    endgenerate
+
+    always @(posedge core_clk) begin
+        if (get_uds_value) begin
+            generic_input_wires <= {
+                `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.fuse_uds_seed[(4'(uds_idx) << 1)].seed.value,
+                `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.fuse_uds_seed[(4'(uds_idx) << 1) + 4'h1].seed.value
+            };
+        end
+        if (get_fe_value) begin
+            generic_input_wires <= {
+                `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.fuse_field_entropy[(3'(fe_idx) << 1)].seed.value,
+                `CPTRA_TOP_PATH.soc_ifc_top1.i_soc_ifc_reg.field_storage.fuse_field_entropy[(3'(fe_idx) << 1) + 3'h1].seed.value
+            };
+        end
+        if (check_kv_clear) begin
+            generic_input_wires <= { {48{1'b0}}, kv_slot_is_clear[kv_idx]};
         end
     end
 

--- a/src/integration/tb/caliptra_top_tb_soc_bfm.sv
+++ b/src/integration/tb/caliptra_top_tb_soc_bfm.sv
@@ -884,7 +884,7 @@ import caliptra_top_tb_pkg::*; #(
                 if (read && write) // Need to merge the results
                     // only keep read response user bit
                     // OR the status, if one is an error, the whole transaction looks like an error
-                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, (axi_rresp.pop_front() || axi_bresp), 1'b1};
+                    generic_input_wires <= {axi_ruser.pop_front(), 29'd0, (axi_rresp.pop_front() | axi_bresp), 1'b1};
                 else if (read)
                     generic_input_wires <= {axi_ruser.pop_front(), 29'd0, axi_rresp.pop_front(), 1'b1};
                 else if (write)// write

--- a/src/integration/test_suites/ifc_reg_dma_soc_access/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_dma_soc_access/caliptra_isr.h
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.c
+++ b/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "soc_access.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+int check_if_soc_write_ignored(uintptr_t reg_addr) {
+    uint32_t initial_value = lsu_read_32(reg_addr);
+    uint32_t rand_value = xorshift32();
+
+    VPRINTF(LOW, "Testing SoC write to 0x%x\n", reg_addr);
+    if(soc_write_32(reg_addr, rand_value)) {
+        VPRINTF(LOW, "Can't access register from SoC, addr: 0x%x\n", reg_addr);
+        return 1;
+    }
+
+    uint32_t new_value = lsu_read_32(reg_addr);
+
+    if(new_value != initial_value) {
+        VPRINTF(LOW, "Register value changed after SoC write, written: 0x%x to 0x%x, expected (initial): 0x%x\n", rand_value, reg_addr, initial_value);
+        return 1;
+    }
+    return 0;
+}
+
+void main(void) {
+    int error_count = 0;
+    VPRINTF(LOW, "==================\nDMA Registers SoC Access\n==================\n\n");
+
+    uintptr_t soc_ro_regs[] = {
+        CLP_AXI_DMA_REG_CTRL,
+        CLP_AXI_DMA_REG_SRC_ADDR_L,
+        CLP_AXI_DMA_REG_SRC_ADDR_H,
+        CLP_AXI_DMA_REG_DST_ADDR_L,
+        CLP_AXI_DMA_REG_DST_ADDR_H,
+        CLP_AXI_DMA_REG_BYTE_COUNT,
+        CLP_AXI_DMA_REG_BLOCK_SIZE
+    };
+    const int soc_ro_reg_count =  sizeof(soc_ro_regs) / sizeof(soc_ro_regs[0]);
+
+    for(int i = 0; i < soc_ro_reg_count; i++) {
+        error_count += check_if_soc_write_ignored(soc_ro_regs[i]);
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.c
+++ b/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.c
@@ -36,20 +36,16 @@ volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 #define TB_CMD_TEST_PASS 0xFF
 #define TB_CMD_TEST_FAIL 0x01
 
-int check_if_soc_write_ignored(uintptr_t reg_addr) {
-    uint32_t initial_value = lsu_read_32(reg_addr);
-    uint32_t rand_value = xorshift32();
-
-    VPRINTF(LOW, "Testing SoC write to 0x%x\n", reg_addr);
-    if(soc_write_32(reg_addr, rand_value)) {
-        VPRINTF(LOW, "Can't access register from SoC, addr: 0x%x\n", reg_addr);
+int check_if_soc_rw_ignored(uintptr_t reg_addr) {
+    VPRINTF(LOW, "Testing SoC access to 0x%x\n", reg_addr);
+    if(!soc_write_32(reg_addr, xorshift32())) {
+        VPRINTF(ERROR, "SoC DMA write accepted, addr: 0x%x\n", reg_addr);
         return 1;
     }
 
-    uint32_t new_value = lsu_read_32(reg_addr);
-
-    if(new_value != initial_value) {
-        VPRINTF(LOW, "Register value changed after SoC write, written: 0x%x to 0x%x, expected (initial): 0x%x\n", rand_value, reg_addr, initial_value);
+    uint32_t read_value = lsu_read_32(reg_addr);
+    if(read_value) {
+        VPRINTF(ERROR, "(0x%x): Read non-zero value: 0x%x. Expected the read to be rejected.\n", reg_addr, read_value);
         return 1;
     }
     return 0;
@@ -71,7 +67,7 @@ void main(void) {
     const int soc_ro_reg_count =  sizeof(soc_ro_regs) / sizeof(soc_ro_regs[0]);
 
     for(int i = 0; i < soc_ro_reg_count; i++) {
-        error_count += check_if_soc_write_ignored(soc_ro_regs[i]);
+        error_count += check_if_soc_rw_ignored(soc_ro_regs[i]);
     }
 
     if (error_count == 0 ) {

--- a/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.mk
+++ b/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library, SoC access through generic wires helpers)
+OFILES += ifc_reg.o soc_access.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access/soc_access.h

--- a/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.yml
+++ b/src/integration/test_suites/ifc_reg_dma_soc_access/ifc_reg_dma_soc_access.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_dma_soc_access

--- a/src/integration/test_suites/ifc_reg_intr_test/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_intr_test/caliptra_isr.h
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_intr_test/ifc_reg_intr_test.c
+++ b/src/integration/test_suites/ifc_reg_intr_test/ifc_reg_intr_test.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+uint32_t error_masks [] = {
+    SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R_ERROR_INTERNAL_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R_ERROR_INV_DEV_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R_ERROR_CMD_FAIL_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R_ERROR_BAD_FUSE_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R_ERROR_ICCM_BLOCKED_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R_ERROR_MBOX_ECC_UNC_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R_ERROR_WDT_TIMER1_TIMEOUT_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R_ERROR_WDT_TIMER2_TIMEOUT_TRIG_MASK
+};
+uint32_t notif_masks [] = {
+    SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_TRIG_R_NOTIF_CMD_AVAIL_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_TRIG_R_NOTIF_MBOX_ECC_COR_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_TRIG_R_NOTIF_DEBUG_LOCKED_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_TRIG_R_NOTIF_SCAN_MODE_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_TRIG_R_NOTIF_SOC_REQ_LOCK_TRIG_MASK,
+    SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_TRIG_R_NOTIF_GEN_IN_TOGGLE_TRIG_MASK
+};
+
+void main(void) {
+
+    VPRINTF(LOW, "==================\nIFC Interrupt Test\n==================\n\n");
+
+    // Disable intr reporting
+    lsu_write_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_EN_R, 0);
+    lsu_write_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R, 0);
+    // Set interrupts
+    for (int i=0; i < sizeof(error_masks)/sizeof(uint32_t); ++i) {
+        lsu_write_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R, error_masks[i]);
+        if(lsu_read_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & error_masks[i] == 0) {
+            VPRINTF(LOW, "Error interrupt %d not set!\n", i);
+            error_count += 1;
+            continue;
+        }
+        // Write 0 should not clear interrupt
+        lsu_write_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R, ~error_masks[i]);
+        if(lsu_read_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & error_masks[i] == 0) {
+            VPRINTF(LOW, "Error interrupt %d cleared by writing 0!\n", i);
+            error_count += 1;
+            continue;
+        }
+        // Write 1 should clear interrupt
+        lsu_write_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R, error_masks[i]);
+        if(lsu_read_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & error_masks[i] != 0) {
+            VPRINTF(LOW, "Error interrupt %d not cleared by writing 1!\n", i);
+            error_count += 1;
+            continue;
+        }
+    }
+    for (int i=0; i < sizeof(notif_masks)/sizeof(uint32_t); ++i) {
+        lsu_write_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_TRIG_R, notif_masks[i]);
+        if(lsu_read_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & notif_masks[i] == 0) {
+            VPRINTF(LOW, "Notif interrupt %d not set!\n", i);
+            error_count += 1;
+            continue;
+        }
+        // Write 0 should not clear interrupt
+        lsu_write_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R, ~notif_masks[i]);
+        if(lsu_read_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & notif_masks[i] == 0) {
+            VPRINTF(LOW, "Notif interrupt %d cleared by writing 0!\n", i);
+            error_count += 1;
+            continue;
+        }
+        // Write 1 should clear interrupt
+        lsu_write_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R, notif_masks[i]);
+        if(lsu_read_32(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & notif_masks[i] != 0) {
+            VPRINTF(LOW, "Notif interrupt %d not cleared by writing 1!\n", i);
+            error_count += 1;
+            continue;
+        }
+    }
+
+    VPRINTF(LOW, "\nIFC Register Access Tests Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_intr_test/ifc_reg_intr_test.mk
+++ b/src/integration/test_suites/ifc_reg_intr_test/ifc_reg_intr_test.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library)
+OFILES += ifc_reg.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h

--- a/src/integration/test_suites/ifc_reg_intr_test/ifc_reg_intr_test.yml
+++ b/src/integration/test_suites/ifc_reg_intr_test/ifc_reg_intr_test.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_intr_test

--- a/src/integration/test_suites/ifc_reg_invalid_access/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_invalid_access/caliptra_isr.h
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#include "caliptra_defines.h"
+#include "caliptra_reg.h"
+#include <stdint.h>
+#include "printf.h"
+#include "riscv_hw_if.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+#define RV_EXCEPTION_STRUCT 1
+typedef struct {
+    uint8_t  exception_hit;
+    uint32_t mcause;
+    uint32_t mscause;
+} rv_exception_struct_s;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {return;}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {return;}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {return;}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {return;}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {return;}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER1_TIMEOUT_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER1_TIMEOUT_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER1_TIMEOUT_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER2_TIMEOUT_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER2_TIMEOUT_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER2_TIMEOUT_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_invalid_access/ifc_reg_invalid_access.c
+++ b/src/integration/test_suites/ifc_reg_invalid_access/ifc_reg_invalid_access.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "riscv-csr.h"
+#include <string.h>
+#include <stdint.h>
+#include "printf.h"
+#include "riscv_hw_if.h"
+#include "wdt.h"
+
+volatile uint32_t* stdout           = (uint32_t *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile uint32_t  rst_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile rv_exception_struct_s exc_flag __attribute__((section(".dccm.persistent")));
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+
+volatile uint32_t * hw_error_fatal      = (uint32_t *) CLP_SOC_IFC_REG_CPTRA_HW_ERROR_FATAL;
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+void nmi_handler       (void);
+
+void nmi_handler (void) {
+    VPRINTF(LOW, "**** Entering NMI Handler ****\n");
+    if (rst_count == 1 && csr_read_mcause() != 0xF0000000) {
+        SEND_STDOUT_CTRL(0x01);
+    } else if (rst_count == 2 && csr_read_mcause() != 0xF0000001) {
+        SEND_STDOUT_CTRL(0x01);
+    }
+    SEND_STDOUT_CTRL(0xf6);
+}
+
+void main() {
+    VPRINTF(LOW, "---------------------------\n");
+    VPRINTF(LOW, " Smoke Test Invalid regs !!\n");
+    VPRINTF(LOW, "---------------------------\n");
+
+    rst_count++;
+
+    // Setup the NMI Handler
+    lsu_write_32((uintptr_t) (CLP_SOC_IFC_REG_INTERNAL_NMI_VECTOR), (uint32_t) (nmi_handler));
+
+    if(rst_count == 1) {
+        VPRINTF(LOW, "Module: AES\n");
+        lsu_write_8((uintptr_t) (CLP_AES_REG_STATUS + 1), 0xFF);
+        SEND_STDOUT_CTRL(0xf6);
+    }
+    if(rst_count == 2) {
+        VPRINTF(LOW, "Module: SOC_IFC \n");
+        lsu_read_32((uintptr_t) (0x30023000));
+        SEND_STDOUT_CTRL(0xf6);
+    }
+    else {
+        VPRINTF(LOW, "End of test\n");
+    }
+}

--- a/src/integration/test_suites/ifc_reg_invalid_access/ifc_reg_invalid_access.mk
+++ b/src/integration/test_suites/ifc_reg_invalid_access/ifc_reg_invalid_access.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library)
+OFILES += ifc_reg.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h

--- a/src/integration/test_suites/ifc_reg_invalid_access/ifc_reg_invalid_access.yml
+++ b/src/integration/test_suites/ifc_reg_invalid_access/ifc_reg_invalid_access.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: 1
+testname: ifc_reg_invalid_access

--- a/src/integration/test_suites/ifc_reg_rand_test/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_rand_test/caliptra_isr.h
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR, "bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR, "bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR, "bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR, "bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR, "bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR, "bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR, "bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR, "bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.c
+++ b/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.c
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int rst_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int test_mode __attribute__((section(".dccm.persistent"))) = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_WARM_RESET 0xF6
+#define TB_CMD_COLD_RESET 0xF5
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+void set_env(void) {
+    lsu_write_32(STDOUT, 0x107F);
+    lsu_write_32(STDOUT, 0x1B7F);
+    if (test_mode & 1) {
+        // Manufacturing mode
+        lsu_write_32(STDOUT, 0x147F);
+    } else {
+        // Production mode
+        lsu_write_32(STDOUT, 0x157F);
+    }
+    if (test_mode & 2) {
+        // Enable debug intent
+        lsu_write_32(STDOUT, 0x167F);
+        lsu_write_32(STDOUT, 0x127F);
+    } else {
+        // Disable debug intent
+        lsu_write_32(STDOUT, 0x177F);
+        lsu_write_32(STDOUT, 0x137F);
+    }
+}
+
+void main(void) {
+    bool was_zero = ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0) == 0;
+    rst_count++;
+    VPRINTF(LOW, "----------------\nrst count = %d\n----------------\n", rst_count);
+
+    VPRINTF(LOW, "==================\nIFC Registers Test\n==================\n\n");
+
+    ifc_register_group_t ifc_reg_groups[] = {
+        REG_GROUP_GENERIC_WIRES,
+        REG_GROUP_CAPABILITIES,
+        REG_GROUP_STATUS,
+        REG_GROUP_ERROR,
+        REG_GROUP_ERROR_MASK,
+        REG_GROUP_WATCHDOG,
+        REG_GROUP_MCU,
+        REG_GROUP_CONTROL,
+        REG_GROUP_MBOX,
+        REG_GROUP_MBOX_RW1S,
+        REG_GROUP_DBG_MANUF_SERVICE,
+        REG_GROUP_FW,
+        REG_GROUP_TRNG,
+        REG_GROUP_TRNG_RW1S,
+        REG_GROUP_FUSE,
+        REG_GROUP_FUSE_RW1S
+    };
+
+    const int num_groups =  sizeof(ifc_reg_groups) / sizeof(ifc_reg_groups[0]);
+
+    if (rst_count == 1) {
+        test_mode = xorshift32() & 3;
+        ifc_init();
+        // Handle manually as random value can trigger unexpected behavior
+        exclude_register(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0);
+        set_env();
+
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ifc_reg_groups[i];
+            // Write random values to all registers in this group
+            write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        ifc_reg_write(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0xFFFFFF7F);
+        if (ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0) != 0xFFFFFF7F) {
+            error_count += 1;
+        }
+
+        // Issue warm reset
+        SEND_STDOUT_CTRL(TB_CMD_WARM_RESET);
+
+        // Halt the MCU
+        while(1);
+
+    } else if (rst_count == 2) {
+        set_env();
+
+        // Read all registers, expect register values to be retained for sticky registers
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ifc_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, false);
+
+            // Write random values to all registers in this group
+            write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, WARM_RESET, false);
+        }
+
+        if (!was_zero) {
+            error_count += 1;
+        }
+        ifc_reg_write(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0xFFFFFF7F);
+        if (ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0) != 0xFFFFFF7F) {
+            error_count += 1;
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+
+        // Halt the MCU
+        while(1);
+
+    } else if (rst_count == 3) {
+        set_env();
+
+        // Read all registers, expect register values to be reset
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ifc_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, COLD_RESET, false);
+        }
+        if (!was_zero) {
+            error_count += 1;
+        }
+    }
+
+    VPRINTF(LOW, "\nIFC Register Access Tests Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.c
+++ b/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.c
@@ -41,23 +41,23 @@ volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 #define TB_CMD_TEST_FAIL 0x01
 
 void set_env(void) {
-    lsu_write_32(STDOUT, 0x107F);
-    lsu_write_32(STDOUT, 0x1B7F);
+    lsu_write_32(STDOUT, 0x10A2);
+    lsu_write_32(STDOUT, 0x1BA2);
     if (test_mode & 1) {
         // Manufacturing mode
-        lsu_write_32(STDOUT, 0x147F);
+        lsu_write_32(STDOUT, 0x7F);
     } else {
         // Production mode
-        lsu_write_32(STDOUT, 0x157F);
+        lsu_write_32(STDOUT, 0x15A2);
     }
     if (test_mode & 2) {
         // Enable debug intent
-        lsu_write_32(STDOUT, 0x167F);
-        lsu_write_32(STDOUT, 0x127F);
+        lsu_write_32(STDOUT, 0x16A2);
+        lsu_write_32(STDOUT, 0x12A2);
     } else {
         // Disable debug intent
-        lsu_write_32(STDOUT, 0x177F);
-        lsu_write_32(STDOUT, 0x137F);
+        lsu_write_32(STDOUT, 0x17A2);
+        lsu_write_32(STDOUT, 0x13A2);
     }
 }
 
@@ -106,8 +106,8 @@ void main(void) {
             error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
         }
 
-        ifc_reg_write(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0xFFFFFF7F);
-        if (ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0) != 0xFFFFFF7F) {
+        ifc_reg_write(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0xFFFFFFA2);
+        if (ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0) != 0xFFFFFFA2) {
             error_count += 1;
         }
 
@@ -137,8 +137,8 @@ void main(void) {
         if (!was_zero) {
             error_count += 1;
         }
-        ifc_reg_write(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0xFFFFFF7F);
-        if (ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0) != 0xFFFFFF7F) {
+        ifc_reg_write(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0xFFFFFFA2);
+        if (ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0) != 0xFFFFFFA2) {
             error_count += 1;
         }
 

--- a/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.mk
+++ b/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library)
+OFILES += ifc_reg.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h

--- a/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.yml
+++ b/src/integration/test_suites/ifc_reg_rand_test/ifc_reg_rand_test.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_rand_test

--- a/src/integration/test_suites/ifc_reg_ro_reg_rand_test/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_ro_reg_rand_test/caliptra_isr.h
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_ro_reg_rand_test/ifc_reg_ro_reg_rand_test.c
+++ b/src/integration/test_suites/ifc_reg_ro_reg_rand_test/ifc_reg_ro_reg_rand_test.c
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int rst_count __attribute__((section(".dccm.persistent"))) = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_WARM_RESET 0xF6
+#define TB_CMD_COLD_RESET 0xF5
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+void main(void) {
+
+    rst_count++;
+    VPRINTF(LOW, "----------------\nrst count = %d\n----------------\n", rst_count);
+
+    VPRINTF(LOW, "==================\nIFC RO Registers Test\n==================\n\n");
+
+    ifc_register_group_t ro_reg_groups[] = {
+        REG_GROUP_STRAPS_RO,
+        REG_GROUP_STRAPS_RO_RO,
+        REG_GROUP_STATUS_RO,
+        REG_GROUP_SECURITY_RO,
+        REG_GROUP_WATCHDOG_RO,
+        REG_GROUP_CONTROL_RO,
+        REG_GROUP_GENERIC_WIRES_RO,
+        REG_GROUP_FUSE_RO,
+        REG_GROUP_OWNER_PK_HASH_RO,
+        REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO,
+        REG_GROUP_INTERRUPT_ERROR_COUNTERS_INCR_RO,
+        REG_GROUP_INTERRUPT_NOTIF_COUNTERS_INCR_RO
+    };
+
+    const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
+
+    if (rst_count == 1) {
+        ifc_init();
+        exclude_register(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0);
+
+        // Loop through all RO register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Loop through all RO register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+            // Write random values to all registers in this group
+            write_random_to_register_group_and_track(group, &g_expected_data_dict);
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Issue warm reset
+        SEND_STDOUT_CTRL(TB_CMD_WARM_RESET);
+
+        // Halt the MCU
+        while(1);
+
+    } else if (rst_count == 2) {
+        // Read all registers, expect register values to be retained for sticky registers
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, false);
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+
+        // Halt the MCU
+        while(1);
+
+    } else if (rst_count == 3) {
+        // Read all registers, expect register values to be reset
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, COLD_RESET, false);
+        }
+    }
+
+    VPRINTF(LOW, "\nIFC Read-Only Register Access Tests Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_ro_reg_rand_test/ifc_reg_ro_reg_rand_test.mk
+++ b/src/integration/test_suites/ifc_reg_ro_reg_rand_test/ifc_reg_ro_reg_rand_test.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library)
+OFILES += ifc_reg.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h

--- a/src/integration/test_suites/ifc_reg_ro_reg_rand_test/ifc_reg_ro_reg_rand_test.yml
+++ b/src/integration/test_suites/ifc_reg_ro_reg_rand_test/ifc_reg_ro_reg_rand_test.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_ro_reg_rand_test

--- a/src/integration/test_suites/ifc_reg_rw_hw/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_rw_hw/caliptra_isr.h
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.c
+++ b/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.c
@@ -52,7 +52,7 @@ void main(void) {
         for (int i = 0; i < 8; ++i) {
             obf_key[i] = xorshift32();
             lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, obf_key[i]);
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x407F|(i<<8));
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x40A2|(i<<8));
         }
 
         // Issue cold reset
@@ -60,7 +60,7 @@ void main(void) {
         while(1);
     } else if (rst_count == 2) {
         for (int i = 0; i < 8; ++i) {
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x487F | (i<<8));
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x48A2 | (i<<8));
             if (lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0) != obf_key[i]) {
                 error_count += 1;
             }
@@ -70,8 +70,8 @@ void main(void) {
         for (int i = 0; i < 8; ++i) {
             uint32_t new_obf_key = xorshift32() ^ obf_key[i];
             lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, new_obf_key);
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x407F|(i<<8));
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x487F | (i<<8));
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x40A2|(i<<8));
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x48A2 | (i<<8));
             if (lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0) != obf_key[i]) {
                 error_count += 1;
             }
@@ -83,7 +83,7 @@ void main(void) {
         while(1);
     } else if (rst_count == 3) {
         for (int i = 0; i < 8; ++i) {
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x487F | (i<<8));
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x48A2 | (i<<8));
             if (lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0) != obf_key[i]) {
                 error_count += 1;
             }

--- a/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.c
+++ b/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "caliptra_rtl_lib.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int rst_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile uint32_t obf_key[8] __attribute__((section(".dccm.persistent")));
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_WARM_RESET 0xF6
+#define TB_CMD_COLD_RESET 0xF5
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+void main(void) {
+
+    rst_count++;
+    VPRINTF(LOW, "----------------\nrst count = %d\n----------------\n", rst_count);
+
+    VPRINTF(LOW, "==================\nIFC HW Only Reg Test\n==================\n\n");
+
+
+    if (rst_count == 1) {
+        for (int i = 0; i < 8; ++i) {
+            obf_key[i] = xorshift32();
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, obf_key[i]);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x407F|(i<<8));
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+        while(1);
+    } else if (rst_count == 2) {
+        for (int i = 0; i < 8; ++i) {
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x487F | (i<<8));
+            if (lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0) != obf_key[i]) {
+                error_count += 1;
+            }
+        }
+
+        // Modify OBF strap and check that it did not changed
+        for (int i = 0; i < 8; ++i) {
+            uint32_t new_obf_key = xorshift32() ^ obf_key[i];
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, new_obf_key);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x407F|(i<<8));
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x487F | (i<<8));
+            if (lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0) != obf_key[i]) {
+                error_count += 1;
+            }
+            obf_key[i] = new_obf_key;
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+        while(1);
+    } else if (rst_count == 3) {
+        for (int i = 0; i < 8; ++i) {
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x487F | (i<<8));
+            if (lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0) != obf_key[i]) {
+                error_count += 1;
+            }
+        }
+    }
+    VPRINTF(LOW, "\nIFC HW Only Reg Test Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.mk
+++ b/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library)
+OFILES += ifc_reg.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h

--- a/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.yml
+++ b/src/integration/test_suites/ifc_reg_rw_hw/ifc_reg_rw_hw.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_rw_hw

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/caliptra_isr.h
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.c
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "soc_access.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int rst_count __attribute__((section(".dccm.persistent"))) = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+#include "riscv_hw_if.h"
+#define TB_CMD_WARM_RESET 0xF6
+#define TB_CMD_COLD_RESET 0xF5
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW, "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
+
+    bool ro_reg = false;
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+                // Generate a unique value for each register
+                uint32_t rand_value = xorshift32();
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (!ro_reg) {
+                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                    }
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, rand_value);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW, "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, write_data);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void main(void) {
+
+    rst_count++;
+    VPRINTF(LOW, "----------------\nrst count = %d\n----------------\n", rst_count);
+
+    VPRINTF(LOW, "==================\nIFC SoC RW, Caliptra RO Registers Test: Strap, Stepping\n==================\n\n");
+
+    ifc_register_group_t ro_reg_groups[] = {
+        REG_GROUP_STRAPS_RO,
+        REG_GROUP_SOC_STEPPING_RO
+    };
+
+    const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+
+    if (rst_count == 1) {
+        ifc_init();
+
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it remains 1
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        // Issue warm reset
+        SEND_STDOUT_CTRL(TB_CMD_WARM_RESET);
+
+        while(1);
+
+    } else if (rst_count == 2) {
+
+        // Read all registers, expect register values to be retained fr sticky registers
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, false);
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, WARM_RESET, false);
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+
+        while(1);
+
+    } else if (rst_count == 3) {
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it's not locked
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x0, &g_expected_data_dict);
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        // Loop through all RW register groups -- all registers should be unlocked
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+    }
+
+    VPRINTF(LOW, "\nIFC SoC Read-Write, Caliptra Read-Only Register Access Tests Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.c
@@ -42,63 +42,41 @@ volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 
 void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
     int count = get_register_count(group);
-    VPRINTF(LOW, "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
-
-    bool ro_reg = false;
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
-                // Generate a unique value for each register
-                uint32_t rand_value = xorshift32();
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (!ro_reg) {
-                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
-                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                    }
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, rand_value);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        uint32_t rand_value = xorshift32();
+        uint32_t mask = get_register_mask(reg->address);
+        if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+            VPRINTF(ERROR, "Dictionary full\n");
+            SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+            while(1);
         }
+        VPRINTF(MEDIUM, "Writing 0x%08x to (0x%08x)\n", rand_value, reg->address);
+        soc_write_32(reg->address, rand_value);
     }
 }
 
+
 void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
     int count = get_register_count(group);
-    VPRINTF(LOW, "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
-                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, write_data);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        uint32_t mask = get_register_mask(reg->address);
+        if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+            VPRINTF(ERROR, "Dictionary full\n");
+            SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+            while(1);
         }
+        VPRINTF(MEDIUM, "Writing 0x%08x to (0x%08x)\n", write_data, reg->address);
+        soc_write_32(reg->address, write_data);
     }
 }
 
@@ -115,7 +93,7 @@ void main(void) {
     };
 
     const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1AA2);
 
     if (rst_count == 1) {
         ifc_init();

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.mk
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library, SoC access through generic wires helpers)
+OFILES += ifc_reg.o soc_access.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access/soc_access.h

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.yml
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_config/ifc_reg_soc_rw_cptra_ro_config.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_soc_rw_cptra_ro_config

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/caliptra_isr.h
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.c
@@ -42,63 +42,41 @@ volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 
 void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
     int count = get_register_count(group);
-    VPRINTF(LOW,  "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
-
-    bool ro_reg = false;
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
-                // Generate a unique value for each register
-                uint32_t rand_value = xorshift32();
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (!ro_reg) {
-                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
-                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                    }
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, rand_value);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        uint32_t rand_value = xorshift32();
+        uint32_t mask = get_register_mask(reg->address);
+        if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+            VPRINTF(ERROR, "Dictionary full\n");
+            SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+            while(1);
         }
+        VPRINTF(MEDIUM, "Writing 0x%08x to (0x%08x)\n", rand_value, reg->address);
+        soc_write_32(reg->address, rand_value);
     }
 }
 
+
 void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
     int count = get_register_count(group);
-    VPRINTF(LOW,  "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
-                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, write_data);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        uint32_t mask = get_register_mask(reg->address);
+        if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+            VPRINTF(ERROR, "Dictionary full\n");
+            SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+            while(1);
         }
+        VPRINTF(MEDIUM, "Writing 0x%08x to (0x%08x)\n", write_data, reg->address);
+        soc_write_32(reg->address, write_data);
     }
 }
 
@@ -114,7 +92,7 @@ void main(void) {
     };
 
     const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1AA2);
 
     if (rst_count == 1) {
         ifc_init();

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.c
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "soc_access.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int rst_count __attribute__((section(".dccm.persistent"))) = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_WARM_RESET 0xF6
+#define TB_CMD_COLD_RESET 0xF5
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW,  "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
+
+    bool ro_reg = false;
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+                // Generate a unique value for each register
+                uint32_t rand_value = xorshift32();
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (!ro_reg) {
+                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                    }
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, rand_value);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW,  "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, write_data);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void main(void) {
+
+    rst_count++;
+    VPRINTF(LOW,  "----------------\nrst count = %d\n----------------\n", rst_count);
+
+    VPRINTF(LOW,  "==================\nIFC SoC RW, Caliptra RO Registers Test: IDEVID\n==================\n\n");
+
+    ifc_register_group_t ro_reg_groups[] = {
+        REG_GROUP_IDEVID_RO
+    };
+
+    const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+
+    if (rst_count == 1) {
+        ifc_init();
+
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it remains 1
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        // Issue warm reset
+        SEND_STDOUT_CTRL(TB_CMD_WARM_RESET);
+
+        while(1);
+
+    } else if (rst_count == 2) {
+
+        // Read all registers, expect register values to be retained fr sticky registers
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, false);
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, WARM_RESET, false);
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+
+        while(1);
+
+    } else if (rst_count == 3) {
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it's not locked
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x0, &g_expected_data_dict);
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        // Loop through all RW register groups -- all registers should be unlocked
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+    }
+
+    VPRINTF(LOW,  "\nIFC SoC Read-Write, Caliptra Read-Only Register Access Tests Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.mk
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library, SoC access through generic wires helpers)
+OFILES += ifc_reg.o soc_access.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access/soc_access.h

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.yml
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_idevid/ifc_reg_soc_rw_cptra_ro_idevid.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_soc_rw_cptra_ro_idevid

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/caliptra_isr.h
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.c
@@ -40,258 +40,166 @@ volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 #define TB_CMD_TEST_PASS 0xFF
 #define TB_CMD_TEST_FAIL 0x01
 
-void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
+static void soc_write_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict,
+                                               bool randomize, uint32_t write_data) {
     int count = get_register_count(group);
-    VPRINTF(LOW,  "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
-
-    bool ro_reg = false;
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
-                // Generate a unique value for each register
-                uint32_t rand_value = xorshift32();
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
+        uint32_t value = randomize ? xorshift32() : write_data;
+        uint32_t mask = get_register_mask(reg->address);
 
-                // Store in dictionary
-                if (!ro_reg) {
-                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
-                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                    }
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, rand_value);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        if (set_reg_exp_data(dict, reg->address, value, mask, true, group, true) != 0) {
+            VPRINTF(ERROR, "Dictionary full\n");
+            SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+            while(1);
         }
+        soc_write_32(reg->address, value);
     }
 }
 
-void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
-    int count = get_register_count(group);
-    VPRINTF(LOW,  "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
+static void write_and_verify_groups(const ifc_register_group_t groups[], int num_groups,
+                                    bool use_soc_access, int reset_type) {
+    for (int i = 0; i < num_groups; i++) {
+        ifc_register_group_t group = groups[i];
 
-    for (int i = 0; i < count; i++) {
-        const ifc_register_info_t *reg = get_register_info(group, i);
-
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
-
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
-                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, write_data);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
-        }
+        if (use_soc_access) soc_write_register_group_and_track(group, &g_expected_data_dict, true, 0);
+        else write_random_to_register_group_and_track(group, &g_expected_data_dict);
+        error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, reset_type, false);
     }
+}
+
+static void verify_retained_then_write_groups(const ifc_register_group_t groups[],
+                                              int num_groups) {
+    for (int i = 0; i < num_groups; i++) {
+        ifc_register_group_t group = groups[i];
+
+        error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, false);
+        soc_write_register_group_and_track(group, &g_expected_data_dict, true, 0);
+        error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, WARM_RESET, false);
+    }
+}
+
+static void write_and_verify_fuse(uint32_t value) {
+    soc_write_register_group_and_track(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, value);
+    read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
 }
 
 void main(void) {
 
     rst_count++;
-    VPRINTF(LOW,  "----------------\nrst count = %d\n----------------\n", rst_count);
-
-    VPRINTF(LOW,  "==================\nIFC SoC RW, Caliptra RO Registers Test: SVN, Manuf DBG Unlock\n==================\n\n");
+    VPRINTF(LOW,  "= (rst count: %d) IFC SoC RW, Caliptra RO Registers Test: SVN, Manuf DBG Unlock =\n\n", rst_count);
 
     ifc_register_group_t ro_reg_groups[] = {
         REG_GROUP_SVN_RO,
         REG_GROUP_MANUF_DBG_UNLOCK_RO
     };
 
-    const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+    const int num_groups = sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1AA2);
 
     if (rst_count == 1) {
         ifc_init();
 
-        // Loop through all RW register groups
-        for (int i = 0; i < num_groups; i++) {
-            ifc_register_group_t group = ro_reg_groups[i];
+        write_and_verify_groups(ro_reg_groups, num_groups, true, COLD_RESET);
+        write_and_verify_fuse(1);
+        write_and_verify_groups(ro_reg_groups, num_groups, false, COLD_RESET);
 
-            // Write random values to all registers in this group
-            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+        // CPTRA_FUSE_WR_DONE must remain set once written.
+        write_and_verify_fuse(1);
 
-            // Read registers and verify data matches
-            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
-        }
-
-        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
-
-        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
-
-        for (int i = 0; i < num_groups; i++) {
-            ifc_register_group_t group = ro_reg_groups[i];
-
-            // Write random values to all registers in this group
-            write_random_to_register_group_and_track(group, &g_expected_data_dict);
-
-            // Read registers and verify data matches
-            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
-        }
-
-        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it remains 1
-        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
-
-        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
-
-        // Issue warm reset
         SEND_STDOUT_CTRL(TB_CMD_WARM_RESET);
-
         while(1);
 
     } else if (rst_count == 2) {
+        // Sticky registers must retain their values across warm reset.
+        verify_retained_then_write_groups(ro_reg_groups, num_groups);
 
-        // Read all registers, expect register values to be retained fr sticky registers
-        for (int i = 0; i < num_groups; i++) {
-            ifc_register_group_t group = ro_reg_groups[i];
-
-            // Read registers and verify data matches
-            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, false);
-
-            // Write random values to all registers in this group
-            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
-
-            // Read registers and verify data matches
-            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, WARM_RESET, false);
-        }
-
-        // Issue cold reset
         SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
-
         while(1);
 
     } else if (rst_count == 3) {
-        // Loop through all RW register groups
-        for (int i = 0; i < num_groups; i++) {
-            ifc_register_group_t group = ro_reg_groups[i];
-
-            // Write random values to all registers in this group
-            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
-
-            // Read registers and verify data matches
-            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
-        }
+        write_and_verify_groups(ro_reg_groups, num_groups, true, COLD_RESET);
 
         // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it's not locked
-        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x0, &g_expected_data_dict);
-        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+        write_and_verify_fuse(0);
 
-        // Loop through all RW register groups -- all registers should be unlocked
-        for (int i = 0; i < num_groups; i++) {
-            ifc_register_group_t group = ro_reg_groups[i];
-
-            // Write random values to all registers in this group
-            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
-
-            // Read registers and verify data matches
-            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
-        }
+        // All registers should be unlocked following cold reset.
+        write_and_verify_groups(ro_reg_groups, num_groups, true, COLD_RESET);
     }
 
     // Test multiple inflight SoC AXI transactions
-    uint32_t w1_data = xorshift32(), w2_data = xorshift32();
-    axi_req_t w1, w2, r1, r2;
-    w1 = (axi_req_t) {
-        .addr = CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_0,
-        .axuser = 0,
-        .burst = AXI_BURST_INCR,
-        .len = 1,
-        .write = true,
-        .read  = false,
-        .use_id = true,
-        .id    = 1,
-        .wuser = (uint32_t[]){0},
-        .wdata = (uint32_t[]){w1_data},
-        .wstrb = (uint8_t[]){0xf}
+    enum { NUM_INFLIGHT = 2 };
+    const uint32_t write_addrs[] = {
+        CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_0,
+        CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_1,
     };
-    w2 = (axi_req_t) {
-        .addr = CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_1,
-        .axuser = 0,
-        .burst = AXI_BURST_INCR,
-        .len = 1,
-        .write = true,
-        .read  = false,
-        .use_id = true,
-        .id    = 2,
-        .wuser = (uint32_t[]){0},
-        .wdata = (uint32_t[]){w2_data},
-        .wstrb = (uint8_t[]){0xf}
+    const uint32_t read_addrs[] = {
+        CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_2,
+        CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_3,
     };
-    r1 = (axi_req_t) {
-        .addr = CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_2,
-        .axuser = 0,
-        .burst = AXI_BURST_INCR,
-        .len = 1,
-        .write = false,
-        .read = true,
-        .use_id = true,
-        .id    = 3,
-    };
-    r2 = (axi_req_t) {
-        .addr = CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_3,
-        .axuser = 0,
-        .burst = AXI_BURST_INCR,
-        .len = 1,
-        .write = false,
-        .read = true,
-        .use_id = true,
-        .id    = 4,
-    };
+    uint32_t write_data[] = {xorshift32(), xorshift32()};
+    uint32_t write_user[NUM_INFLIGHT][1] = {{0}, {0}};
+    uint8_t write_strb[NUM_INFLIGHT][1] = {{0xf}, {0xf}};
+    axi_req_t writes[NUM_INFLIGHT];
+    axi_req_t reads[NUM_INFLIGHT];
+
+    for (int i = 0; i < NUM_INFLIGHT; i++) {
+        writes[i] = (axi_req_t) {
+            .addr = write_addrs[i],
+            .axuser = 0,
+            .burst = AXI_BURST_INCR,
+            .len = 1,
+            .write = true,
+            .read = false,
+            .use_id = true,
+            .id = i + 1,
+            .wuser = write_user[i],
+            .wdata = &write_data[i],
+            .wstrb = write_strb[i],
+        };
+        reads[i] = (axi_req_t) {
+            .addr = read_addrs[i],
+            .axuser = 0,
+            .burst = AXI_BURST_INCR,
+            .len = 1,
+            .write = false,
+            .read = true,
+            .use_id = true,
+            .id = i + 3,
+        };
+    }
 
     // Send address and simulate data delay
-    soc_write_addr(w1);
-    soc_write_addr(w2);
-    // Send address and simulate stall
-    soc_read_addr(r1);
-    soc_read_addr(r2);
+    for (int i = 0; i < NUM_INFLIGHT; i++) soc_write_addr(writes[i]);
 
-    soc_write_data(w1);
-    soc_write_data(w2);
+    // Send address and simulate stall
+    for (int i = 0; i < NUM_INFLIGHT; i++) soc_read_addr(reads[i]);
+
+    for (int i = 0; i < NUM_INFLIGHT; i++) soc_write_data(writes[i]);
 
     // Get responses
     axi_resp_t resp;
-    uint32_t value = lsu_read_32(w1.addr);
-    resp = soc_write_resp(w1);
-    if (resp.resp != 0 || value != w1_data) {
-        VPRINTF(LOW,  "Write to 0x%x failed, expected: %x, got %x!\n", w1.addr, w1_data, value);
-        error_count++;
-    }
-    value = lsu_read_32(w2.addr);
-    resp = soc_write_resp(w2);
-    if (resp.resp != 0 || value != w2_data) {
-        VPRINTF(LOW,  "Write to 0x%x failed, expected: %x, got %x!\n", w2.addr, w2_data, value);
-        error_count++;
-    }
-    value = lsu_read_32(r1.addr);
-    resp = soc_read_resp(r1);
-    if (resp.resp != 0 || value != resp.rdata) {
-        VPRINTF(LOW,  "Read from 0x%x failed, expected: %x, got %x!\n", r1.addr, value, resp.rdata);
-        error_count++;
-    }
-    value = lsu_read_32(r2.addr);
-    resp = soc_read_resp(r2);
-    if (resp.resp != 0 || value != resp.rdata) {
-        VPRINTF(LOW,  "Read from 0x%x failed, expected: %x, got %x!\n", r2.addr, value, resp.rdata);
-        error_count++;
+    for (int i = 0; i < NUM_INFLIGHT; i++) {
+        uint32_t value = lsu_read_32(writes[i].addr);
+        resp = soc_write_resp(writes[i]);
+        if (resp.resp != 0 || value != write_data[i]) {
+            VPRINTF(LOW, "(0x%x): write failed, expected: %x, got %x!\n", writes[i].addr, write_data[i], value);
+            error_count++;
+        }
     }
 
-    VPRINTF(LOW,  "\nIFC SoC Read-Write, Caliptra Read-Only Register Access Tests Completed\n");
+    for (int i = 0; i < NUM_INFLIGHT; i++) {
+        uint32_t value = lsu_read_32(reads[i].addr);
+        resp = soc_read_resp(reads[i]);
+        if (resp.resp != 0 || value != resp.rdata) {
+            VPRINTF(LOW, "(0x%x): read failed, expected: %x, got %x!\n", reads[i].addr, value, resp.rdata);
+            error_count++;
+        }
+    }
 
     for (uint8_t ii = 0; ii < 160; ii++) {
         __asm__ volatile ("nop"); // Sleep loop as "nop"

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.c
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "soc_access.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int rst_count __attribute__((section(".dccm.persistent"))) = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_WARM_RESET 0xF6
+#define TB_CMD_COLD_RESET 0xF5
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW,  "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
+
+    bool ro_reg = false;
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+                // Generate a unique value for each register
+                uint32_t rand_value = xorshift32();
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (!ro_reg) {
+                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                    }
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, rand_value);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW,  "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, write_data);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void main(void) {
+
+    rst_count++;
+    VPRINTF(LOW,  "----------------\nrst count = %d\n----------------\n", rst_count);
+
+    VPRINTF(LOW,  "==================\nIFC SoC RW, Caliptra RO Registers Test: SVN, Manuf DBG Unlock\n==================\n\n");
+
+    ifc_register_group_t ro_reg_groups[] = {
+        REG_GROUP_SVN_RO,
+        REG_GROUP_MANUF_DBG_UNLOCK_RO
+    };
+
+    const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+
+    if (rst_count == 1) {
+        ifc_init();
+
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it remains 1
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        // Issue warm reset
+        SEND_STDOUT_CTRL(TB_CMD_WARM_RESET);
+
+        while(1);
+
+    } else if (rst_count == 2) {
+
+        // Read all registers, expect register values to be retained fr sticky registers
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, false);
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, WARM_RESET, false);
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+
+        while(1);
+
+    } else if (rst_count == 3) {
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it's not locked
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x0, &g_expected_data_dict);
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        // Loop through all RW register groups -- all registers should be unlocked
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+    }
+
+    // Test multiple inflight SoC AXI transactions
+    uint32_t w1_data = xorshift32(), w2_data = xorshift32();
+    axi_req_t w1, w2, r1, r2;
+    w1 = (axi_req_t) {
+        .addr = CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_0,
+        .axuser = 0,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = true,
+        .read  = false,
+        .use_id = true,
+        .id    = 1,
+        .wuser = (uint32_t[]){0},
+        .wdata = (uint32_t[]){w1_data},
+        .wstrb = (uint8_t[]){0xf}
+    };
+    w2 = (axi_req_t) {
+        .addr = CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_1,
+        .axuser = 0,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = true,
+        .read  = false,
+        .use_id = true,
+        .id    = 2,
+        .wuser = (uint32_t[]){0},
+        .wdata = (uint32_t[]){w2_data},
+        .wstrb = (uint8_t[]){0xf}
+    };
+    r1 = (axi_req_t) {
+        .addr = CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_2,
+        .axuser = 0,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = false,
+        .read = true,
+        .use_id = true,
+        .id    = 3,
+    };
+    r2 = (axi_req_t) {
+        .addr = CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_3,
+        .axuser = 0,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = false,
+        .read = true,
+        .use_id = true,
+        .id    = 4,
+    };
+
+    // Send address and simulate data delay
+    soc_write_addr(w1);
+    soc_write_addr(w2);
+    // Send address and simulate stall
+    soc_read_addr(r1);
+    soc_read_addr(r2);
+
+    soc_write_data(w1);
+    soc_write_data(w2);
+
+    // Get responses
+    axi_resp_t resp;
+    uint32_t value = lsu_read_32(w1.addr);
+    resp = soc_write_resp(w1);
+    if (resp.resp != 0 || value != w1_data) {
+        VPRINTF(LOW,  "Write to 0x%x failed, expected: %x, got %x!\n", w1.addr, w1_data, value);
+        error_count++;
+    }
+    value = lsu_read_32(w2.addr);
+    resp = soc_write_resp(w2);
+    if (resp.resp != 0 || value != w2_data) {
+        VPRINTF(LOW,  "Write to 0x%x failed, expected: %x, got %x!\n", w2.addr, w2_data, value);
+        error_count++;
+    }
+    value = lsu_read_32(r1.addr);
+    resp = soc_read_resp(r1);
+    if (resp.resp != 0 || value != resp.rdata) {
+        VPRINTF(LOW,  "Read from 0x%x failed, expected: %x, got %x!\n", r1.addr, value, resp.rdata);
+        error_count++;
+    }
+    value = lsu_read_32(r2.addr);
+    resp = soc_read_resp(r2);
+    if (resp.resp != 0 || value != resp.rdata) {
+        VPRINTF(LOW,  "Read from 0x%x failed, expected: %x, got %x!\n", r2.addr, value, resp.rdata);
+        error_count++;
+    }
+
+    VPRINTF(LOW,  "\nIFC SoC Read-Write, Caliptra Read-Only Register Access Tests Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.mk
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library, SoC access through generic wires helpers)
+OFILES += ifc_reg.o soc_access.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access/soc_access.h

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.yml
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_misc/ifc_reg_soc_rw_cptra_ro_misc.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_soc_rw_cptra_ro_misc

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/caliptra_isr.h
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.c
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "soc_access.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int rst_count __attribute__((section(".dccm.persistent"))) = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_WARM_RESET 0xF6
+#define TB_CMD_COLD_RESET 0xF5
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW,  "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
+
+    bool ro_reg = false;
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+                // Generate a unique value for each register
+                uint32_t rand_value = xorshift32();
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (!ro_reg) {
+                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                    }
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, rand_value);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW,  "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, write_data);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void main(void) {
+
+    rst_count++;
+    VPRINTF(LOW,  "----------------\nrst count = %d\n----------------\n", rst_count);
+
+    VPRINTF(LOW,  "==================\nIFC SoC RW, Caliptra RO Registers Test: PK HASHes, Revocation, Anti-Rollback, Key Type\n==================\n\n");
+
+    ifc_register_group_t ro_reg_groups[] = {
+        REG_GROUP_OWNER_PK_HASH_RO,
+        REG_GROUP_VENDOR_PK_HASH_RO,
+        REG_GROUP_ECC_REVOCATION_RO,
+        REG_GROUP_ANTI_ROLLBACK_RO,
+        REG_GROUP_KEY_TYPE_RO
+    };
+
+    const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+
+    if (rst_count == 1) {
+        ifc_init();
+
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it remains 1
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        // Issue warm reset
+        SEND_STDOUT_CTRL(TB_CMD_WARM_RESET);
+
+        while(1);
+
+    } else if (rst_count == 2) {
+
+        // Read all registers, expect register values to be retained fr sticky registers
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, false);
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, WARM_RESET, false);
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+
+        while(1);
+
+    } else if (rst_count == 3) {
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it's not locked
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x0, &g_expected_data_dict);
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, false);
+
+        // Loop through all RW register groups -- all registers should be unlocked
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, false);
+        }
+    }
+
+    VPRINTF(LOW,  "\nIFC SoC Read-Write, Caliptra Read-Only Register Access Tests Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.c
@@ -42,63 +42,41 @@ volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 
 void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
     int count = get_register_count(group);
-    VPRINTF(LOW,  "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
-
-    bool ro_reg = false;
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
-                // Generate a unique value for each register
-                uint32_t rand_value = xorshift32();
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (!ro_reg) {
-                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
-                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                    }
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, rand_value);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        uint32_t rand_value = xorshift32();
+        uint32_t mask = get_register_mask(reg->address);
+        if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+            VPRINTF(ERROR, "Dictionary full\n");
+            SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+            while(1);
         }
+        VPRINTF(MEDIUM, "Writing 0x%08x to (0x%08x)\n", rand_value, reg->address);
+        soc_write_32(reg->address, rand_value);
     }
 }
 
+
 void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
     int count = get_register_count(group);
-    VPRINTF(LOW,  "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
-                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, write_data);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        uint32_t mask = get_register_mask(reg->address);
+        if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+            VPRINTF(ERROR, "Dictionary full\n");
+            SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+            while(1);
         }
+        VPRINTF(MEDIUM, "Writing 0x%08x to (0x%08x)\n", write_data, reg->address);
+        soc_write_32(reg->address, write_data);
     }
 }
 
@@ -118,7 +96,7 @@ void main(void) {
     };
 
     const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1AA2);
 
     if (rst_count == 1) {
         ifc_init();

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.mk
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library, SoC access through generic wires helpers)
+OFILES += ifc_reg.o soc_access.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access/soc_access.h

--- a/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.yml
+++ b/src/integration/test_suites/ifc_reg_soc_rw_cptra_ro_pk_hash/ifc_reg_soc_rw_cptra_ro_pk_hash.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_soc_rw_cptra_ro_pk_hash

--- a/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/caliptra_isr.h
+++ b/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/caliptra_isr.h
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t abr_error;
+    uint32_t abr_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha3_error_intr() {return;}
+inline void service_sha3_notif_intr() {return;}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_abr_error_intr() {return;}
+inline void service_abr_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.c
@@ -42,64 +42,37 @@ volatile caliptra_intr_received_s cptra_intr_rcv = {0};
 
 void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
     int count = get_register_count(group);
-    VPRINTF(LOW,  "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
-
-    bool ro_reg = false;
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
-                // Generate a unique value for each register
-                uint32_t rand_value = xorshift32();
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (!ro_reg) {
-                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
-                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                    }
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, rand_value);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        uint32_t rand_value = xorshift32();
+        uint32_t mask = get_register_mask(reg->address);
+        if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+            VPRINTF(WARNING, "(0x%x): Could not store expected data\n", reg->address);
         }
+        VPRINTF(MEDIUM, "Writing 0x%08x to (0x%08x)\n", rand_value, reg->address);
+        soc_write_32(reg->address, rand_value);
     }
 }
 
 
 void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
     int count = get_register_count(group);
-    VPRINTF(LOW,  "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
 
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (reg) {
-            // Check if this register should be excluded using our efficient method
-            if (!is_register_excluded(reg->address)) {
+        if (!reg || is_register_excluded(reg->address)) continue;
 
-                /* Get mask for this register */
-                uint32_t mask = get_register_mask(reg->address);
-
-                // Store in dictionary
-                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
-                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
-                }
-
-                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
-                soc_write_32(reg->address, write_data);
-            } else {
-                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
-            }
+        uint32_t mask = get_register_mask(reg->address);
+        if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+            VPRINTF(WARNING, "(0x%x): Could not store expected data\n", reg->address);
         }
+        VPRINTF(MEDIUM, "Writing 0x%08x to (0x%08x)\n", write_data, reg->address);
+        soc_write_32(reg->address, write_data);
     }
 }
 
@@ -116,7 +89,7 @@ void main(void) {
     };
 
     const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1AA2);
 
     if (rst_count == 1) {
         ifc_init();

--- a/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.c
+++ b/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.c
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ifc_reg.h"
+#include "soc_access.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "printf.h"
+#include "riscv-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t  intr_count = 0;
+volatile int error_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile int rst_count __attribute__((section(".dccm.persistent"))) = 0;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+#define TB_CMD_WARM_RESET 0xF6
+#define TB_CMD_COLD_RESET 0xF5
+#define TB_CMD_TEST_PASS 0xFF
+#define TB_CMD_TEST_FAIL 0x01
+
+void soc_write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW,  "Writing random values to all %s registers (%d total):\n", get_group_name(group), count);
+
+    bool ro_reg = false;
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+                // Generate a unique value for each register
+                uint32_t rand_value = xorshift32();
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (!ro_reg) {
+                    if (set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, true) != 0) {
+                        VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                    }
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", rand_value, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, rand_value);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+
+void soc_write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    VPRINTF(LOW,  "Writing fixed value to all %s registers (%d total):\n", get_group_name(group), count);
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (reg) {
+            // Check if this register should be excluded using our efficient method
+            if (!is_register_excluded(reg->address)) {
+
+                /* Get mask for this register */
+                uint32_t mask = get_register_mask(reg->address);
+
+                // Store in dictionary
+                if (set_reg_exp_data(dict, reg->address, write_data, mask, true, group, true) != 0) {
+                    VPRINTF(MEDIUM, "  WARNING: Could not store expected data for %s[%d]\n", get_group_name(group), i);
+                }
+
+                VPRINTF(MEDIUM, "  Writing 0x%08x to %s[%d] (0x%08x)\n", write_data, get_group_name(group), i, reg->address);
+                soc_write_32(reg->address, write_data);
+            } else {
+                VPRINTF(MEDIUM, "  Skipping excluded register %s[%d] (0x%08x)\n", get_group_name(group), i, reg->address);
+            }
+        }
+    }
+}
+
+void main(void) {
+
+    rst_count++;
+    VPRINTF(LOW,  "----------------\nrst count = %d\n----------------\n", rst_count);
+
+    VPRINTF(LOW,  "==================\nIFC SoC WO, HW RO Registers Test\n==================\n\n");
+
+    ifc_register_group_t ro_reg_groups[] = {
+        REG_GROUP_UDS_RO,
+        REG_GROUP_FIELD_ENTROPY_RO
+    };
+
+    const int num_groups =  sizeof(ro_reg_groups) / sizeof(ro_reg_groups[0]);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x1A7F);
+
+    if (rst_count == 1) {
+        ifc_init();
+
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, true);
+        }
+
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, true);
+
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, true);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it remains 1
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x1, &g_expected_data_dict);
+
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, true);
+
+        // Issue warm reset
+        SEND_STDOUT_CTRL(TB_CMD_WARM_RESET);
+
+        while(1);
+
+    } else if (rst_count == 2) {
+
+        // Read all registers, expect register values to be retained fr sticky registers
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, true, WARM_RESET, true);
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, WARM_RESET, true);
+        }
+
+        // Issue cold reset
+        SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+
+        while(1);
+
+    } else if (rst_count == 3) {
+        // Loop through all RW register groups
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, true);
+        }
+
+        // Write 0 to CPTRA_FUSE_WR_DONE register, make sure it's not locked
+        soc_write_to_register_group_and_track(REG_GROUP_FUSE_RO, 0x0, &g_expected_data_dict);
+        read_register_group_and_verify(REG_GROUP_FUSE_RO, &g_expected_data_dict, false, COLD_RESET, true);
+
+        // Loop through all RW register groups -- all registers should be unlocked
+        for (int i = 0; i < num_groups; i++) {
+            ifc_register_group_t group = ro_reg_groups[i];
+
+            // Write random values to all registers in this group
+            soc_write_random_to_register_group_and_track(group, &g_expected_data_dict);
+
+            // Read registers and verify data matches
+            error_count += read_register_group_and_verify(group, &g_expected_data_dict, false, COLD_RESET, true);
+        }
+    }
+
+    VPRINTF(LOW,  "\nIFC SoC Read-Write, Caliptra Read-Only Register Access Tests Completed\n");
+
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (error_count == 0 ) {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_PASS);
+    } else {
+        SEND_STDOUT_CTRL(TB_CMD_TEST_FAIL);
+    }
+}

--- a/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.mk
+++ b/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Link ifc_reg and soc_access libraries (register testing library, SoC access through generic wires helpers)
+OFILES += ifc_reg.o soc_access.o
+AUX_LIB_DIR += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access
+AUX_HEADER_FILES += $(CALIPTRA_ROOT)/src/integration/test_suites/libs/ifc_reg/ifc_reg.h $(CALIPTRA_ROOT)/src/integration/test_suites/libs/soc_access/soc_access.h

--- a/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.yml
+++ b/src/integration/test_suites/ifc_reg_soc_rw_hw_ro/ifc_reg_soc_rw_hw_ro.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: ${PLAYBOOK_RANDOM_SEED}
+testname: ifc_reg_soc_rw_hw_ro

--- a/src/integration/test_suites/libs/caliptra_rtl_lib/caliptra_rtl_lib.c
+++ b/src/integration/test_suites/libs/caliptra_rtl_lib/caliptra_rtl_lib.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/integration/test_suites/libs/ifc_reg/ifc_reg.c
+++ b/src/integration/test_suites/libs/ifc_reg/ifc_reg.c
@@ -82,7 +82,11 @@ bool is_ro(ifc_register_group_t group) {
 }
 
 uint32_t report_mismatch(ifc_register_group_t group, uint32_t id, uint32_t reg_addr, uint32_t read_data, uint32_t exp_data) {
-    VPRINTF(LOW, "No match: %s[%d] (0x%08x): Read 0x%08x, Expected 0x%08x\n", get_group_name(group), id, reg_addr, read_data, exp_data);
+    VPRINTF(LOW, "(0x%08x): Read 0x%08x, Expected 0x%08x\n", reg_addr, read_data, exp_data);
+}
+
+uint32_t report_no_data(uint32_t reg_addr) {
+    VPRINTF(ERROR, "(0x%08x): No expected data in dictionary\n", reg_addr);
 }
 
 // Array of register with non-zero initial values
@@ -536,57 +540,6 @@ const ifc_register_info_t *register_groups[] = {
     REG_GROUP_INTERRUPT_NOTIF_COUNTERS_INCR_RO_ARRAY
 };
 
-/* Function to get a string representation of a register group */
-const char* get_group_name(ifc_register_group_t group) {
-    switch(group) {
-        case REG_GROUP_CAPABILITIES: return "Capabilities";
-        case REG_GROUP_STRAPS_RO: return "Caliptra Straps RO";
-        case REG_GROUP_STATUS: return "Status";
-        case REG_GROUP_STATUS_RO: return "Status-RO";
-        case REG_GROUP_SECURITY_RO: return "Security-RO";
-        case REG_GROUP_ERROR_RW1C: return "Ftl/Non-Ftl err W1C";
-        case REG_GROUP_ERROR: return "Ftl/Non-Ftl Err";
-        case REG_GROUP_ERROR_MASK: return "Err Mask";
-        case REG_GROUP_WATCHDOG: return "Watchdog";
-        case REG_GROUP_WATCHDOG_RO: return "Watchdog-RO";
-        case REG_GROUP_MCU: return "MCU";
-        case REG_GROUP_CONTROL: return "Control";
-        case REG_GROUP_CONTROL_RO: return "Control RO (Tap Access RW in Debug Mode)";
-        case REG_GROUP_MBOX: return "IFC Mailbox AXI User";
-        case REG_GROUP_MBOX_RW1S: return "IFC Mailbox AXI User Lock";
-        case REG_GROUP_DBG_MANUF_SERVICE: return "Debug Services";
-        case REG_GROUP_GENERIC_WIRES: return "Generic Wires";
-        case REG_GROUP_GENERIC_WIRES_RO: return "Generic Wires - RO";
-        case REG_GROUP_FW: return "FW Reset Cycles";
-        case REG_GROUP_FW_PULSE_RW1S: return "FW Reset";
-        case REG_GROUP_TRNG: return "TRNG control registers";
-        case REG_GROUP_TRNG_RW1S: return "TRNG AXI User Lock";
-        case REG_GROUP_FUSE: return "Fuse AXI User";
-        case REG_GROUP_FUSE_RW1S: return "Fuse AXI User Lock";
-        case REG_GROUP_FUSE_RO: return "Fuse Status - RO";
-        case REG_GROUP_OWNER_PK_HASH_RO: return "Caliptra Owner PK Hash - RO";
-        case REG_GROUP_UDS_RO: return "Unique Device Secret - RO";
-        case REG_GROUP_FIELD_ENTROPY_RO: return "Field Entropy - RO";
-        case REG_GROUP_VENDOR_PK_HASH_RO: return "Vendor PK Hash - RO";
-        case REG_GROUP_ECC_REVOCATION_RO: return "ECC Revocation - RO";
-        case REG_GROUP_SVN_RO: return "Security Version Number - RO";
-        case REG_GROUP_ANTI_ROLLBACK_RO: return "Anti Rollback - RO";
-        case REG_GROUP_IDEVID_RO: return "IDevID - RO";
-        case REG_GROUP_MANUF_DBG_UNLOCK_RO: return "Manufacturing Debug Unlock Token - RO";
-        case REG_GROUP_SOC_STEPPING_RO: return " SoC Stepping - RO";
-        case REG_GROUP_KEY_TYPE_RO: return "PQC Key Type - RO";
-        case REG_GROUP_INTERRUPT_EN: return "Intrpt Enable";
-        case REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO: return "Intrpt Global Status RO";
-        case REG_GROUP_INTERRUPT_STATUS_RW1C: return "Intrpt Status W1C";
-        case REG_GROUP_INTERRUPT_TRIGGER_PULSE_RW1S: return "Intrpt Trigger Pulse W1S";
-        case REG_GROUP_INTERRUPT_ERROR_COUNTERS: return "Err Intrpt Counters";
-        case REG_GROUP_INTERRUPT_NOTIF_COUNTERS: return "Notif Intrpt Counters";
-        case REG_GROUP_INTERRUPT_ERROR_COUNTERS_INCR_RO: return "Err Intrpt Counters Increment - RO";
-        case REG_GROUP_INTERRUPT_NOTIF_COUNTERS_INCR_RO: return "Notif Intrpt Counters Increment - RO";
-        default: return "Unknown";
-    }
-}
-
 /* Get the number of registers in a group */
 int get_register_count(ifc_register_group_t group) {
     int count = 0;
@@ -986,8 +939,7 @@ int exclude_register(uint32_t reg_addr) {
         return 0;
     }
 
-    // Collision table is full
-    VPRINTF(WARNING, "Collision table full, cannot add register 0x%08x\n", reg_addr);
+    VPRINTF(WARNING, "Collision table full");
     return -1;
 }
 
@@ -1096,13 +1048,8 @@ int read_register_group_and_verify(ifc_register_group_t group, ifc_reg_exp_dict_
     for (int i = 0; i < count; i++) {
         const ifc_register_info_t *reg = get_register_info(group, i);
 
-        if (!reg) {
-            VPRINTF(ERROR, "Register index %d not found in group\n", i);
-            continue;
-        }
-
         // Skip excluded registers with collision-aware check
-        if (is_register_excluded(reg->address)) {
+        if (!reg || is_register_excluded(reg->address)) {
             continue;
         }
 
@@ -1112,14 +1059,14 @@ int read_register_group_and_verify(ifc_register_group_t group, ifc_reg_exp_dict_
             const ifc_register_info_t *cmd_reg = get_register_info(REG_GROUP_GENERIC_WIRES, 0);
             const ifc_register_info_t *rsp_reg0 = get_register_info(REG_GROUP_GENERIC_WIRES_RO, 0);
             const ifc_register_info_t *rsp_reg1 = get_register_info(REG_GROUP_GENERIC_WIRES_RO, 1);
-            ifc_reg_write(cmd_reg->address, 0x207F | ((i << 7) & 0xF00));
+            ifc_reg_write(cmd_reg->address, 0x20A2 | ((i << 7) & 0xF00));
             read_data = i & 1 ? ifc_reg_read(rsp_reg0->address): ifc_reg_read(rsp_reg1->address);
         }
         if (group == REG_GROUP_FIELD_ENTROPY_RO && use_hw) {
             const ifc_register_info_t *cmd_reg = get_register_info(REG_GROUP_GENERIC_WIRES, 0);
             const ifc_register_info_t *rsp_reg0 = get_register_info(REG_GROUP_GENERIC_WIRES_RO, 0);
             const ifc_register_info_t *rsp_reg1 = get_register_info(REG_GROUP_GENERIC_WIRES_RO, 1);
-            ifc_reg_write(cmd_reg->address, 0x307F | ((i << 7) & 0xF00));
+            ifc_reg_write(cmd_reg->address, 0x30A2 | ((i << 7) & 0xF00));
             read_data = i & 1 ? ifc_reg_read(rsp_reg0->address): ifc_reg_read(rsp_reg1->address);
         }
 
@@ -1181,8 +1128,7 @@ int read_register_group_and_verify(ifc_register_group_t group, ifc_reg_exp_dict_
                             mismatch_count++;
                         }
                     } else {
-                        VPRINTF(ERROR, "%s[%d] (0x%08x): Read 0x%08x, No expected data in dictionary\n",
-                                get_group_name(group), i, reg->address, read_data);
+                        report_no_data(reg->address);
                     }
                 }
             } else if (reset_type == WARM_RESET) {
@@ -1222,8 +1168,7 @@ int read_register_group_and_verify(ifc_register_group_t group, ifc_reg_exp_dict_
                             mismatch_count++;
                         }
                     } else {
-                        VPRINTF(ERROR, "%s[%d] (0x%08x): Read 0x%08x, No expected data in dictionary\n",
-                                get_group_name(group), i, reg->address, read_data);
+                        report_no_data(reg->address);
                     }
                 } else {
                     if (reg->has_init_value == true) {
@@ -1282,7 +1227,7 @@ int read_register_group_and_verify(ifc_register_group_t group, ifc_reg_exp_dict_
                                 mismatch_count++;
                             }
                         } else {
-                            VPRINTF(ERROR, "%s[%d] (0x%08x): Read 0x%08x, No expected data in dictionary\n", get_group_name(group), i, reg->address, read_data);
+                            report_no_data(reg->address);
                         }
                     }
                 }
@@ -1315,7 +1260,7 @@ int read_register_group_and_verify(ifc_register_group_t group, ifc_reg_exp_dict_
                     mismatch_count++;
                 }
             } else {
-                VPRINTF(ERROR, "%s[%d] (0x%08x): Read 0x%08x, No expected data in dictionary\n", get_group_name(group), i, reg->address, read_data);
+                report_no_data(reg->address);
             }
         }
     }
@@ -1347,12 +1292,10 @@ void read_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_
 
             // Store in dictionary
             if (set_reg_exp_data(dict, reg->address, read_data, mask, false, group, false) != 0) {
-                VPRINTF(WARNING, "Could not store read data for %s[%d]\n", get_group_name(group), i);
+                VPRINTF(ERROR, "Dictionary full\n");
             }
         }
     }
-
-    VPRINTF(LOW, "Register tracking complete: %d register(s) read and tracked\n", count);
 }
 
 

--- a/src/integration/test_suites/libs/ifc_reg/ifc_reg.c
+++ b/src/integration/test_suites/libs/ifc_reg/ifc_reg.c
@@ -1,0 +1,1483 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ifc_reg.h"
+#include "caliptra_reg.h"
+#include "printf.h"
+#include "riscv_hw_if.h"
+#include "string.h"
+#include "stdint.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define ADDRESS_BITS_FOR_INDEXING 12   // 4096 possible indices
+#define BITMAP_SIZE_WORDS ((1 << ADDRESS_BITS_FOR_INDEXING) / 32)
+
+/* Global dictionary for expected register values */
+ifc_reg_exp_dict_t g_expected_data_dict  __attribute__((section(".dccm.persistent")));
+static register_mask_dict_t g_mask_dict  __attribute__((section(".dccm.persistent")));
+// The bitmap array for register exclusions
+static uint32_t excluded_registers_bitmap[BITMAP_SIZE_WORDS] __attribute__((section(".dccm.persistent")));
+
+// Collision table to handle hash collisions - stores full register addresses
+#define MAX_EXCLUDED_REGISTERS 4
+static uint32_t collision_table[MAX_EXCLUDED_REGISTERS] __attribute__((section(".dccm.persistent"))) = {0};
+static uint8_t collision_count __attribute__((section(".dccm.persistent"))) = 0;
+
+/**
+ * Read a 32-bit IFC register value
+ *
+ * @param reg_addr Register address
+ * @return The register value
+ */
+uint32_t ifc_reg_read(uint32_t reg_addr) {
+    return lsu_read_32(reg_addr);
+}
+
+/**
+ * Write a 32-bit value to an IFC register
+ *
+ * @param reg_addr Register address
+ * @param value Value to write
+ */
+void ifc_reg_write(uint32_t reg_addr, uint32_t value) {
+    lsu_write_32(reg_addr, value);
+}
+
+bool is_ro(ifc_register_group_t group) {
+    return (group == REG_GROUP_STRAPS_RO ||
+        group == REG_GROUP_STATUS_RO ||
+        group == REG_GROUP_SECURITY_RO ||
+        group == REG_GROUP_WATCHDOG_RO ||
+        group == REG_GROUP_CONTROL_RO ||
+        group == REG_GROUP_GENERIC_WIRES_RO ||
+        group == REG_GROUP_FUSE_RO ||
+        group == REG_GROUP_OWNER_PK_HASH_RO ||
+        group == REG_GROUP_UDS_RO ||
+        group == REG_GROUP_FIELD_ENTROPY_RO ||
+        group == REG_GROUP_VENDOR_PK_HASH_RO ||
+        group == REG_GROUP_ECC_REVOCATION_RO ||
+        group == REG_GROUP_SVN_RO ||
+        group == REG_GROUP_ANTI_ROLLBACK_RO ||
+        group == REG_GROUP_IDEVID_RO ||
+        group == REG_GROUP_MANUF_DBG_UNLOCK_RO ||
+        group == REG_GROUP_SOC_STEPPING_RO ||
+        group == REG_GROUP_KEY_TYPE_RO ||
+        group == REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO ||
+        group == REG_GROUP_INTERRUPT_ERROR_COUNTERS_INCR_RO ||
+        group == REG_GROUP_INTERRUPT_NOTIF_COUNTERS_INCR_RO);
+}
+
+uint32_t report_mismatch(ifc_register_group_t group, uint32_t id, uint32_t reg_addr, uint32_t read_data, uint32_t exp_data) {
+    VPRINTF(LOW, "No match: %s[%d] (0x%08x): Read 0x%08x, Expected 0x%08x\n", get_group_name(group), id, reg_addr, read_data, exp_data);
+}
+
+// Array of register with non-zero initial values
+const ifc_reg_def_value_t reg_init_values[] = {
+    {CLP_SOC_IFC_REG_SS_CALIPTRA_BASE_ADDR_L, 0xBA5EBA11},  // Set in caliptra_top_tb.sv
+    {CLP_SOC_IFC_REG_CPTRA_SECURITY_STATE,    0x00000007},  // Base TB configuration is locked production
+    {CLP_SOC_IFC_REG_CPTRA_FUSE_WR_DONE,      0x00000001},  // Register read post start, RO from CPTRA, RW from SoC
+    {CLP_SOC_IFC_REG_FUSE_SOC_STEPPING_ID,    0x00000001},
+    {CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_0, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_1, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_2, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_3, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_4, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_TRNG_VALID_AXI_USER,   0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_FUSE_VALID_AXI_USER,   0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_WDT_TIMER1_TIMEOUT_PERIOD_0, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_WDT_TIMER1_TIMEOUT_PERIOD_1, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_WDT_TIMER2_TIMEOUT_PERIOD_0, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_CPTRA_WDT_TIMER2_TIMEOUT_PERIOD_1, 0xFFFFFFFF},
+    {CLP_SOC_IFC_REG_INTERNAL_FW_UPDATE_RESET_WAIT_CYCLES, 0x00000005}
+};
+
+/* Group structs*/
+
+const ifc_register_info_t REG_GROUP_CAPABILITIES_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_HW_CAPABILITIES, REG_EXT_LOCK, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_CAPABILITIES, REG_EXT_LOCK, false },
+    { CLP_SOC_IFC_REG_CPTRA_CAP_LOCK, REG_SELF_LOCK_NON_ZERO, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_STRAPS_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_SS_CALIPTRA_BASE_ADDR_L, REG_EXT_LOCK_STICKY, true },
+    { CLP_SOC_IFC_REG_SS_CALIPTRA_BASE_ADDR_H, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_MCI_BASE_ADDR_L, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_MCI_BASE_ADDR_H, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_RECOVERY_IFC_BASE_ADDR_L, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_RECOVERY_IFC_BASE_ADDR_H, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_OTP_FC_BASE_ADDR_L, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_OTP_FC_BASE_ADDR_H, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_UDS_SEED_BASE_ADDR_L, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_UDS_SEED_BASE_ADDR_H, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_PROD_DEBUG_UNLOCK_AUTH_PK_HASH_REG_BANK_OFFSET, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_NUM_OF_PROD_DEBUG_UNLOCK_AUTH_PK_HASHES, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_CALIPTRA_DMA_AXI_USER, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_STRAPS_RO_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_SS_DEBUG_INTENT, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_STATUS_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_BOOT_STATUS, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_DBG_MANUF_SERVICE_REG, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_RSVD_REG_0, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_RSVD_REG_1, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_STATUS_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_RESET_REASON, REG_STICKY, false }, // bit 1 non sticky
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_SECURITY_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_SECURITY_STATE, REG_NOT_STICKY, true },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_ERROR_RW1C_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_HW_ERROR_FATAL, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_HW_ERROR_NON_FATAL, REG_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_ERROR_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_FW_ERROR_FATAL, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_ERROR_NON_FATAL, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_HW_ERROR_ENC, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_ERROR_ENC, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_0, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_1, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_2, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_3, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_4, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_5, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_6, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_FW_EXTENDED_ERROR_INFO_7, REG_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_ERROR_MASK_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTERNAL_HW_ERROR_FATAL_MASK, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTERNAL_HW_ERROR_NON_FATAL_MASK, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTERNAL_FW_ERROR_FATAL_MASK, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTERNAL_FW_ERROR_NON_FATAL_MASK, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_WATCHDOG_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_WDT_TIMER1_EN, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_TIMER1_CTRL, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_TIMER1_TIMEOUT_PERIOD_0, REG_NOT_STICKY, true },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_TIMER1_TIMEOUT_PERIOD_1, REG_NOT_STICKY, true },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_TIMER2_EN, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_TIMER2_CTRL, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_TIMER2_TIMEOUT_PERIOD_0, REG_NOT_STICKY, true },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_TIMER2_TIMEOUT_PERIOD_1, REG_NOT_STICKY, true },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_CFG_0, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_WDT_CFG_1, REG_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_WATCHDOG_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_WDT_STATUS, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_MCU_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_TIMER_CONFIG, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTERNAL_RV_MTIME_L, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTERNAL_RV_MTIME_H, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTERNAL_RV_MTIMECMP_L, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTERNAL_RV_MTIMECMP_H, REG_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_CONTROL_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTERNAL_ICCM_LOCK, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTERNAL_NMI_VECTOR, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_CONTROL_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_CLK_GATING_EN, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_MBOX_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_0, REG_EXT_LOCK, true },
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_1, REG_EXT_LOCK, true },
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_2, REG_EXT_LOCK, true },
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_3, REG_EXT_LOCK, true },
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_VALID_AXI_USER_4, REG_EXT_LOCK, true },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_MBOX_RW1S_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_0, REG_SELF_LOCK_NON_ZERO, false },
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_1, REG_SELF_LOCK_NON_ZERO, false },
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_2, REG_SELF_LOCK_NON_ZERO, false },
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_3, REG_SELF_LOCK_NON_ZERO, false },
+    { CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_4, REG_SELF_LOCK_NON_ZERO, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_DBG_MANUF_SERVICE_ARRAY [] = {
+    { CLP_SOC_IFC_REG_SS_DBG_SERVICE_REG_REQ, REG_EXT_LOCK, false },
+    { CLP_SOC_IFC_REG_SS_DBG_SERVICE_REG_RSP, REG_EXT_LOCK, false },
+    { CLP_SOC_IFC_REG_SS_SOC_DBG_UNLOCK_LEVEL_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_SOC_DBG_UNLOCK_LEVEL_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_GENERIC_FW_EXEC_CTRL_0, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_GENERIC_FW_EXEC_CTRL_1, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_GENERIC_FW_EXEC_CTRL_2, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_SS_GENERIC_FW_EXEC_CTRL_3, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_GENERIC_WIRES_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_GENERIC_WIRES_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_1, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_FW_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTERNAL_FW_UPDATE_RESET_WAIT_CYCLES, REG_NOT_STICKY, true },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_FW_PULSE_RW1S_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTERNAL_FW_UPDATE_RESET, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_TRNG_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_TRNG_VALID_AXI_USER, REG_EXT_LOCK, true },
+    { CLP_SOC_IFC_REG_CPTRA_TRNG_STATUS, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_ITRNG_ENTROPY_CONFIG_0, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_ITRNG_ENTROPY_CONFIG_1, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_TRNG_RW1S_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_TRNG_AXI_USER_LOCK, REG_SELF_LOCK_NON_ZERO, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_TRNG_PULSE_RW1S_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_TRNG_CTRL, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_FUSE_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_FUSE_VALID_AXI_USER, REG_EXT_LOCK_STICKY, true },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_FUSE_RW1S_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_FUSE_AXI_USER_LOCK, REG_SELF_LOCK_NON_ZERO_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_FUSE_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_FUSE_WR_DONE, REG_EXT_LOCK_STICKY, true },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_OWNER_PK_HASH_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_3, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_4, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_5, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_6, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_7, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_8, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_9, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_10, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_11, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_LOCK, REG_SELF_LOCK_NON_ZERO_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_UDS_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_3, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_4, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_5, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_6, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_7, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_8, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_9, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_10, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_11, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_12, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_13, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_14, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_UDS_SEED_15, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_FIELD_ENTROPY_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_FIELD_ENTROPY_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_FIELD_ENTROPY_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_FIELD_ENTROPY_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_FIELD_ENTROPY_3, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_FIELD_ENTROPY_4, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_FIELD_ENTROPY_5, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_FIELD_ENTROPY_6, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_FIELD_ENTROPY_7, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_VENDOR_PK_HASH_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_3, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_4, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_5, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_6, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_7, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_8, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_9, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_10, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_VENDOR_PK_HASH_11, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_ECC_REVOCATION_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_ECC_REVOCATION, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_LMS_REVOCATION, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MLDSA_REVOCATION, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_SVN_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_FMC_KEY_MANIFEST_SVN, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_RUNTIME_SVN_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_RUNTIME_SVN_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_RUNTIME_SVN_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_RUNTIME_SVN_3, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_SOC_MANIFEST_SVN_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_SOC_MANIFEST_SVN_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_SOC_MANIFEST_SVN_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_SOC_MANIFEST_SVN_3, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_SOC_MANIFEST_MAX_SVN, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_ANTI_ROLLBACK_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_ANTI_ROLLBACK_DISABLE,  REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_IDEVID_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_3, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_4, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_5, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_6, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_7, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_8, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_9, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_10, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_11, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_12, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_13, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_14, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_15, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_16, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_17, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_18, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_19, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_20, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_21, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_22, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_CERT_ATTR_23, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_MANUF_HSM_ID_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_MANUF_HSM_ID_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_MANUF_HSM_ID_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_IDEVID_MANUF_HSM_ID_3, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_MANUF_DBG_UNLOCK_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_0, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_1, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_2, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_3, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_4, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_5, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_6, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_7, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_8, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_9, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_10, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_11, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_12, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_13, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_14, REG_EXT_LOCK_STICKY, false },
+    { CLP_SOC_IFC_REG_FUSE_MANUF_DBG_UNLOCK_TOKEN_15, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_SOC_STEPPING_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_SOC_STEPPING_ID, REG_EXT_LOCK_STICKY, true },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_KEY_TYPE_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_FUSE_PQC_KEY_TYPE, REG_EXT_LOCK_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_INTERRUPT_EN_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_GLOBAL_INTR_EN_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_EN_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_GLOBAL_INTR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_GLOBAL_INTR_R, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_INTERRUPT_STATUS_RW1C_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_INTERRUPT_TRIGGER_PULSE_RW1S_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTR_TRIG_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTR_TRIG_R, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_INTERRUPT_ERROR_COUNTERS_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_COUNT_R,           REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INV_DEV_INTR_COUNT_R,            REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_CMD_FAIL_INTR_COUNT_R,           REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_BAD_FUSE_INTR_COUNT_R,           REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_ICCM_BLOCKED_INTR_COUNT_R,       REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_MBOX_ECC_UNC_INTR_COUNT_R,       REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_WDT_TIMER1_TIMEOUT_INTR_COUNT_R, REG_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_WDT_TIMER2_TIMEOUT_INTR_COUNT_R, REG_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_INTERRUPT_NOTIF_COUNTERS_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_CMD_AVAIL_INTR_COUNT_R,     REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_MBOX_ECC_COR_INTR_COUNT_R,  REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_DEBUG_LOCKED_INTR_COUNT_R,  REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_SCAN_MODE_INTR_COUNT_R,     REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_SOC_REQ_LOCK_INTR_COUNT_R,  REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_GEN_IN_TOGGLE_INTR_COUNT_R, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_INTERRUPT_ERROR_COUNTERS_INCR_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INV_DEV_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_CMD_FAIL_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_BAD_FUSE_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_ICCM_BLOCKED_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_MBOX_ECC_UNC_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_WDT_TIMER1_TIMEOUT_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_WDT_TIMER2_TIMEOUT_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+const ifc_register_info_t REG_GROUP_INTERRUPT_NOTIF_COUNTERS_INCR_RO_ARRAY [] = {
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_CMD_AVAIL_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_MBOX_ECC_COR_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_DEBUG_LOCKED_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_SCAN_MODE_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_SOC_REQ_LOCK_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_GEN_IN_TOGGLE_INTR_COUNT_INCR_R, REG_NOT_STICKY, false },
+    { 0, REG_NOT_STICKY, false }  // End marker
+};
+
+/* Array of register infos by group */
+const ifc_register_info_t *register_groups[] = {
+    REG_GROUP_CAPABILITIES_ARRAY,
+    REG_GROUP_STRAPS_RO_ARRAY,
+    REG_GROUP_STRAPS_RO_RO_ARRAY,
+    REG_GROUP_STATUS_ARRAY,
+    REG_GROUP_STATUS_RO_ARRAY,
+    REG_GROUP_SECURITY_RO_ARRAY,
+    REG_GROUP_ERROR_RW1C_ARRAY,
+    REG_GROUP_ERROR_ARRAY,
+    REG_GROUP_ERROR_MASK_ARRAY,
+    REG_GROUP_WATCHDOG_ARRAY,
+    REG_GROUP_WATCHDOG_RO_ARRAY,
+    REG_GROUP_MCU_ARRAY,
+    REG_GROUP_CONTROL_ARRAY,
+    REG_GROUP_CONTROL_RO_ARRAY,
+    REG_GROUP_MBOX_ARRAY,
+    REG_GROUP_MBOX_RW1S_ARRAY,
+    REG_GROUP_DBG_MANUF_SERVICE_ARRAY,
+    REG_GROUP_GENERIC_WIRES_ARRAY,
+    REG_GROUP_GENERIC_WIRES_RO_ARRAY,
+    REG_GROUP_FW_ARRAY,
+    REG_GROUP_FW_PULSE_RW1S_ARRAY,
+    REG_GROUP_TRNG_ARRAY,
+    REG_GROUP_TRNG_RW1S_ARRAY,
+    REG_GROUP_TRNG_PULSE_RW1S_ARRAY,
+    REG_GROUP_FUSE_ARRAY,
+    REG_GROUP_FUSE_RW1S_ARRAY,
+    REG_GROUP_FUSE_RO_ARRAY,
+    REG_GROUP_OWNER_PK_HASH_RO_ARRAY,
+    REG_GROUP_UDS_RO_ARRAY,
+    REG_GROUP_FIELD_ENTROPY_RO_ARRAY,
+    REG_GROUP_VENDOR_PK_HASH_RO_ARRAY,
+    REG_GROUP_ECC_REVOCATION_RO_ARRAY,
+    REG_GROUP_SVN_RO_ARRAY,
+    REG_GROUP_ANTI_ROLLBACK_RO_ARRAY,
+    REG_GROUP_IDEVID_RO_ARRAY,
+    REG_GROUP_MANUF_DBG_UNLOCK_RO_ARRAY,
+    REG_GROUP_SOC_STEPPING_RO_ARRAY,
+    REG_GROUP_KEY_TYPE_RO_ARRAY,
+    REG_GROUP_INTERRUPT_EN_ARRAY,
+    REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO_ARRAY,
+    REG_GROUP_INTERRUPT_STATUS_RW1C_ARRAY,
+    REG_GROUP_INTERRUPT_TRIGGER_PULSE_RW1S_ARRAY,
+    REG_GROUP_INTERRUPT_ERROR_COUNTERS_ARRAY,
+    REG_GROUP_INTERRUPT_NOTIF_COUNTERS_ARRAY,
+    REG_GROUP_INTERRUPT_ERROR_COUNTERS_INCR_RO_ARRAY,
+    REG_GROUP_INTERRUPT_NOTIF_COUNTERS_INCR_RO_ARRAY
+};
+
+/* Function to get a string representation of a register group */
+const char* get_group_name(ifc_register_group_t group) {
+    switch(group) {
+        case REG_GROUP_CAPABILITIES: return "Capabilities";
+        case REG_GROUP_STRAPS_RO: return "Caliptra Straps RO";
+        case REG_GROUP_STATUS: return "Status";
+        case REG_GROUP_STATUS_RO: return "Status-RO";
+        case REG_GROUP_SECURITY_RO: return "Security-RO";
+        case REG_GROUP_ERROR_RW1C: return "Ftl/Non-Ftl err W1C";
+        case REG_GROUP_ERROR: return "Ftl/Non-Ftl Err";
+        case REG_GROUP_ERROR_MASK: return "Err Mask";
+        case REG_GROUP_WATCHDOG: return "Watchdog";
+        case REG_GROUP_WATCHDOG_RO: return "Watchdog-RO";
+        case REG_GROUP_MCU: return "MCU";
+        case REG_GROUP_CONTROL: return "Control";
+        case REG_GROUP_CONTROL_RO: return "Control RO (Tap Access RW in Debug Mode)";
+        case REG_GROUP_MBOX: return "IFC Mailbox AXI User";
+        case REG_GROUP_MBOX_RW1S: return "IFC Mailbox AXI User Lock";
+        case REG_GROUP_DBG_MANUF_SERVICE: return "Debug Services";
+        case REG_GROUP_GENERIC_WIRES: return "Generic Wires";
+        case REG_GROUP_GENERIC_WIRES_RO: return "Generic Wires - RO";
+        case REG_GROUP_FW: return "FW Reset Cycles";
+        case REG_GROUP_FW_PULSE_RW1S: return "FW Reset";
+        case REG_GROUP_TRNG: return "TRNG control registers";
+        case REG_GROUP_TRNG_RW1S: return "TRNG AXI User Lock";
+        case REG_GROUP_FUSE: return "Fuse AXI User";
+        case REG_GROUP_FUSE_RW1S: return "Fuse AXI User Lock";
+        case REG_GROUP_FUSE_RO: return "Fuse Status - RO";
+        case REG_GROUP_OWNER_PK_HASH_RO: return "Caliptra Owner PK Hash - RO";
+        case REG_GROUP_UDS_RO: return "Unique Device Secret - RO";
+        case REG_GROUP_FIELD_ENTROPY_RO: return "Field Entropy - RO";
+        case REG_GROUP_VENDOR_PK_HASH_RO: return "Vendor PK Hash - RO";
+        case REG_GROUP_ECC_REVOCATION_RO: return "ECC Revocation - RO";
+        case REG_GROUP_SVN_RO: return "Security Version Number - RO";
+        case REG_GROUP_ANTI_ROLLBACK_RO: return "Anti Rollback - RO";
+        case REG_GROUP_IDEVID_RO: return "IDevID - RO";
+        case REG_GROUP_MANUF_DBG_UNLOCK_RO: return "Manufacturing Debug Unlock Token - RO";
+        case REG_GROUP_SOC_STEPPING_RO: return " SoC Stepping - RO";
+        case REG_GROUP_KEY_TYPE_RO: return "PQC Key Type - RO";
+        case REG_GROUP_INTERRUPT_EN: return "Intrpt Enable";
+        case REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO: return "Intrpt Global Status RO";
+        case REG_GROUP_INTERRUPT_STATUS_RW1C: return "Intrpt Status W1C";
+        case REG_GROUP_INTERRUPT_TRIGGER_PULSE_RW1S: return "Intrpt Trigger Pulse W1S";
+        case REG_GROUP_INTERRUPT_ERROR_COUNTERS: return "Err Intrpt Counters";
+        case REG_GROUP_INTERRUPT_NOTIF_COUNTERS: return "Notif Intrpt Counters";
+        case REG_GROUP_INTERRUPT_ERROR_COUNTERS_INCR_RO: return "Err Intrpt Counters Increment - RO";
+        case REG_GROUP_INTERRUPT_NOTIF_COUNTERS_INCR_RO: return "Notif Intrpt Counters Increment - RO";
+        default: return "Unknown";
+    }
+}
+
+/* Get the number of registers in a group */
+int get_register_count(ifc_register_group_t group) {
+    int count = 0;
+
+    if (group >= REG_GROUP_COUNT) {
+        return 0;
+    }
+
+    while (register_groups[group][count].address != 0) {
+        count++;
+    }
+
+    return count;
+}
+
+/* Get register information by its index within a group */
+const ifc_register_info_t* get_register_info(ifc_register_group_t group, int index) {
+    if (group >= REG_GROUP_COUNT) {
+        return NULL;
+    }
+
+    if (index < 0 || index >= MAX_REGISTERS_PER_GROUP) {
+        return NULL;
+    }
+
+    if (register_groups[group][index].address == 0) {
+        return NULL;
+    }
+
+    return &register_groups[group][index];
+}
+
+/**
+ * Function to find a register by address (across all groups)
+ *
+ * @param address Register address
+ * @param group_index Pointer to store group index
+ * @param reg_index Pointer to store register index
+ * @return Register info pointer, or NULL if not found
+ */
+const ifc_register_info_t* find_register_by_address(uint32_t address,
+                                                   ifc_register_group_t *group_index,
+                                                   int *reg_index,
+                                                   ifc_register_group_t start_index) {
+    for (int group = start_index; group < REG_GROUP_COUNT; group++) {
+        int count = get_register_count((ifc_register_group_t)group);
+
+        for (int i = 0; i < count; i++) {
+            const ifc_register_info_t *reg = get_register_info((ifc_register_group_t)group, i);
+
+            if (reg && reg->address == address) {
+                if (group_index) *group_index = (ifc_register_group_t)group;
+                if (reg_index) *reg_index = i;
+                return reg;
+            }
+        }
+    }
+
+    return NULL;
+
+}
+
+uint32_t exp_reg_group_interrupt_global_status_ro(uint32_t reg_id) {
+        uint32_t exp_data;
+        const ifc_register_info_t *intr0_reg;
+        const ifc_register_info_t *intr1_reg;
+        const ifc_register_info_t *intr0_en_reg;
+        const ifc_register_info_t *intr1_en_reg;
+        uint32_t read_intr0_sts;
+        uint32_t read_intr1_sts;
+        uint32_t read_intr0_en;
+        uint32_t read_intr1_en;
+
+        // ERROR/NOTIF global status = ERROR/NOTIF status & ERROR/NOTIF enable
+        intr0_reg = get_register_info(REG_GROUP_INTERRUPT_STATUS_RW1C, reg_id);
+        intr0_en_reg = get_register_info(REG_GROUP_INTERRUPT_EN, reg_id + 1); // ERROR_INTR_EN_R/NOTIF_INTR_EN_R
+
+        read_intr0_sts = ifc_reg_read(intr0_reg->address);
+        read_intr0_en = ifc_reg_read(intr0_en_reg->address);
+
+        // Global status bit is set only if (status & enable) != 0
+        if ((read_intr0_sts & read_intr0_en) != 0) {
+            if (REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO_ARRAY[reg_id].address == CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_GLOBAL_INTR_R)
+                exp_data = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_GLOBAL_INTR_R_AGG_STS_MASK;
+
+            if (REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO_ARRAY[reg_id].address == CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_GLOBAL_INTR_R)
+                exp_data = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_GLOBAL_INTR_R_AGG_STS_MASK;
+        }
+
+        return exp_data;
+}
+
+uint32_t exp_with_init_value(uint32_t reg_address) {
+    uint32_t exp_data = 0;
+    size_t init_array_size = sizeof(reg_init_values) / sizeof(reg_init_values[0]);
+    for (size_t i = 0; i < init_array_size; i++) {
+        if (reg_init_values[i].address == reg_address) {
+            exp_data = reg_init_values[i].default_value;
+            break;
+        }
+    }
+    return exp_data;
+}
+
+/**
+ * Function to calculate the total number of registers across all groups
+ *
+ * @return Total number of registers
+ */
+int get_total_register_count(void) {
+    int total = 0;
+    for (int group = 0; group < REG_GROUP_COUNT; group++) {
+        total += get_register_count((ifc_register_group_t)group);
+    }
+    return total;
+}
+
+/**
+ * Initialize the register expected data dictionary
+ *
+ * @param dict Pointer to dictionary to initialize
+ */
+void init_reg_exp_dict(ifc_reg_exp_dict_t *dict) {
+    dict->count = 0;
+
+    size_t init_array_size = sizeof(reg_init_values) / sizeof(reg_init_values[0]);
+    // Add new entry if space available
+    for (ifc_register_group_t group = 0; group < REG_GROUP_COUNT; group++) {
+        int count = get_register_count(group);
+
+        for (int i = 0; i < count; i++) {
+            const ifc_register_info_t *reg = get_register_info(group, i);
+            dict->entries[dict->count].address = reg->address;
+            dict->entries[dict->count].expected_data = 0;
+            if (reg->has_init_value) {
+                dict->entries[dict->count].expected_data = exp_with_init_value(reg->address);
+            }
+            dict->count++;
+        }
+    }
+}
+
+/**
+ * Add or update an entry in the register expected data dictionary
+ *
+ * @param dict Pointer to dictionary
+ * @param address Register address (key)
+ * @param value Expected data value
+ * @param mask Mask to apply to the value
+ * @param reg_write Write to W1C register
+ * @param group_index_arg Register group index or -1, when >0 it improves speed
+ * @param soc_access Access from SoC side, not Caliptra, some register become RW when accessed from SoC
+ * @return 0 on success, -1 if dictionary is full
+ */
+ int set_reg_exp_data(ifc_reg_exp_dict_t *dict, uint32_t address, uint32_t value, uint32_t mask, bool reg_write, ifc_register_group_t group_index_arg, bool soc_access) {
+    ifc_register_group_t group_index;
+    int reg_index;
+    const ifc_register_info_t *reg_info;
+    const ifc_register_info_t *intr_glb_sts_reg;
+    const ifc_register_info_t *intr_sts_reg;
+    const ifc_register_info_t *axi_user_lock_reg;
+    const ifc_register_info_t *cap_lock_reg;
+    uint32_t glb_sts_mask;
+    uint32_t intr_sts_mask;
+    uint32_t err_data;
+    uint32_t read_intr_sts;
+    uint32_t axi_user_lock;
+    uint32_t cap_lock_reg_value;
+    bool ext_allowed = false;
+    bool reset_reason_reg = false;
+    bool update_exp_data = false;
+
+    reg_info = find_register_by_address(address, &group_index, &reg_index, group_index_arg);
+    if (group_index == REG_GROUP_ERROR_RW1C || group_index == REG_GROUP_INTERRUPT_STATUS_RW1C) {
+        err_data = ifc_reg_read(address);
+        if (reg_write) {
+            value = err_data & ~value;
+        }
+    }
+
+    if (group_index == REG_GROUP_INTERRUPT_TRIGGER_PULSE_RW1S) {
+        intr_sts_reg = get_register_info(REG_GROUP_INTERRUPT_STATUS_RW1C, reg_index);
+        read_intr_sts = ifc_reg_read(intr_sts_reg->address) | (value & mask);
+        intr_sts_mask = get_register_mask(intr_sts_reg->address);
+
+        if (reg_index == 0) {
+            intr_glb_sts_reg = get_register_info(REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO, 0);
+            glb_sts_mask = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_GLOBAL_INTR_R_AGG_STS_MASK;
+        } else if (reg_index == 1) {
+            intr_glb_sts_reg = get_register_info(REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO, 1);
+            glb_sts_mask = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_GLOBAL_INTR_R_AGG_STS_MASK;
+        }
+    }
+
+    if (group_index == REG_GROUP_MBOX) {
+        axi_user_lock_reg = get_register_info(REG_GROUP_MBOX_RW1S, reg_index);
+        axi_user_lock = ifc_reg_read(axi_user_lock_reg->address);
+        if (axi_user_lock == 0) {
+            ext_allowed = true;
+        }
+    }
+
+    if (group_index == REG_GROUP_TRNG && reg_index == 0) {
+        axi_user_lock_reg = get_register_info(REG_GROUP_TRNG_RW1S, reg_index);
+        axi_user_lock = ifc_reg_read(axi_user_lock_reg->address);
+        if (axi_user_lock == 0) {
+            ext_allowed = true;
+        }
+    }
+
+    if (group_index == REG_GROUP_FUSE) {
+        axi_user_lock_reg = get_register_info(REG_GROUP_FUSE_RW1S, reg_index);
+        axi_user_lock = ifc_reg_read(axi_user_lock_reg->address);
+        if (axi_user_lock == 0) {
+            ext_allowed = true;
+        }
+    }
+
+    // Special case for capabilities registers - override the above conditions
+    if (group_index == REG_GROUP_CAPABILITIES && reg_index <= 2) {
+        cap_lock_reg = get_register_info(REG_GROUP_CAPABILITIES, 2);
+        cap_lock_reg_value = ifc_reg_read(cap_lock_reg->address);
+        ext_allowed = (cap_lock_reg_value == 0);
+    }
+
+    if (group_index == REG_GROUP_DBG_MANUF_SERVICE) {
+        const ifc_register_info_t *debug_intent_reg = get_register_info(REG_GROUP_STRAPS_RO_RO, 0);
+        bool debug_intent = ifc_reg_read(debug_intent_reg->address) & SOC_IFC_REG_SS_DEBUG_INTENT_DEBUG_INTENT_MASK;
+        if (reg_index == 0) {
+            const ifc_register_info_t *sec_state_reg = get_register_info(REG_GROUP_SECURITY_RO, 0);
+            if (debug_intent) {
+                if ((ifc_reg_read(sec_state_reg->address) & SOC_IFC_REG_CPTRA_SECURITY_STATE_DEVICE_LIFECYCLE_MASK) == 1) {
+                    mask |= 0x1;
+                } else if ((ifc_reg_read(sec_state_reg->address) & SOC_IFC_REG_CPTRA_SECURITY_STATE_DEVICE_LIFECYCLE_MASK) == 3) {
+                    mask |= 0x2;
+                }
+            }
+            ext_allowed = true;
+        } else if (reg_index == 1) {
+            const ifc_register_info_t *sec_state_reg = get_register_info(REG_GROUP_SECURITY_RO, 0);
+            const ifc_register_info_t *debug_rsp_reg = get_register_info(REG_GROUP_DBG_MANUF_SERVICE, 1);
+            value |= (
+                ifc_reg_read(debug_rsp_reg->address) & (
+                    SOC_IFC_REG_SS_DBG_SERVICE_REG_RSP_MANUF_DBG_UNLOCK_SUCCESS_MASK |
+                    SOC_IFC_REG_SS_DBG_SERVICE_REG_RSP_PROD_DBG_UNLOCK_SUCCESS_MASK
+                )
+            );
+            if (debug_intent) {
+                if ((ifc_reg_read(sec_state_reg->address) & SOC_IFC_REG_CPTRA_SECURITY_STATE_DEVICE_LIFECYCLE_MASK) == 1) {
+                    mask |= 0x7;
+                } else if ((ifc_reg_read(sec_state_reg->address) & SOC_IFC_REG_CPTRA_SECURITY_STATE_DEVICE_LIFECYCLE_MASK) == 3) {
+                    mask |= 0x38;
+                }
+            }
+            ext_allowed = true;
+        } else if (debug_intent && (reg_index == 2 || reg_index == 3)) {
+            ext_allowed = true;
+        }
+    }
+
+    // Registers that are RW by SoC and RO by Caliptra(uC)
+    if (soc_access && (
+        group_index == REG_GROUP_STRAPS_RO            ||
+        group_index == REG_GROUP_UDS_RO               ||
+        group_index == REG_GROUP_FIELD_ENTROPY_RO     ||
+        group_index == REG_GROUP_VENDOR_PK_HASH_RO    ||
+        group_index == REG_GROUP_ECC_REVOCATION_RO    ||
+        group_index == REG_GROUP_SVN_RO               ||
+        group_index == REG_GROUP_ANTI_ROLLBACK_RO     ||
+        group_index == REG_GROUP_IDEVID_RO            ||
+        group_index == REG_GROUP_MANUF_DBG_UNLOCK_RO  ||
+        group_index == REG_GROUP_SOC_STEPPING_RO      ||
+        group_index == REG_GROUP_KEY_TYPE_RO          ||
+        group_index == REG_GROUP_FUSE_RO
+    )) {
+        const ifc_register_info_t *fuse_locked = get_register_info(REG_GROUP_FUSE_RO, 0);
+        ext_allowed = !(ifc_reg_read(fuse_locked->address) & 0x1);
+    }
+    if (soc_access && group_index == REG_GROUP_OWNER_PK_HASH_RO) {
+        const ifc_register_info_t *fuse_locked = get_register_info(REG_GROUP_OWNER_PK_HASH_RO, 12);
+        ext_allowed = !(ifc_reg_read(fuse_locked->address) & 0x1);
+    }
+
+    // Standard update condition
+    if ((reg_info->is_sticky == REG_SELF_LOCK_NON_ZERO && ifc_reg_read(address) == 0) ||
+        (reg_info->is_sticky == REG_SELF_LOCK_NON_ZERO_STICKY && ifc_reg_read(address) == 0) ||
+        (reg_info->is_sticky != REG_CONFIG_DONE_STICKY && reg_info->is_sticky != REG_CONFIG_DONE &&
+         reg_info->is_sticky != REG_SELF_LOCK_NON_ZERO_STICKY && reg_info->is_sticky != REG_EXT_LOCK_STICKY &&
+         reg_info->is_sticky != REG_SELF_LOCK_NON_ZERO && reg_info->is_sticky != REG_EXT_LOCK) ||
+        ext_allowed) {
+        update_exp_data = true;
+    }
+
+    bool pulse_timer_reg = (address == CLP_SOC_IFC_REG_CPTRA_WDT_TIMER1_CTRL || address == CLP_SOC_IFC_REG_CPTRA_WDT_TIMER2_CTRL);
+    bool pulse_intr_reg = (group_index == REG_GROUP_INTERRUPT_TRIGGER_PULSE_RW1S);
+
+    // First check if entry already exists
+    for (int i = 0; i < dict->count; i++) {
+        if (dict->entries[i].address == address) {
+            // Update existing entry's expected data only if sticky bit is NOT set
+            if (update_exp_data) {
+                if (!pulse_timer_reg && !pulse_intr_reg) {
+                    dict->entries[i].expected_data = value & mask;
+                } else if (pulse_timer_reg) {
+                    dict->entries[i].expected_data = 0x0;
+                } else {
+                    dict->entries[i].expected_data = 0x0;
+                    // Update expected data for corresponding interrupt status register
+                    set_reg_exp_data(dict, intr_sts_reg->address, read_intr_sts, intr_sts_mask, false, 0, soc_access);
+                    // Update global interrupt status register
+                    set_reg_exp_data(dict, intr_glb_sts_reg->address, (1U << (glb_sts_mask - 1)), glb_sts_mask, false, 0, soc_access);
+                }
+            }
+            // If sticky bit is set, retain previous expected value (do nothing)
+
+            return 0; // Return after handling existing entry
+        }
+    }
+
+    // Add new entry if space available
+    if (dict->count < MAX_REGISTER_ENTRIES) {
+        dict->entries[dict->count].address = address;
+        if (!pulse_timer_reg && !pulse_intr_reg) {
+            dict->entries[dict->count].expected_data = value & mask;
+        } else if (pulse_timer_reg) {
+            dict->entries[dict->count].expected_data = 0x0;
+        }
+        else {
+            dict->entries[dict->count].expected_data = 0x0;
+            // Update expected data for corresponding interrupt status register
+            set_reg_exp_data(dict, intr_sts_reg->address, read_intr_sts, intr_sts_mask, false, 0, soc_access);
+            // Update global interrupt status register
+            set_reg_exp_data(dict, intr_glb_sts_reg->address, (1U << (glb_sts_mask - 1)), glb_sts_mask, false, 0, soc_access);
+        }
+        dict->count++;
+        return 0;
+    }
+
+    return -1; // Dictionary full
+}
+
+/**
+ * Get expected data for a register
+ *
+ * @param dict Pointer to dictionary
+ * @param address Register address to lookup
+ * @param value Pointer to store expected value
+ * @return 0 if found, -1 if not found
+ */
+int get_reg_exp_data(ifc_reg_exp_dict_t *dict, uint32_t address, uint32_t *value) {
+    for (int i = 0; i < dict->count; i++) {
+        if (dict->entries[i].address == address) {
+            if (value) {
+                *value = dict->entries[i].expected_data;
+            }
+            return 0;
+        }
+    }
+
+    return -1; // Not found
+}
+
+/**
+ * Convert a register address to a bitmap index and bit position
+ *
+ * @param reg_addr Register address
+ * @param word_index Pointer to store the word index in the bitmap
+ * @param bit_position Pointer to store the bit position in the word
+ */
+static void address_to_bitmap_position(uint32_t reg_addr, uint32_t *word_index, uint32_t *bit_position) {
+    // Use the lower bits of the address as a simple hash
+    // This works because register addresses are typically aligned and spaced apart
+    uint32_t hash_value = reg_addr & ((1 << ADDRESS_BITS_FOR_INDEXING) - 1);
+
+    *word_index = hash_value / 32;
+    *bit_position = hash_value % 32;
+}
+
+/**
+ * Exclude a register by its address with collision handling
+ *
+ * @param reg_addr Register address to exclude
+ * @return 0 on success, -1 if collision table is full
+ */
+int exclude_register(uint32_t reg_addr) {
+    uint32_t word_index, bit_position;
+
+    // Compute position in bitmap
+    address_to_bitmap_position(reg_addr, &word_index, &bit_position);
+
+    // Set the bit in the bitmap
+    excluded_registers_bitmap[word_index] |= (1UL << bit_position);
+
+    // Add to collision table
+    if (collision_count < MAX_EXCLUDED_REGISTERS) {
+        collision_table[collision_count++] = reg_addr;
+        return 0;
+    }
+
+    // Collision table is full
+    VPRINTF(WARNING, "Collision table full, cannot add register 0x%08x\n", reg_addr);
+    return -1;
+}
+
+/**
+ * Check if a register is excluded with collision handling
+ *
+ * @param reg_addr Register address to check
+ * @return 1 if excluded, 0 otherwise
+ */
+int is_register_excluded(uint32_t reg_addr) {
+    uint32_t word_index, bit_position;
+
+    // Compute position in bitmap
+    address_to_bitmap_position(reg_addr, &word_index, &bit_position);
+
+    // First, check the bit in the bitmap
+    if (excluded_registers_bitmap[word_index] & (1UL << bit_position)) {
+        // Potential match, verify in collision table to handle hash collisions
+        for (int i = 0; i < collision_count; i++) {
+            if (collision_table[i] == reg_addr) {
+                return 1;  // Confirmed match in collision table
+            }
+        }
+    }
+
+    return 0;  // Not excluded
+}
+
+/**
+ * Initialize the excluded registers bitmap
+ */
+void init_excluded_registers(void) {
+
+    // Clear the bitmap and collision table
+    memset(excluded_registers_bitmap, 0, sizeof(excluded_registers_bitmap));
+    memset(collision_table, 0, sizeof(collision_table));
+    collision_count = 0;
+}
+
+
+void write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+    bool ro_reg = is_ro(group);
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (!reg || is_register_excluded(reg->address)) continue;
+
+        // Generate a unique value for each register
+        uint32_t rand_value = xorshift32();
+
+        /* Get mask for this register */
+        uint32_t mask = get_register_mask(reg->address);
+
+        // Store in dictionary
+        if (!ro_reg) {
+            set_reg_exp_data(dict, reg->address, rand_value, mask, true, group, false);
+        }
+
+        ifc_reg_write(reg->address, rand_value);
+    }
+}
+
+void write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict) {
+    int count = get_register_count(group);
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (!reg || is_register_excluded(reg->address)) continue;
+
+        /* Get mask for this register */
+        uint32_t mask = get_register_mask(reg->address);
+
+        // Store in dictionary
+        set_reg_exp_data(dict, reg->address, write_data, mask, true, group, false);
+
+        ifc_reg_write(reg->address, write_data);
+    }
+}
+
+/**
+ * Function to read all registers in a group and verify their values against expected data
+ *
+ * @param group Register group
+ * @param dict Dictionary containing expected register values
+ * @return Number of registers that failed verification
+ */
+int read_register_group_and_verify(ifc_register_group_t group, ifc_reg_exp_dict_t *dict, bool reset, reset_type_t reset_type, bool use_hw) {
+    uint32_t read_data;
+    int count = get_register_count(group);
+    int mismatch_count = 0;
+    uint32_t exp_data;
+    uint32_t read_intr0_sts;
+    uint32_t read_intr1_sts;
+    uint32_t read_intr0_en;
+    uint32_t read_intr1_en;
+    const ifc_register_info_t *intr0_reg;
+    const ifc_register_info_t *intr1_reg;
+    const ifc_register_info_t *intr0_en_reg;
+    const ifc_register_info_t *intr1_en_reg;
+
+    bool ro_reg = is_ro(group);
+
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+
+        if (!reg) {
+            VPRINTF(ERROR, "Register index %d not found in group\n", i);
+            continue;
+        }
+
+        // Skip excluded registers with collision-aware check
+        if (is_register_excluded(reg->address)) {
+            continue;
+        }
+
+        // Read the register value
+        read_data = ifc_reg_read(reg->address);
+        if (group == REG_GROUP_UDS_RO && use_hw) {
+            const ifc_register_info_t *cmd_reg = get_register_info(REG_GROUP_GENERIC_WIRES, 0);
+            const ifc_register_info_t *rsp_reg0 = get_register_info(REG_GROUP_GENERIC_WIRES_RO, 0);
+            const ifc_register_info_t *rsp_reg1 = get_register_info(REG_GROUP_GENERIC_WIRES_RO, 1);
+            ifc_reg_write(cmd_reg->address, 0x207F | ((i << 7) & 0xF00));
+            read_data = i & 1 ? ifc_reg_read(rsp_reg0->address): ifc_reg_read(rsp_reg1->address);
+        }
+        if (group == REG_GROUP_FIELD_ENTROPY_RO && use_hw) {
+            const ifc_register_info_t *cmd_reg = get_register_info(REG_GROUP_GENERIC_WIRES, 0);
+            const ifc_register_info_t *rsp_reg0 = get_register_info(REG_GROUP_GENERIC_WIRES_RO, 0);
+            const ifc_register_info_t *rsp_reg1 = get_register_info(REG_GROUP_GENERIC_WIRES_RO, 1);
+            ifc_reg_write(cmd_reg->address, 0x307F | ((i << 7) & 0xF00));
+            read_data = i & 1 ? ifc_reg_read(rsp_reg0->address): ifc_reg_read(rsp_reg1->address);
+        }
+
+        // Get expected data from dictionary
+        if (reset) {
+            if (reset_type == COLD_RESET) {
+                if (reg->has_init_value == true) {
+                    exp_data =  exp_with_init_value(reg->address);
+                    if (read_data == exp_data) {
+                        continue;
+                    } else {
+                        report_mismatch(group, i, reg->address, read_data, exp_data);
+                        mismatch_count++;
+                    }
+                } else if (ro_reg == false) {
+                    exp_data  = 0;
+                    if (reg->address == CLP_SOC_IFC_REG_INTERNAL_RV_MTIME_H || reg->address == CLP_SOC_IFC_REG_INTERNAL_RV_MTIME_L && read_data >= exp_data) {
+                        continue;
+                    } else if (read_data == exp_data) {
+                        continue;
+                    } else if (reg->address == CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) {
+                        if (ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_SECURITY_STATE) & SOC_IFC_REG_CPTRA_SECURITY_STATE_DEBUG_LOCKED_MASK) {
+                            exp_data |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+                        }
+                        if (ifc_reg_read(CLP_SOC_IFC_REG_CPTRA_SECURITY_STATE) & SOC_IFC_REG_CPTRA_SECURITY_STATE_SCAN_MODE_MASK) {
+                            exp_data |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+                        }
+                        if (read_data == exp_data) {
+                            continue;
+                        } else {
+                            mismatch_count++;
+                        }
+                    } else if (reg->address == CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS) {
+                        exp_data |= 4 << 25; //uC out of reset, so BOOTFSM is in DONE state
+                        if (read_data == exp_data) {
+                            continue;
+                        } else {
+                            mismatch_count++;
+                        }
+                    } else {
+                        report_mismatch(group, i, reg->address, read_data, exp_data);
+                        mismatch_count++;
+                    }
+                } else {
+                    if (get_reg_exp_data(&g_expected_data_dict, reg->address, &exp_data) == 0) {
+                        if (read_data == exp_data) {
+                            continue;
+                        } else if (group == REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO) {
+                            exp_data = exp_reg_group_interrupt_global_status_ro(i);
+                            if (read_data == exp_data) {
+                                continue;
+                            }
+                            else {
+                                report_mismatch(group, i, reg->address, read_data, exp_data);
+                                mismatch_count++;
+                            }
+                        } else {
+                            report_mismatch(group, i, reg->address, read_data, exp_data);
+                            mismatch_count++;
+                        }
+                    } else {
+                        VPRINTF(ERROR, "%s[%d] (0x%08x): Read 0x%08x, No expected data in dictionary\n",
+                                get_group_name(group), i, reg->address, read_data);
+                    }
+                }
+            } else if (reset_type == WARM_RESET) {
+                if (reg->is_sticky == REG_STICKY || reg->is_sticky == REG_CONFIG_DONE_STICKY || reg->is_sticky == REG_SELF_LOCK_NON_ZERO_STICKY || reg->is_sticky == REG_EXT_LOCK_STICKY) {
+                    if (get_reg_exp_data(&g_expected_data_dict, reg->address, &exp_data) == 0) {
+                        // Compare and report
+                        if (group == REG_GROUP_INTERRUPT_ERROR_COUNTERS) {
+                            if ((i == 0 && (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK)) ||
+                                (i == 1 && (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK)) ||
+                                (i == 2 && (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK)) ||
+                                (i == 3 && (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK)) ||
+                                (i == 4 && (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK)) ||
+                                (i == 5 && (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK)) ||
+                                (i == 6 && (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER1_TIMEOUT_STS_MASK)) ||
+                                (i == 7 && (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER2_TIMEOUT_STS_MASK))) {
+                                if (read_data >= exp_data) {
+                                    continue;
+                                } else {
+                                    report_mismatch(group, i, reg->address, read_data, exp_data);
+                                    mismatch_count++;
+                                }
+                            }
+                        } else if (reg->address == CLP_SOC_IFC_REG_CPTRA_RESET_REASON) {
+                            exp_data = exp_data | SOC_IFC_REG_CPTRA_RESET_REASON_WARM_RESET_MASK; // bit 1 is not sticky
+                            if (read_data == exp_data) {
+                                continue;
+                            } else {
+                                report_mismatch(group, i, reg->address, read_data, exp_data);
+                                mismatch_count++;
+                            }
+                        } else if (read_data == exp_data) {
+                                continue;
+                        } else if (read_data > exp_data && reg->address == CLP_SOC_IFC_REG_INTERNAL_RV_MTIME_H || reg->address == CLP_SOC_IFC_REG_INTERNAL_RV_MTIME_L) {
+                                continue;
+                        } else {
+                            report_mismatch(group, i, reg->address, read_data, exp_data);
+                            mismatch_count++;
+                        }
+                    } else {
+                        VPRINTF(ERROR, "%s[%d] (0x%08x): Read 0x%08x, No expected data in dictionary\n",
+                                get_group_name(group), i, reg->address, read_data);
+                    }
+                } else {
+                    if (reg->has_init_value == true) {
+                        exp_data =  exp_with_init_value(reg->address);
+                        if (read_data == exp_data) {
+                            continue;
+                        } else {
+                            report_mismatch(group, i, reg->address, read_data, exp_data);
+                            mismatch_count++;
+                        }
+                    } else if (ro_reg == false) {
+                        exp_data  = 0;
+
+                        if (read_data == exp_data) {
+                        } else if (group == REG_GROUP_INTERRUPT_NOTIF_COUNTERS) {
+                            if ((i == 0 &&  (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK)) ||
+                                (i == 1 &&  (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK)) ||
+                                (i == 2 &&  (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK)) ||
+                                (i == 3 &&  (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK)) ||
+                                (i == 4 &&  (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK)) ||
+                                (i == 5 &&  (ifc_reg_read(CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R) & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK))) {
+                                if (read_data >= exp_data) {
+                                    continue;
+                                } else {
+                                    report_mismatch(group, i, reg->address, read_data, exp_data);
+                                    mismatch_count++;
+                                }
+                            }
+                        } else if (reg->address == CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS) {
+                            exp_data |= 4 << 25; //uC out of reset, so BOOTFSM is in DONE state
+                            if (read_data == exp_data) {
+                                continue;
+                            } else {
+                                report_mismatch(group, i, reg->address, read_data, exp_data);
+                                mismatch_count++;
+                            }
+                        } else {
+                            report_mismatch(group, i, reg->address, read_data, exp_data);
+                            mismatch_count++;
+                        }
+                    } else {
+                        if (get_reg_exp_data(&g_expected_data_dict, reg->address, &exp_data) == 0) {
+                            if (read_data == exp_data) {
+                                continue;
+                            } else if (group == REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO) {
+                                exp_data = exp_reg_group_interrupt_global_status_ro(i);
+                                if (read_data == exp_data) {
+                                    continue;
+                                }
+                                else {
+                                    report_mismatch(group, i, reg->address, read_data, exp_data);
+                                    mismatch_count++;
+                                }
+                            } else {
+                                report_mismatch(group, i, reg->address, read_data, exp_data);
+                                mismatch_count++;
+                            }
+                        } else {
+                            VPRINTF(ERROR, "%s[%d] (0x%08x): Read 0x%08x, No expected data in dictionary\n", get_group_name(group), i, reg->address, read_data);
+                        }
+                    }
+                }
+            }
+        } else { // Verifying after a write operation
+            if (get_reg_exp_data(&g_expected_data_dict, reg->address, &exp_data) == 0) {
+                // Compare and report
+                if (read_data == exp_data) {
+                    continue;
+                } else if (read_data > exp_data && reg->address == CLP_SOC_IFC_REG_INTERNAL_RV_MTIME_H || reg->address == CLP_SOC_IFC_REG_INTERNAL_RV_MTIME_L) {
+                    continue;
+                } else if (reg->address == CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS) {
+                    exp_data |= 4 << 25; //uC out of reset, so BOOTFSM is in DONE state
+                    if (read_data == exp_data) {
+                        continue;
+                    } else {
+                        report_mismatch(group, i, reg->address, read_data, exp_data);
+                        mismatch_count++;
+                    }
+                } else if (group == REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO) {
+                    exp_data = exp_reg_group_interrupt_global_status_ro(i);
+                    if (read_data == exp_data) {
+                        continue;
+                    } else {
+                        report_mismatch(group, i, reg->address, read_data, exp_data);
+                        mismatch_count++;
+                    }
+                } else {
+                    report_mismatch(group, i, reg->address, read_data, exp_data);
+                    mismatch_count++;
+                }
+            } else {
+                VPRINTF(ERROR, "%s[%d] (0x%08x): Read 0x%08x, No expected data in dictionary\n", get_group_name(group), i, reg->address, read_data);
+            }
+        }
+    }
+
+    VPRINTF(LOW, "Verification complete: %d register(s) matched, %d register(s) mismatched\n", count - mismatch_count, mismatch_count);
+    return mismatch_count;
+}
+
+/**
+ * Function to read all registers in a group and track their values in a dictionary
+ *
+ * @param group Register group
+ * @param dict Dictionary to store register values
+ */
+void read_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict) {
+    uint32_t read_data;
+    int count = get_register_count(group);
+    for (int i = 0; i < count; i++) {
+        const ifc_register_info_t *reg = get_register_info(group, i);
+        if (!reg) continue;
+
+        // Check if this register should be excluded
+        if (!is_register_excluded(reg->address)) {
+            // Read the register value
+            read_data = ifc_reg_read(reg->address);
+
+            /* Get mask for this register */
+            uint32_t mask = get_register_mask(reg->address);
+
+            // Store in dictionary
+            if (set_reg_exp_data(dict, reg->address, read_data, mask, false, group, false) != 0) {
+                VPRINTF(WARNING, "Could not store read data for %s[%d]\n", get_group_name(group), i);
+            }
+        }
+    }
+
+    VPRINTF(LOW, "Register tracking complete: %d register(s) read and tracked\n", count);
+}
+
+
+void init_mask_dict(void) {
+    g_mask_dict.count = 0;
+
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_CAP_LOCK,
+            SOC_IFC_REG_CPTRA_CAP_LOCK_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS,
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_MAILBOX_FLOW_DONE_MASK |
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_RUNTIME_MASK |
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_MB_PROCESSING_MASK |
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_IDEVID_CSR_READY_MASK |
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_STATUS_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_WDT_TIMER1_EN,
+            SOC_IFC_REG_CPTRA_WDT_TIMER1_EN_TIMER1_EN_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_WDT_TIMER2_EN,
+            SOC_IFC_REG_CPTRA_WDT_TIMER2_EN_TIMER2_EN_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_INTERNAL_ICCM_LOCK,
+            SOC_IFC_REG_INTERNAL_ICCM_LOCK_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_0,
+            SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_0_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_1,
+            SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_1_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_2,
+            SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_2_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_3,
+            SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_3_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_4,
+            SOC_IFC_REG_CPTRA_MBOX_AXI_USER_LOCK_4_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_FLOW_STATUS,
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_STATUS_MASK |
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_IDEVID_CSR_READY_MASK |
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_MB_PROCESSING_MASK |
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_RUNTIME_MASK |
+            SOC_IFC_REG_CPTRA_FLOW_STATUS_MAILBOX_FLOW_DONE_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_INTERNAL_FW_UPDATE_RESET_WAIT_CYCLES,
+            SOC_IFC_REG_INTERNAL_FW_UPDATE_RESET_WAIT_CYCLES_WAIT_CYCLES_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_INTERNAL_HW_ERROR_FATAL_MASK,
+            SOC_IFC_REG_INTERNAL_HW_ERROR_FATAL_MASK_MASK_ICCM_ECC_UNC_MASK |
+            SOC_IFC_REG_INTERNAL_HW_ERROR_FATAL_MASK_MASK_DCCM_ECC_UNC_MASK |
+            SOC_IFC_REG_INTERNAL_HW_ERROR_FATAL_MASK_MASK_NMI_PIN_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_INTERNAL_HW_ERROR_NON_FATAL_MASK,
+            SOC_IFC_REG_INTERNAL_HW_ERROR_NON_FATAL_MASK_MASK_MBOX_PROT_NO_LOCK_MASK |
+            SOC_IFC_REG_INTERNAL_HW_ERROR_NON_FATAL_MASK_MASK_MBOX_PROT_OOO_MASK |
+            SOC_IFC_REG_INTERNAL_HW_ERROR_NON_FATAL_MASK_MASK_MBOX_ECC_UNC_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_TRNG_STATUS,
+            SOC_IFC_REG_CPTRA_TRNG_STATUS_DATA_REQ_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_TRNG_AXI_USER_LOCK,
+            SOC_IFC_REG_CPTRA_TRNG_AXI_USER_LOCK_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_FUSE_AXI_USER_LOCK,
+            SOC_IFC_REG_CPTRA_FUSE_AXI_USER_LOCK_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_SS_DBG_SERVICE_REG_REQ, 0);
+    add_mask_entry(CLP_SOC_IFC_REG_SS_DBG_SERVICE_REG_RSP,
+            SOC_IFC_REG_SS_DBG_SERVICE_REG_RSP_UDS_PROGRAM_SUCCESS_MASK |
+            SOC_IFC_REG_SS_DBG_SERVICE_REG_RSP_UDS_PROGRAM_FAIL_MASK |
+            SOC_IFC_REG_SS_DBG_SERVICE_REG_RSP_UDS_PROGRAM_IN_PROGRESS_MASK |
+            SOC_IFC_REG_SS_DBG_SERVICE_REG_RSP_TAP_MAILBOX_AVAILABLE_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_TRNG_CTRL, SOC_IFC_REG_CPTRA_TRNG_CTRL_CLEAR_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_OWNER_PK_HASH_LOCK,
+            SOC_IFC_REG_CPTRA_OWNER_PK_HASH_LOCK_LOCK_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_FUSE_ECC_REVOCATION,
+            SOC_IFC_REG_FUSE_ECC_REVOCATION_ECC_REVOCATION_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_FUSE_MLDSA_REVOCATION,
+            SOC_IFC_REG_FUSE_MLDSA_REVOCATION_MLDSA_REVOCATION_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_FUSE_SOC_MANIFEST_MAX_SVN,
+            SOC_IFC_REG_FUSE_SOC_MANIFEST_MAX_SVN_SVN_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_FUSE_ANTI_ROLLBACK_DISABLE,
+            SOC_IFC_REG_FUSE_ANTI_ROLLBACK_DISABLE_DIS_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_FUSE_SOC_STEPPING_ID,
+            SOC_IFC_REG_FUSE_SOC_STEPPING_ID_SOC_STEPPING_ID_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_FUSE_PQC_KEY_TYPE,
+            SOC_IFC_REG_FUSE_PQC_KEY_TYPE_KEY_TYPE_MASK);
+    add_mask_entry(CLP_SOC_IFC_REG_CPTRA_FUSE_WR_DONE,
+            SOC_IFC_REG_CPTRA_FUSE_WR_DONE_DONE_MASK);
+}
+
+/**
+ * Add an entry to the register mask dictionary
+ *
+ * @param address Register address
+ * @param mask Combined mask for the register
+ * @return 0 on success, -1 if dictionary is full
+ */
+int add_mask_entry(uint32_t address, uint32_t mask) {
+    if (g_mask_dict.count < MAX_REGISTER_ENTRIES) {
+        g_mask_dict.entries[g_mask_dict.count].address = address;
+        g_mask_dict.entries[g_mask_dict.count].combined_mask = mask;
+        g_mask_dict.count++;
+        return 0;
+    }
+    return -1;
+}
+
+/**
+ * Get the combined mask for a register
+ *
+ * @param address Register address
+ * @return Combined mask, or 0xFFFFFFFF if not found
+ */
+uint32_t get_register_mask(uint32_t address) {
+    for (int i = 0; i < g_mask_dict.count; i++) {
+        if (g_mask_dict.entries[i].address == address) {
+            return g_mask_dict.entries[i].combined_mask;
+        }
+    }
+
+    /* Default mask for unknown registers */
+    return 0xFFFFFFFF;
+}
+
+/**
+ * Initialize IFC module
+ */
+void ifc_init(void) {
+    // Initialize register mask dictionary if not already done
+    static int masks_initialized = 0;
+    if (!masks_initialized) {
+        init_mask_dict();
+        masks_initialized = 1;
+    }
+
+    // Initialize expected data dictionary
+    init_reg_exp_dict(&g_expected_data_dict);
+
+    // Initialize excluded registers
+    init_excluded_registers();
+}

--- a/src/integration/test_suites/libs/ifc_reg/ifc_reg.h
+++ b/src/integration/test_suites/libs/ifc_reg/ifc_reg.h
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef IFC_REG_H
+#define IFC_REG_H
+
+#include <stdbool.h>
+#include "stdint.h"
+#include <stddef.h>
+#include "caliptra_rtl_lib.h"
+
+// IFC Register Count: 261/270
+#define MAX_REGISTER_ENTRIES 270
+
+// Maximum number of registers in any group
+#define MAX_REGISTERS_PER_GROUP 29
+
+// Enum for register sticky behavior
+typedef enum {
+    REG_NOT_STICKY = 0,
+    REG_STICKY = 1,
+    REG_CONFIG_DONE_STICKY = 2,
+    REG_CONFIG_DONE = 3,
+    REG_SELF_LOCK_NON_ZERO = 4,
+    REG_SELF_LOCK_NON_ZERO_STICKY = 5,
+    REG_EXT_LOCK = 6,
+    REG_EXT_LOCK_STICKY = 7
+} register_sticky_t;
+
+
+// Register info struct
+typedef struct {
+    uint32_t address;   /* Register address */
+    register_sticky_t is_sticky;        /* Flag to indicate if register is sticky */
+    uint8_t has_init_value:1; /* Single bit */
+} ifc_register_info_t;
+
+// Register expected data struct
+typedef struct {
+    uint32_t address;         // Address of the register instead of name
+    uint32_t expected_data;   // Expected data value
+} ifc_register_exp_data_t;
+
+// Dictionary of register expected values
+typedef struct {
+    ifc_register_exp_data_t entries[MAX_REGISTER_ENTRIES];  /* Fixed-size array of entries */
+    int count;                                             /* Current number of entries */
+} ifc_reg_exp_dict_t;
+
+typedef struct {
+    uint32_t address;
+    uint32_t default_value;
+} ifc_reg_def_value_t;
+
+// Register mask struct
+typedef struct {
+    uint32_t address;        /* Register address */
+    uint32_t combined_mask;  /* Combined mask of all readable/writable bits */
+} register_mask_t;
+
+// Dictionary of register mask values
+typedef struct {
+    register_mask_t entries[MAX_REGISTER_ENTRIES];  /* Fixed-size array of entries */
+    int count;                                      /* Current number of entries */
+} register_mask_dict_t;
+
+typedef enum {
+    COLD_RESET = 0,
+    WARM_RESET = 1
+} reset_type_t;
+
+// Register groups
+typedef enum {
+    REG_GROUP_CAPABILITIES,
+    REG_GROUP_STRAPS_RO,
+    REG_GROUP_STRAPS_RO_RO,
+    REG_GROUP_STATUS,
+    REG_GROUP_STATUS_RO,
+    REG_GROUP_SECURITY_RO,
+    REG_GROUP_ERROR_RW1C,
+    REG_GROUP_ERROR,
+    REG_GROUP_ERROR_MASK,
+    REG_GROUP_WATCHDOG,
+    REG_GROUP_WATCHDOG_RO,
+    REG_GROUP_MCU,
+    REG_GROUP_CONTROL,
+    REG_GROUP_CONTROL_RO,
+    REG_GROUP_MBOX,
+    REG_GROUP_MBOX_RW1S,
+    REG_GROUP_DBG_MANUF_SERVICE,
+    REG_GROUP_GENERIC_WIRES,
+    REG_GROUP_GENERIC_WIRES_RO,
+    REG_GROUP_FW,
+    REG_GROUP_FW_PULSE_RW1S,
+    REG_GROUP_TRNG,
+    REG_GROUP_TRNG_RW1S,
+    REG_GROUP_TRNG_PULSE_RW1S,
+    REG_GROUP_FUSE,
+    REG_GROUP_FUSE_RW1S,
+    REG_GROUP_FUSE_RO,
+    REG_GROUP_OWNER_PK_HASH_RO,
+    // FUSES
+    REG_GROUP_UDS_RO,
+    REG_GROUP_FIELD_ENTROPY_RO,
+    REG_GROUP_VENDOR_PK_HASH_RO,
+    REG_GROUP_ECC_REVOCATION_RO,
+    REG_GROUP_SVN_RO,
+    REG_GROUP_ANTI_ROLLBACK_RO,
+    REG_GROUP_IDEVID_RO,
+    REG_GROUP_MANUF_DBG_UNLOCK_RO,
+    REG_GROUP_SOC_STEPPING_RO,
+    REG_GROUP_KEY_TYPE_RO,
+    // INTR
+    REG_GROUP_INTERRUPT_EN,
+    REG_GROUP_INTERRUPT_GLOBAL_STATUS_RO,
+    REG_GROUP_INTERRUPT_STATUS_RW1C,
+    REG_GROUP_INTERRUPT_TRIGGER_PULSE_RW1S,
+    REG_GROUP_INTERRUPT_ERROR_COUNTERS,
+    REG_GROUP_INTERRUPT_NOTIF_COUNTERS,
+    REG_GROUP_INTERRUPT_ERROR_COUNTERS_INCR_RO,
+    REG_GROUP_INTERRUPT_NOTIF_COUNTERS_INCR_RO,
+    REG_GROUP_COUNT
+} ifc_register_group_t;
+
+extern const ifc_register_info_t *register_groups[];
+
+// Global dictionary
+extern ifc_reg_exp_dict_t g_expected_data_dict;
+
+uint32_t ifc_reg_read(uint32_t reg_addr);
+void ifc_reg_write(uint32_t reg_addr, uint32_t value);
+bool is_ro(ifc_register_group_t group);
+uint32_t report_mismatch(ifc_register_group_t group, uint32_t id, uint32_t reg_addr, uint32_t read_data, uint32_t exp_data);
+
+const ifc_register_info_t* find_register_by_address(uint32_t address, ifc_register_group_t *group_index, int *reg_index, ifc_register_group_t start_index);
+uint32_t exp_reg_group_interrupt_global_status_ro(uint32_t reg_id);
+uint32_t exp_with_init_value(uint32_t reg_address);
+int get_total_register_count(void);
+void init_reg_exp_dict(ifc_reg_exp_dict_t *dict);
+int set_reg_exp_data(ifc_reg_exp_dict_t *dict, uint32_t address, uint32_t value, uint32_t mask, bool reg_write, ifc_register_group_t group_index_arg, bool soc_access);
+int get_reg_exp_data(ifc_reg_exp_dict_t *dict, uint32_t address, uint32_t *value);
+void init_mask_dict(void);
+const ifc_register_info_t* get_register_info(ifc_register_group_t group, int index);
+int get_register_count(ifc_register_group_t group);
+uint32_t get_register_mask(uint32_t address);
+const char* get_group_name(ifc_register_group_t group);
+int add_mask_entry(uint32_t address, uint32_t mask);
+void write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict);
+void write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict);
+int read_register_group_and_verify(ifc_register_group_t group, ifc_reg_exp_dict_t *dict, bool reset, reset_type_t reset_type, bool use_hw);
+void read_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict);
+static void address_to_bitmap_position(uint32_t reg_addr, uint32_t *word_index, uint32_t *bit_position);
+int exclude_register(uint32_t reg_addr);
+int is_register_excluded(uint32_t reg_addr);
+void init_excluded_registers(void);
+
+/* Initialization */
+void ifc_init(void);
+
+#endif /* IFC_REG_H */

--- a/src/integration/test_suites/libs/ifc_reg/ifc_reg.h
+++ b/src/integration/test_suites/libs/ifc_reg/ifc_reg.h
@@ -155,7 +155,6 @@ void init_mask_dict(void);
 const ifc_register_info_t* get_register_info(ifc_register_group_t group, int index);
 int get_register_count(ifc_register_group_t group);
 uint32_t get_register_mask(uint32_t address);
-const char* get_group_name(ifc_register_group_t group);
 int add_mask_entry(uint32_t address, uint32_t mask);
 void write_random_to_register_group_and_track(ifc_register_group_t group, ifc_reg_exp_dict_t *dict);
 void write_to_register_group_and_track(ifc_register_group_t group, uint32_t write_data, ifc_reg_exp_dict_t *dict);

--- a/src/integration/test_suites/libs/soc_access/soc_access.c
+++ b/src/integration/test_suites/libs/soc_access/soc_access.c
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+#include <stddef.h>
+#include "soc_access.h"
+#include "caliptra_defines.h"
+#include "riscv_hw_if.h"
+
+#define AXI_WRITE      0x1
+#define AXI_READ       0x2
+#define AXI_WRITE_ADDR 0x4
+#define AXI_WRITE_DATA 0x8
+#define AXI_WRITE_RESP 0x10
+#define AXI_READ_ADDR  0x20
+#define AXI_READ_RESP  0x40
+#define AXI_USE_ID     0x80
+#define AXI_DEFAULT_MASK 0xF
+#define AXI_DEFAULT_USER 0
+
+
+axi_resp_t soc_access_32(axi_req_t req) {
+    axi_resp_t axi_resp;
+    // Set AXI address
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+
+    // Set AXI burst
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+
+    // Set AXI aXuser
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+
+    if (req.write) {
+        // Clear SoC access queues
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0A7F);
+
+        for (int i = 0; i < req.len; i++) {
+            // Push AXI wdata
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wdata ? req.wdata[i] : 0);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x027F);
+            // Push AXI wuser
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wuser ? req.wuser[i] : AXI_DEFAULT_USER);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x067F);
+            // Push AXI wstrb
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wstrb ? (req.wstrb[i] & 0xF) : 0xF);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x097F);
+        }
+    }
+
+    uint32_t execute = (req.write ? AXI_WRITE : 0) | (req.read ? AXI_READ : 0) | (req.use_id ? AXI_USE_ID : 0) |
+            ((req.len - 1) << 8) | (req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+
+    if (req.ignore_resp)
+        return (axi_resp_t){ .resp = 0, .rdata = 0 };
+
+    while (1) {
+        axi_resp_t axi_resp;
+
+        // Check if AXI has finished
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+
+        if(axi_resp.resp & 1) {
+            axi_resp.resp = (axi_resp.resp >> 1) & 0b11;
+
+            if (req.read) {
+                for (int i = 0; i < req.len; i++) {
+                    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x057F);
+                    uint32_t rdata = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+                    if (i == 0) axi_resp.rdata = rdata;
+                    if (req.rdata) req.rdata[i] = rdata;
+                }
+            }
+            return axi_resp;
+        }
+    }
+}
+
+// intended to be used only after soc_access_32 with .ignore_resp = true
+uint8_t soc_access_await_done() {
+    while(1) {
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        uint8_t resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+        if (resp & 1)
+            return (resp >> 1) & 0b11; 
+    }
+}
+
+uint8_t soc_masked_write_32(uint32_t reg_addr, uint32_t value, uint32_t mask) {
+    axi_resp_t axi_resp;
+
+    axi_resp = soc_access_32((axi_req_t){
+        .addr = reg_addr,
+        .axuser = AXI_DEFAULT_USER,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = true,
+        .read = false,
+        .wuser = (uint32_t[]){AXI_DEFAULT_USER},
+        .wdata = (uint32_t[]){value},
+        .wstrb = (uint8_t[]){mask}
+    });
+
+    return axi_resp.resp;
+}
+
+uint8_t soc_write_user_32(uint32_t reg_addr, uint32_t value, uint32_t user) {
+    axi_resp_t axi_resp;
+
+    axi_resp = soc_access_32((axi_req_t){
+        .addr = reg_addr,
+        .axuser = user,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = true,
+        .read = false,
+        .wuser = (uint32_t[]){user},
+        .wdata = (uint32_t[]){value},
+        .wstrb = (uint8_t[]){AXI_DEFAULT_MASK}
+    });
+
+    return axi_resp.resp;
+}
+
+uint8_t soc_write_32(uint32_t reg_addr, uint32_t value) {
+    return soc_write_user_32(reg_addr, value, AXI_DEFAULT_USER);
+}
+
+axi_resp_t soc_read_user_32(uint32_t reg_addr, uint32_t user) {
+    axi_resp_t axi_resp;
+
+    axi_resp = soc_access_32((axi_req_t){
+        .addr = reg_addr,
+        .axuser = user,
+        .burst = AXI_BURST_INCR,
+        .len = 1,
+        .write = false,
+        .read = true
+    });
+
+    return axi_resp;
+}
+
+axi_resp_t soc_read_32(uint32_t reg_addr) {
+    return soc_read_user_32(reg_addr, AXI_DEFAULT_USER);
+}
+
+void soc_write_addr(axi_req_t req) {
+    if (!req.write) return;
+    // Set AXI address
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+
+    // Set AXI burst
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+
+    // Set AXI aXuser
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+
+    // Send on AW channel
+    uint32_t execute = AXI_WRITE_ADDR | AXI_USE_ID | ((req.len - 1) << 8) | (req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+}
+
+void soc_write_data(axi_req_t req) {
+    if (!req.write) return;
+    // Clear SoC access queues
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0A7F);
+
+    for (int i = 0; i < req.len; i++) {
+        // Push AXI wdata
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wdata ? req.wdata[i] : 0);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x027F);
+        // Push AXI wuser
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wuser ? req.wuser[i] : AXI_DEFAULT_USER);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x067F);
+        // Push AXI wstrb
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wstrb ? (req.wstrb[i] & 0xF) : 0xF);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x097F);
+    }
+
+    // Send on W channel
+    uint32_t execute = AXI_WRITE_DATA | ((req.len - 1) << 8);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+}
+
+axi_resp_t soc_write_resp(axi_req_t req) {
+    if (!req.write)
+        return (axi_resp_t){ .resp = 0, .rdata = 0 };
+    // Receive from B channel
+    uint32_t execute = AXI_WRITE_RESP | AXI_USE_ID | (req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    while (1) {
+        axi_resp_t axi_resp;
+
+        // Check if AXI has finished
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+
+        if(axi_resp.resp & 1) {
+            axi_resp.resp = (axi_resp.resp >> 1) & 0b11;
+            return axi_resp;
+        }
+    }
+}
+
+void soc_read_addr(axi_req_t req) {
+    if (!req.read) return;
+    // Set AXI address
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+
+    // Set AXI burst
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+
+    // Set AXI aXuser
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+
+    // Send on AR channel
+    uint32_t execute = AXI_READ_ADDR | AXI_USE_ID | ((req.len - 1) << 8) | (req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+
+}
+
+axi_resp_t soc_read_resp(axi_req_t req) {
+    if (!req.read)
+        return (axi_resp_t){ .resp = 0, .rdata = 0 };
+    // Receive from R channel
+    uint32_t execute = AXI_READ_RESP | AXI_USE_ID | ((req.len - 1) << 8) |(req.id << 16);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+
+    while (1) {
+        axi_resp_t axi_resp;
+
+        // Check if AXI has finished
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+
+        if(axi_resp.resp & 1) {
+            axi_resp.resp = (axi_resp.resp >> 1) & 0b11;
+            for (int i = 0; i < req.len; i++) {
+                lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x057F);
+                uint32_t rdata = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
+                if (i == 0) axi_resp.rdata = rdata;
+                if (req.rdata) req.rdata[i] = rdata;
+            }
+            return axi_resp;
+        }
+    }
+}

--- a/src/integration/test_suites/libs/soc_access/soc_access.c
+++ b/src/integration/test_suites/libs/soc_access/soc_access.c
@@ -33,37 +33,37 @@ axi_resp_t soc_access_32(axi_req_t req) {
     axi_resp_t axi_resp;
     // Set AXI address
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x01A2);
 
     // Set AXI burst
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x08A2);
 
     // Set AXI aXuser
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x07A2);
 
     if (req.write) {
         // Clear SoC access queues
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0A7F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0AA2);
 
         for (int i = 0; i < req.len; i++) {
             // Push AXI wdata
             lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wdata ? req.wdata[i] : 0);
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x027F);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x02A2);
             // Push AXI wuser
             lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wuser ? req.wuser[i] : AXI_DEFAULT_USER);
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x067F);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x06A2);
             // Push AXI wstrb
             lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wstrb ? (req.wstrb[i] & 0xF) : 0xF);
-            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x097F);
+            lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x09A2);
         }
     }
 
     uint32_t execute = (req.write ? AXI_WRITE : 0) | (req.read ? AXI_READ : 0) | (req.use_id ? AXI_USE_ID : 0) |
             ((req.len - 1) << 8) | (req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 
     if (req.ignore_resp)
         return (axi_resp_t){ .resp = 0, .rdata = 0 };
@@ -72,7 +72,7 @@ axi_resp_t soc_access_32(axi_req_t req) {
         axi_resp_t axi_resp;
 
         // Check if AXI has finished
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x04A2);
         axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
 
         if(axi_resp.resp & 1) {
@@ -80,7 +80,7 @@ axi_resp_t soc_access_32(axi_req_t req) {
 
             if (req.read) {
                 for (int i = 0; i < req.len; i++) {
-                    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x057F);
+                    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x05A2);
                     uint32_t rdata = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
                     if (i == 0) axi_resp.rdata = rdata;
                     if (req.rdata) req.rdata[i] = rdata;
@@ -94,7 +94,7 @@ axi_resp_t soc_access_32(axi_req_t req) {
 // intended to be used only after soc_access_32 with .ignore_resp = true
 uint8_t soc_access_await_done() {
     while(1) {
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x04A2);
         uint8_t resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
         if (resp & 1)
             return (resp >> 1) & 0b11; 
@@ -164,43 +164,43 @@ void soc_write_addr(axi_req_t req) {
     if (!req.write) return;
     // Set AXI address
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x01A2);
 
     // Set AXI burst
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x08A2);
 
     // Set AXI aXuser
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x07A2);
 
     // Send on AW channel
     uint32_t execute = AXI_WRITE_ADDR | AXI_USE_ID | ((req.len - 1) << 8) | (req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 }
 
 void soc_write_data(axi_req_t req) {
     if (!req.write) return;
     // Clear SoC access queues
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0A7F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x0AA2);
 
     for (int i = 0; i < req.len; i++) {
         // Push AXI wdata
         lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wdata ? req.wdata[i] : 0);
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x027F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x02A2);
         // Push AXI wuser
         lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wuser ? req.wuser[i] : AXI_DEFAULT_USER);
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x067F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x06A2);
         // Push AXI wstrb
         lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.wstrb ? (req.wstrb[i] & 0xF) : 0xF);
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x097F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x09A2);
     }
 
     // Send on W channel
     uint32_t execute = AXI_WRITE_DATA | ((req.len - 1) << 8);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 }
 
 axi_resp_t soc_write_resp(axi_req_t req) {
@@ -209,12 +209,12 @@ axi_resp_t soc_write_resp(axi_req_t req) {
     // Receive from B channel
     uint32_t execute = AXI_WRITE_RESP | AXI_USE_ID | (req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
     while (1) {
         axi_resp_t axi_resp;
 
         // Check if AXI has finished
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x04A2);
         axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
 
         if(axi_resp.resp & 1) {
@@ -228,20 +228,20 @@ void soc_read_addr(axi_req_t req) {
     if (!req.read) return;
     // Set AXI address
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.addr);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x017F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x01A2);
 
     // Set AXI burst
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.burst);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x087F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x08A2);
 
     // Set AXI aXuser
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, req.axuser);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x077F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x07A2);
 
     // Send on AR channel
     uint32_t execute = AXI_READ_ADDR | AXI_USE_ID | ((req.len - 1) << 8) | (req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 
 }
 
@@ -251,19 +251,19 @@ axi_resp_t soc_read_resp(axi_req_t req) {
     // Receive from R channel
     uint32_t execute = AXI_READ_RESP | AXI_USE_ID | ((req.len - 1) << 8) |(req.id << 16);
     lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_1, execute);
-    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x037F);
+    lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x03A2);
 
     while (1) {
         axi_resp_t axi_resp;
 
         // Check if AXI has finished
-        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x047F);
+        lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x04A2);
         axi_resp.resp = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
 
         if(axi_resp.resp & 1) {
             axi_resp.resp = (axi_resp.resp >> 1) & 0b11;
             for (int i = 0; i < req.len; i++) {
-                lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x057F);
+                lsu_write_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_OUTPUT_WIRES_0, 0x05A2);
                 uint32_t rdata = lsu_read_32(CLP_SOC_IFC_REG_CPTRA_GENERIC_INPUT_WIRES_0);
                 if (i == 0) axi_resp.rdata = rdata;
                 if (req.rdata) req.rdata[i] = rdata;

--- a/src/integration/test_suites/libs/soc_access/soc_access.h
+++ b/src/integration/test_suites/libs/soc_access/soc_access.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOC_ACCESS_LIB
+#define SOC_ACCESS_LIB
+
+#include <stdbool.h>
+#include "stdint.h"
+
+typedef enum {
+    AXI_BURST_FIXED = 0,
+    AXI_BURST_INCR = 1,
+    AXI_BURST_WRAP = 2
+} axi_burst_t;
+
+typedef struct {
+    uint32_t  rdata;
+    uint8_t   resp;
+} axi_resp_t;
+
+typedef struct {
+    uint32_t addr, axuser;
+    axi_burst_t burst;
+    uint32_t *wdata, *wuser, *rdata;
+    uint8_t *wstrb;
+    uint8_t len;
+    uint8_t id;
+    bool write, read, ignore_resp, use_id;
+} axi_req_t;
+
+axi_resp_t soc_access_32(axi_req_t req);
+uint8_t soc_access_await_done();
+uint8_t soc_masked_write_32(uint32_t reg_addr, uint32_t value, uint32_t mask);
+uint8_t soc_write_user_32(uint32_t reg_addr, uint32_t value, uint32_t user);
+uint8_t soc_write_32(uint32_t reg_addr, uint32_t value);
+axi_resp_t soc_read_user_32(uint32_t reg_addr, uint32_t user);
+axi_resp_t soc_read_32(uint32_t reg_addr);
+void       soc_write_addr(axi_req_t req);
+void       soc_write_data(axi_req_t req);
+axi_resp_t soc_write_resp(axi_req_t req);
+void       soc_read_addr(axi_req_t req);
+axi_resp_t soc_read_resp(axi_req_t req);
+
+#endif /* SOC_ACCESS_LIB */

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.c
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.c
@@ -25,7 +25,7 @@ uint32_t soc_ifc_mbox_read_dataout_single() {
 uint32_t soc_ifc_mbox_dir_read_single(uint32_t rdptr) {
     return lsu_read_32(CLP_MBOX_SRAM_BASE_ADDR + rdptr);
 }
-uint32_t soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata) {
+void soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata) {
     lsu_write_32(CLP_MBOX_SRAM_BASE_ADDR + wrptr, wrdata);
 }
 
@@ -66,6 +66,19 @@ void soc_ifc_set_mbox_status_field(enum mbox_status_e field) {
     reg = lsu_read_32(CLP_MBOX_CSR_MBOX_STATUS);
     reg = (reg & ~MBOX_CSR_MBOX_STATUS_STATUS_MASK) | (field << MBOX_CSR_MBOX_STATUS_STATUS_LOW);
     lsu_write_32(CLP_MBOX_CSR_MBOX_STATUS,reg);
+}
+
+uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_status_e exp_state) {
+    for(uint32_t ii=0; ii<attempt_count; ii++) {
+        if(((lsu_read_32(CLP_MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_MBOX_FSM_PS_MASK) >> MBOX_CSR_MBOX_STATUS_MBOX_FSM_PS_LOW) == exp_state) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+uint32_t soc_ifc_mbox_read_rdptr() {
+    return (lsu_read_32(CLP_MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_MBOX_RDPTR_MASK) >> MBOX_CSR_MBOX_STATUS_MBOX_RDPTR_LOW;
 }
 
 void soc_ifc_set_flow_status_field(uint32_t field) {
@@ -328,20 +341,20 @@ void soc_ifc_sha_accel_clr_lock() {
 }   
 
 // AXI DMA Functions
-uint8_t soc_ifc_axi_dma_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
+void soc_ifc_axi_dma_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
     soc_ifc_axi_dma_arm_send_ahb_payload(dst_addr, fixed, payload, byte_count, block_size);
     soc_ifc_axi_dma_get_send_ahb_payload(payload, byte_count);
     soc_ifc_axi_dma_wait_idle(0);
 }
 
 // AXI DMA Functions
-uint8_t soc_ifc_axi_dma_send_ahb_payload_w_error_expected(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected) {
+void soc_ifc_axi_dma_send_ahb_payload_w_error_expected(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected) {
     soc_ifc_axi_dma_arm_send_ahb_payload(dst_addr, fixed, payload, byte_count, block_size);
     soc_ifc_axi_dma_get_send_ahb_payload(payload, byte_count);
     soc_ifc_axi_dma_wait_idle_w_error_expected(0, error_expected);
 }
 
-uint8_t soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
+void soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
     uint32_t reg;
 
     // Arm the command
@@ -357,7 +370,7 @@ uint8_t soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, u
     lsu_write_32(CLP_AXI_DMA_REG_CTRL, reg);
 }
 
-uint8_t soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_count) {
+void soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_count) {
     uint16_t mdepth;
 
     // Send data
@@ -369,19 +382,19 @@ uint8_t soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_c
     }
 }
 
-uint8_t soc_ifc_axi_dma_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
+void soc_ifc_axi_dma_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
     soc_ifc_axi_dma_arm_read_ahb_payload(src_addr, fixed, payload, byte_count, block_size);
     soc_ifc_axi_dma_get_read_ahb_payload(payload, byte_count);
     soc_ifc_axi_dma_wait_idle(0);
 }
 
-uint8_t soc_ifc_axi_dma_read_ahb_payload_w_error_expected(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected) {
+void soc_ifc_axi_dma_read_ahb_payload_w_error_expected(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected) {
     soc_ifc_axi_dma_arm_read_ahb_payload(src_addr, fixed, payload, byte_count, block_size);
     soc_ifc_axi_dma_get_read_ahb_payload(payload, byte_count);
     soc_ifc_axi_dma_wait_idle_w_error_expected(0, error_expected);
 }
 
-uint8_t soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
+void soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size) {
     uint32_t reg;
 
     // Arm the command
@@ -398,7 +411,7 @@ uint8_t soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, u
 
 }
 
-uint8_t soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_count) {
+void soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_count) {
     uint16_t mdepth;
     // Read data
     mdepth = (lsu_read_32(CLP_AXI_DMA_REG_CAP) & AXI_DMA_REG_CAP_FIFO_MAX_DEPTH_MASK) >> AXI_DMA_REG_CAP_FIFO_MAX_DEPTH_LOW;
@@ -410,6 +423,17 @@ uint8_t soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_c
 }
 
 uint8_t soc_ifc_axi_dma_send_mbox_payload(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size) {
+    uint8_t res;
+
+    res = soc_ifc_axi_dma_send_mbox_payload_no_wait(src_addr, dst_addr, fixed, byte_count, block_size);
+
+    if (res == 0)
+        soc_ifc_axi_dma_wait_idle(1);
+
+    return res;
+}
+
+uint8_t soc_ifc_axi_dma_send_mbox_payload_no_wait(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size) {
     uint32_t reg;
 
     // Acquire the mailbox lock
@@ -444,26 +468,18 @@ uint8_t soc_ifc_axi_dma_send_mbox_payload(uint64_t src_addr, uint64_t dst_addr, 
           (fixed ? AXI_DMA_REG_CTRL_WR_FIXED_MASK : 0);
     lsu_write_32(CLP_AXI_DMA_REG_CTRL, reg);
 
-    // Check completion
-    reg = lsu_read_32(CLP_AXI_DMA_REG_STATUS0);
-    while ((reg & AXI_DMA_REG_STATUS0_BUSY_MASK) && !(reg & AXI_DMA_REG_STATUS0_ERROR_MASK)) {
-        reg = lsu_read_32(CLP_AXI_DMA_REG_STATUS0);
-    }
-
-    // Check status
-    if (reg & AXI_DMA_REG_STATUS0_ERROR_MASK) {
-        VPRINTF(FATAL, "FATAL: AXI DMA reports error status for MBOX-to-AXI xfer\n");
-        lsu_write_32(CLP_AXI_DMA_REG_CTRL, AXI_DMA_REG_CTRL_FLUSH_MASK);
-        SEND_STDOUT_CTRL(0x1);
-    }
-
-    lsu_write_32(CLP_MBOX_CSR_MBOX_UNLOCK, MBOX_CSR_MBOX_UNLOCK_UNLOCK_MASK);
     return 0;
 }
 
 uint8_t soc_ifc_axi_dma_read_mbox_payload(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size) {
-    soc_ifc_axi_dma_read_mbox_payload_no_wait(src_addr, dst_addr, fixed, byte_count, block_size);
-    soc_ifc_axi_dma_wait_idle(1);
+    uint8_t res;
+
+    res = soc_ifc_axi_dma_read_mbox_payload_no_wait(src_addr, dst_addr, fixed, byte_count, block_size);
+
+    if (res == 0)
+        soc_ifc_axi_dma_wait_idle(1);
+
+    return res;
 }
 
 uint8_t soc_ifc_axi_dma_read_mbox_payload_no_wait(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size) {
@@ -504,7 +520,7 @@ uint8_t soc_ifc_axi_dma_read_mbox_payload_no_wait(uint64_t src_addr, uint64_t ds
     return 0;
 }
 
-uint8_t soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_count) {
+void soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_count) {
     uint32_t reg;
     VPRINTF(LOW, "FW: Sending KV to AXI with ERR\n");
     reg = lsu_read_32(CLP_AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R);
@@ -516,13 +532,13 @@ uint8_t soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_co
     lsu_write_32(CLP_AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R, reg | AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTR_EN_R_NOTIF_TXN_DONE_EN_MASK);
 }
 
-uint8_t soc_ifc_axi_dma_send_kv_to_axi(uint64_t dst_addr, uint32_t byte_count) {
+void soc_ifc_axi_dma_send_kv_to_axi(uint64_t dst_addr, uint32_t byte_count) {
     VPRINTF(LOW, "FW: Sending KV to AXI\n");
     soc_ifc_axi_dma_send_kv_to_axi_no_wait(dst_addr, byte_count);
     soc_ifc_axi_dma_wait_idle(0);
 }
 
-uint8_t soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_count) {
+void soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_count) {
     uint32_t reg;
 
     // Arm the command
@@ -537,22 +553,22 @@ uint8_t soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_
 
 }
 
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_error(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
+void soc_ifc_axi_dma_send_axi_to_axi_error(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
     soc_ifc_axi_dma_send_axi_to_axi_no_wait(src_addr, src_fixed, dst_addr, dst_fixed, byte_count, block_size,  aes_mode, aes_gcm_mode);
     soc_ifc_axi_dma_wait_error(0);
 }
 
-uint8_t soc_ifc_axi_dma_send_axi_to_axi(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
+void soc_ifc_axi_dma_send_axi_to_axi(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
     soc_ifc_axi_dma_send_axi_to_axi_no_wait(src_addr, src_fixed, dst_addr, dst_fixed, byte_count, block_size,  aes_mode, aes_gcm_mode);
     soc_ifc_axi_dma_wait_idle(0);
 }
 
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_w_error_expected(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode, uint8_t error_expected) {
+void soc_ifc_axi_dma_send_axi_to_axi_w_error_expected(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode, uint8_t error_expected) {
     soc_ifc_axi_dma_send_axi_to_axi_no_wait(src_addr, src_fixed, dst_addr, dst_fixed, byte_count, block_size,  aes_mode, aes_gcm_mode);
     soc_ifc_axi_dma_wait_idle_w_error_expected(0, error_expected);
 }
 
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
+void soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode) {
     uint32_t reg;
 
     // Arm the command
@@ -574,7 +590,7 @@ uint8_t soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_f
 
 }
 
-uint8_t soc_ifc_axi_dma_wait_idle(uint8_t clr_lock) {
+void soc_ifc_axi_dma_wait_idle(uint8_t clr_lock) {
     uint32_t reg;
 
     // Check completion
@@ -595,7 +611,7 @@ uint8_t soc_ifc_axi_dma_wait_idle(uint8_t clr_lock) {
     }
 }
 
-uint8_t soc_ifc_axi_dma_wait_error(uint8_t clr_lock) {
+void soc_ifc_axi_dma_wait_error(uint8_t clr_lock) {
     uint32_t reg;
 
     // Check completion
@@ -747,7 +763,7 @@ uint8_t soc_ifc_axi_dma_inject_inv_error(enum err_inj_type err_type) {
 }
 
 
-uint8_t soc_ifc_axi_dma_wait_idle_w_error_expected(uint8_t clr_lock, uint8_t error_expected) {
+void soc_ifc_axi_dma_wait_idle_w_error_expected(uint8_t clr_lock, uint8_t error_expected) {
     
     uint32_t reg;
     uint32_t error_observed = 0;

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.c
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.c
@@ -68,7 +68,7 @@ void soc_ifc_set_mbox_status_field(enum mbox_status_e field) {
     lsu_write_32(CLP_MBOX_CSR_MBOX_STATUS,reg);
 }
 
-uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_status_e exp_state) {
+uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_fsm_e exp_state) {
     for(uint32_t ii=0; ii<attempt_count; ii++) {
         if(((lsu_read_32(CLP_MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_MBOX_FSM_PS_MASK) >> MBOX_CSR_MBOX_STATUS_MBOX_FSM_PS_LOW) == exp_state) {
             return 0;

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
@@ -38,8 +38,9 @@ enum mbox_fsm_e {
     MBOX_RDY_FOR_CMD  = 0x1,
     MBOX_RDY_FOR_DATA = 0x2,
     MBOX_RDY_FOR_DLEN = 0x3,
-    MBOX_EXECUTE_UC   = 0x6,
     MBOX_EXECUTE_SOC  = 0x4,
+    MBOX_EXECUTE_TAP  = 0x5,
+    MBOX_EXECUTE_UC   = 0x6,
     MBOX_ERROR        = 0x7
 };
 
@@ -146,10 +147,12 @@ enum sha_accel_mode_e {
 // Simple reg accesses
 uint32_t soc_ifc_mbox_read_dataout_single();
 uint32_t soc_ifc_mbox_dir_read_single(uint32_t rdptr);
-uint32_t soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata);
+void soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata);
 void soc_ifc_clear_execute_reg();
 uint8_t soc_ifc_chk_execute_uc();
 void soc_ifc_set_mbox_status_field(enum mbox_status_e field);
+uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_status_e exp_state);
+uint32_t soc_ifc_mbox_read_rdptr();
 void soc_ifc_set_flow_status_field(uint32_t field);
 void soc_ifc_clr_flow_status_field(uint32_t field);
 void soc_ifc_set_fw_update_reset(uint8_t wait_cycles);
@@ -170,28 +173,29 @@ void soc_ifc_sha_accel_clr_lock();
 void soc_ifc_w1clr_sha_lock_field(uint32_t field);
 
 // AXI DMA Functions
-uint8_t soc_ifc_axi_dma_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_count);
-uint8_t soc_ifc_axi_dma_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_count);
+void soc_ifc_axi_dma_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
+void soc_ifc_axi_dma_arm_send_ahb_payload(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
+void soc_ifc_axi_dma_get_send_ahb_payload(uint32_t * payload, uint32_t byte_count);
+void soc_ifc_axi_dma_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
+void soc_ifc_axi_dma_arm_read_ahb_payload(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size);
+void soc_ifc_axi_dma_get_read_ahb_payload(uint32_t * payload, uint32_t byte_count);
 uint8_t soc_ifc_axi_dma_send_mbox_payload(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size);
+uint8_t soc_ifc_axi_dma_send_mbox_payload_no_wait(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size);
 uint8_t soc_ifc_axi_dma_read_mbox_payload(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size);
 uint8_t soc_ifc_axi_dma_read_mbox_payload_no_wait(uint64_t src_addr, uint64_t dst_addr, uint8_t fixed, uint32_t byte_count, uint16_t block_size);
-uint8_t soc_ifc_axi_dma_send_axi_to_axi(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_error(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
-uint8_t soc_ifc_axi_dma_send_kv_to_axi(uint64_t dst_addr, uint32_t byte_count);
-uint8_t soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_count);
-uint8_t soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_count);
-uint8_t soc_ifc_axi_dma_wait_idle      (uint8_t clr_lock);
-uint8_t soc_ifc_axi_dma_wait_error     (uint8_t clr_lock);
+void soc_ifc_axi_dma_send_axi_to_axi(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
+void soc_ifc_axi_dma_send_axi_to_axi_error(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
+void soc_ifc_axi_dma_send_axi_to_axi_no_wait(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode);
+void soc_ifc_axi_dma_send_kv_to_axi(uint64_t dst_addr, uint32_t byte_count);
+void soc_ifc_axi_dma_send_kv_to_axi_error(uint64_t dst_addr, uint32_t byte_count);
+void soc_ifc_axi_dma_send_kv_to_axi_no_wait(uint64_t dst_addr, uint32_t byte_count);
+void soc_ifc_axi_dma_wait_idle      (uint8_t clr_lock);
+void soc_ifc_axi_dma_wait_error     (uint8_t clr_lock);
 uint8_t soc_ifc_axi_dma_inject_inv_error(enum err_inj_type err_type);
 
-uint8_t soc_ifc_axi_dma_read_ahb_payload_w_error_expected(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected);
-uint8_t soc_ifc_axi_dma_send_axi_to_axi_w_error_expected(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode, uint8_t error_expected);
-uint8_t soc_ifc_axi_dma_send_ahb_payload_w_error_expected(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected);
-uint8_t soc_ifc_axi_dma_wait_idle_w_error_expected(uint8_t clr_lock, uint8_t error_expected);
+void soc_ifc_axi_dma_read_ahb_payload_w_error_expected(uint64_t src_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected);
+void soc_ifc_axi_dma_send_axi_to_axi_w_error_expected(uint64_t src_addr, uint8_t src_fixed, uint64_t dst_addr, uint8_t dst_fixed, uint32_t byte_count, uint16_t block_size, uint8_t aes_mode, uint8_t aes_gcm_mode, uint8_t error_expected);
+void soc_ifc_axi_dma_send_ahb_payload_w_error_expected(uint64_t dst_addr, uint8_t fixed, uint32_t * payload, uint32_t byte_count, uint16_t block_size, uint8_t error_expected);
+void soc_ifc_axi_dma_wait_idle_w_error_expected(uint8_t clr_lock, uint8_t error_expected);
 
 #endif

--- a/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
+++ b/src/integration/test_suites/libs/soc_ifc/soc_ifc.h
@@ -151,7 +151,7 @@ void soc_ifc_mbox_dir_write_single(uint32_t wrptr, uint32_t wrdata);
 void soc_ifc_clear_execute_reg();
 uint8_t soc_ifc_chk_execute_uc();
 void soc_ifc_set_mbox_status_field(enum mbox_status_e field);
-uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_status_e exp_state);
+uint8_t soc_ifc_poll_mbox_state(uint32_t attempt_count, enum mbox_fsm_e exp_state);
 uint32_t soc_ifc_mbox_read_rdptr();
 void soc_ifc_set_flow_status_field(uint32_t field);
 void soc_ifc_clr_flow_status_field(uint32_t field);

--- a/src/integration/test_suites/smoke_test_kv_len_mismatch_abr/smoke_test_kv_len_mismatch_abr.c
+++ b/src/integration/test_suites/smoke_test_kv_len_mismatch_abr/smoke_test_kv_len_mismatch_abr.c
@@ -68,7 +68,7 @@ static void fail_test(const char* m){
 }
 
 static inline void kv_inject(uint8_t slot, uint8_t last_dword, uint8_t dest_valid) {
-    uint32_t cmd = 0xa2u
+    uint32_t cmd = 0xa3u
                  | ((uint32_t)(slot & 0x1Fu) << 8)
                  | ((uint32_t)(last_dword & 0xFu) << 13)
                  | ((uint32_t)dest_valid << 17);

--- a/src/integration/test_suites/smoke_test_kv_len_mismatch_aes/smoke_test_kv_len_mismatch_aes.c
+++ b/src/integration/test_suites/smoke_test_kv_len_mismatch_aes/smoke_test_kv_len_mismatch_aes.c
@@ -88,7 +88,7 @@ static void fail_test(const char* m){
 }
 
 static inline void kv_inject(uint8_t slot, uint8_t last_dword, uint8_t dest_valid) {
-    uint32_t cmd = 0xa2u
+    uint32_t cmd = 0xa3u
                  | ((uint32_t)(slot & 0x1Fu) << 8)
                  | ((uint32_t)(last_dword & 0xFu) << 13)
                  | ((uint32_t)dest_valid << 17);

--- a/src/integration/test_suites/smoke_test_kv_len_mismatch_ecc/smoke_test_kv_len_mismatch_ecc.c
+++ b/src/integration/test_suites/smoke_test_kv_len_mismatch_ecc/smoke_test_kv_len_mismatch_ecc.c
@@ -61,7 +61,7 @@ static void fail_test(const char* m){
 }
 
 static inline void kv_inject(uint8_t slot, uint8_t last_dword, uint8_t dest_valid) {
-    uint32_t cmd = 0xa2u
+    uint32_t cmd = 0xa3u
                  | ((uint32_t)(slot & 0x1Fu) << 8)
                  | ((uint32_t)(last_dword & 0xFu) << 13)
                  | ((uint32_t)dest_valid << 17);

--- a/src/integration/test_suites/smoke_test_kv_len_mismatch_hmac/smoke_test_kv_len_mismatch_hmac.c
+++ b/src/integration/test_suites/smoke_test_kv_len_mismatch_hmac/smoke_test_kv_len_mismatch_hmac.c
@@ -76,9 +76,9 @@ static void fail_test(const char* m){
     while(1);
 }
 
-// TB inject cmd 0xa2 — arbitrary slot/last_dword/dest_valid.
+// TB inject cmd 0xa3 — arbitrary slot/last_dword/dest_valid.
 static inline void kv_inject(uint8_t slot, uint8_t last_dword, uint8_t dest_valid) {
-    uint32_t cmd = 0xa2u
+    uint32_t cmd = 0xa3u
                  | ((uint32_t)(slot & 0x1Fu) << 8)
                  | ((uint32_t)(last_dword & 0xFu) << 13)
                  | ((uint32_t)dest_valid << 17);


### PR DESCRIPTION

* Allow for logging code reduction with custom define
* Add 'ifc_reg' library for register testing infrastructure
* Add tests:
  * ifc_reg_rand_test
  * ifc_reg_ro_reg_rand_test
  * ifc_reg_soc_rw_cptra_ro_config
  * ifc_reg_soc_rw_cptra_ro_idevid
  * ifc_reg_soc_rw_cptra_ro_pk_hash
  * ifc_reg_soc_rw_cptra_ro_misc
  * ifc_reg_intr_test
  * ifc_reg_dma_soc_access
  * ifc_reg_rw_hw
  * ifc_reg_soc_rw_hw_ro
  * ifc_reg_invalid_access

Depends on https://github.com/chipsalliance/caliptra-rtl/pull/1321