### PR TITLE
[DOC] Update ECC performance table to radix-48 measurements

### DIFF
--- a/docs/CaliptraHardwareSpecification.md
+++ b/docs/CaliptraHardwareSpecification.md
@@ -1640,13 +1640,14 @@ The ECC core performance is reported in the next section.
 
 ### Pure hardware architecture
 
-In this architecture, the ECC interface and controller are implemented in hardware. The performance specification of the ECC architecture is reported as shown in the following table.
+In this architecture, the ECC interface and controller are implemented in hardware. The Montgomery multiplier in the current RTL uses a **radix-48** datapath (`MULT_RADIX = 48` in `src/ecc/rtl/ecc_params_pkg.sv`), which reduces the number of PE iterations per 384-bit modular multiplication from 12 (radix-32) to 8. The performance specification of the ECC architecture is reported as shown in the following table. Cycle counts were measured on `ecc_top_tb` running the `ecc_normal_test` (radix-48 RTL).
 
-| Operation | Cycle count \[CCs\] | Time \[ms\] @ 400 MHz | Throughput \[op/s\] |
-| :-------- | :------------------ | :-------------------- | :------------------ |
-| Keygen    | 909,648             | 2.274                 | 439                 |
-| Signing   | 932,990             | 2.332                 | 428                 |
-| Verifying | 1,223,938           | 3.060                 | 326                 |
+| Operation      | Cycle count \[CCs\] | Time \[ms\] @ 400 MHz | Throughput \[op/s\] |
+| :------------- | :------------------ | :-------------------- | :------------------ |
+| Keygen         | 719,675             | 1.799                 | 556                 |
+| Signing        | 736,978             | 1.842                 | 543                 |
+| Verifying      | 960,404             | 2.401                 | 416                 |
+| ECDH sharedkey | 717,421             | 1.794                 | 558                 |
 
 
 ## LMS Accelerator


### PR DESCRIPTION
The ECC Montgomery multiplier in current RTL uses radix-48 (`MULT_RADIX = 48` in `src/ecc/rtl/ecc_params_pkg.sv`), replacing the earlier radix-32 architecture (PR #321). The performance table in the ECC "Pure hardware architecture" section of `docs/CaliptraHardwareSpecification.md` still listed the older radix-32 cycle counts.

Measured on `ecc_top_tb` running `ecc_normal_test` with current RTL:

| Operation      | Cycles  | Time @ 400 MHz | Throughput |
| :------------- | ------: | -------------: | ---------: |
| Keygen         | 719,675 |       1.799 ms |    556 op/s |
| Signing        | 736,978 |       1.842 ms |    543 op/s |
| Verifying      | 960,404 |       2.401 ms |    416 op/s |
| ECDH sharedkey | 717,421 |       1.794 ms |    558 op/s |

For reference, the previous radix-32 numbers were 909,648 / 932,990 / 1,223,938 cycles for keygen/signing/verifying (~21% cycle reduction with radix-48).