### PR TITLE
[VAL] Per-consumer coverage for KV key-length mismatch

### DIFF
--- a/docs/CaliptraHardwareSpecification.md
+++ b/docs/CaliptraHardwareSpecification.md
@@ -2665,6 +2665,81 @@ must observe `AES_KV_RD_KEY_STATUS.ERROR` after the status VALID bit
 sets. The `AES_KV_RD_KEY_STATUS.ERROR` field encodes the KV error
 code (`KV_SUCCESS=0`, `KV_READ_FAIL=1`, `KV_RD_LEN_MISMATCH=3`).
 
+**Consumers that do not check.** `hmac_block_kv_read` and
+`sha512_block_kv_read` are instantiated with `LEN_CHECK=0`. The
+comparison logic, the `stored_last_dword` register, and the trigger
+select are inside a `generate if (LEN_CHECK != 0)` block, so for these
+two instances the logic is not elaborated at all. This is deliberate:
+a parameter-gated `always_comb` would leave permanently unreachable
+condition and branch bins in every non-checking instance (and an
+unreachable arm of the trigger select in *every* instance), which then
+have to be papered over with coverage exclusions. Generating the logic
+away instead keeps every remaining line/condition/branch bin in
+`kv_read_client.sv` genuinely reachable in the instance that owns it,
+so no exclusion file is required for this feature.
+
+#### Coverage sign-off for the length check
+
+VCS merges code coverage across module instances whose coverable code
+structure is identical, and the merge is per metric. Measured on a
+`caliptra_top_tb` coverage run, **all eight `LEN_CHECK=1` instances
+land in a single condition/branch coverage group**:
+
+```
+Cond Coverage for Module : \RTL.kv_read_client
+  ( DATA_WIDTH=384,...,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=0
+  + DATA_WIDTH=512,...,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=1
+  + DATA_WIDTH=256,...,AES=1,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=1
+  + DATA_WIDTH=256,...,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=0
+  + DATA_WIDTH=512,...,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=0 )
+
+  EXPRESSION (length_check_trigger && (stored_last_dword < expected_key_size))
+              -----------1-----------    ---------------2----------------
+  -1- -2- Status
+   0   1  Covered
+   1   0  Not Covered
+   1   1  Covered
+```
+
+That truth table is shared by `hmac_key_kv_read`,
+`ecc_privkey_kv_read`, `ecc_seed_kv_read`, `aes_key_kv_read`,
+`kv_mldsa_seed_read_inst`, `kv_mlkem_seed_read_inst`,
+`kv_mlkem_msg_read_inst` and `dma_data_kv_read`. A single
+`smoke_test_kv_len_mismatch_hmac` run marks the `1 1` (mismatch) bin
+covered for **all eight** consumers. Two consequences for sign-off:
+
+1. **Condition and branch coverage on `length_mismatch` cannot be used
+   as per-consumer evidence.** Per-instance line/cond/branch scores are
+   still available in the urg hierarchy view and in the "Module
+   self-instances" table of `modinfo.txt`, so read those rather than
+   the merged group score.
+2. The instance-unique cover properties in
+   `src/integration/asserts/caliptra_top_sva.sv` are the authoritative
+   per-consumer evidence. Each checking consumer has the same bin set:
+   `_len_mismatch_C` (comparator fired), `_len_err_latched_C`
+   (FW-visible `error_code`), `_len_match_C`, `_len_exact_C`
+   (`stored == expected` boundary) and `_len_larger_C` (the relaxed
+   accept-larger path). HMAC additionally crosses the check against
+   `mode_reg` (384/512) and AES against `key_len` (128/192/256),
+   because for those two consumers the expected size is programmed
+   *after* the KV read completes and an aggregate bin would not prove
+   the check tracks the register.
+
+Note that the merged `1 0` bin above (check evaluated, entry large
+enough) is the accept path; `smoke_test_kv_len_mismatch_*` are
+negative-only, so the `_len_match_C` / `_len_exact_C` / `_len_larger_C`
+covers are the ones that close it per consumer.
+
+`caliptra_top_sva` is instantiated at `caliptra_top_tb.sva`, outside
+the `+tree caliptra_top_tb.caliptra_top_dut` scope in
+`src/integration/coverage/config/caliptra_top_tb_cm_hier.cfg`. That
+`begin` block lists only `line+tgl+fsm+cond+branch`, so `assert`
+coverage is unscoped and collected design-wide; all of these covers
+have been confirmed present in `urg` `asserts.txt` as
+`caliptra_top_tb.sva.KV_*_len_*_C`. If the cfg ever gains an `assert`
+block scoped to the DUT tree, they would silently disappear rather
+than fail.
+
 If multiple iterations of the cryptographic function are required, the key vault read and write controls must be programmed for each iteration. This ensures that the lock is set and the digest is not readable.
 
 The following tables describe read, write, and status values for key vault blocks.

--- a/src/integration/asserts/caliptra_top_sva.sv
+++ b/src/integration/asserts/caliptra_top_sva.sv
@@ -1520,32 +1520,185 @@ module caliptra_top_sva
       ~`HMAC_PATH.hmac_key_kv_read.kv_read_rules.read_allow);
 
   // -----------------------------------------------------------------
-  // KV key-length-mismatch (per-consumer, per RFC)
+  // KV key-length-mismatch (per-consumer)
   // -----------------------------------------------------------------
-  // The stored last_dword captured inside kv_read_client must equal the
-  // entry's stored last_dword whenever the read completes without error.
-  `CALIPTRA_ASSERT(KV_hmac_stored_len_matches_entry,
-      $rose(`HMAC_PATH.kv_key_done) && (`HMAC_PATH.kv_key_error == 0) |->
-      (`HMAC_PATH.hmac_key_kv_read.stored_last_dword ==
-       `KEYVAULT_PATH.kv_reg1.hwif_out.KEY_CTRL[`HMAC_PATH.kv_read[0].read_entry].last_dword.value),
+  // COVERAGE NOTE -- why every consumer gets its own bins.
+  //
+  // VCS scores code coverage per module definition per unique parameter set,
+  // so kv_read_client instances that share a parameter set are MERGED in the
+  // module view. Colliding pairs today:
+  //     ecc_privkey_kv_read      / ecc_seed_kv_read         (DATA_WIDTH=384)
+  //     kv_mldsa_seed_read_inst  / kv_mlkem_msg_read_inst   (DATA_WIDTH=256)
+  //     kv_mlkem_seed_read_inst  / dma_data_kv_read         (DATA_WIDTH=512)
+  // Hitting the mismatch branch in one member of a pair marks it covered for
+  // the other. These instance-unique cover properties are therefore the only
+  // per-consumer evidence that the check was actually exercised end to end.
+  // Sign-off must read the urg HIERARCHY view for code coverage, not the
+  // module view. See docs/CaliptraHardwareSpecification.md.
+  //
+  // Uniform bin set per checking consumer:
+  //   _len_mismatch_C        comparator fired (stored entry too small)
+  //   _len_err_latched_C     FW-visible outcome: error_code == KV_RD_LEN_MISMATCH
+  //   _len_match_C           check evaluated and passed
+  //   _len_exact_C           stored == expected (boundary)
+  //   _len_larger_C          stored >  expected (relaxed accept-larger path)
+  //
+  // hmac_block_kv_read and sha512_block_kv_read are LEN_CHECK=0: the logic is
+  // generated away entirely, so there is nothing to cover and nothing to
+  // exclude.
+
+  // kv_defines_pkg is elaborated into both the RTL and TB libraries, so a
+  // direct enum-to-enum compare between a DUT `error_code` and a TB-scope
+  // enum literal raises Warning-[DTIE]/[DTII]. Mirror the codes as ints and
+  // cast at the comparison instead.
+  localparam int KV_ERRC_SUCCESS      = int'(KV_SUCCESS);
+  localparam int KV_ERRC_LEN_MISMATCH = int'(KV_RD_LEN_MISMATCH);
+
+`define KV_LEN_COVERS(NAME, CLIENT)                                                    \
+  KV_``NAME``_len_mismatch_C: cover property (                                         \
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)                                  \
+      CLIENT.length_mismatch);                                                         \
+  KV_``NAME``_len_err_latched_C: cover property (                                      \
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)                                  \
+      int'(CLIENT.error_code) == KV_ERRC_LEN_MISMATCH);                                        \
+  KV_``NAME``_len_match_C: cover property (                                            \
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)                                  \
+      CLIENT.len_check_gen.length_check_trigger && !CLIENT.length_mismatch);           \
+  KV_``NAME``_len_exact_C: cover property (                                            \
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)                                  \
+      CLIENT.len_check_gen.length_check_trigger &&                                     \
+      (CLIENT.len_check_gen.stored_last_dword == CLIENT.expected_key_size));           \
+  KV_``NAME``_len_larger_C: cover property (                                           \
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)                                  \
+      CLIENT.len_check_gen.length_check_trigger &&                                     \
+      (CLIENT.len_check_gen.stored_last_dword > CLIENT.expected_key_size));
+
+  // The size latched from the KV read-mux must equal the addressed entry's
+  // stored last_dword whenever the read completed cleanly. Applied per
+  // consumer: DATA_WIDTH differs per client, and the whole point of sourcing
+  // entry_last_dword from the mux is that a client whose read window is
+  // shorter than the entry still sees the true stored size.
+`define KV_LEN_STORED_MATCHES_ENTRY(NAME, CLIENT)                                      \
+  `CALIPTRA_ASSERT(KV_``NAME``_stored_len_matches_entry,                               \
+      $rose(CLIENT.read_done) && (int'(CLIENT.error_code) == KV_ERRC_SUCCESS) |->                 \
+      (CLIENT.len_check_gen.stored_last_dword ==                                       \
+       `KEYVAULT_REG_PATH.hwif_out.KEY_CTRL[CLIENT.read_ctrl_reg.read_entry].last_dword.value), \
       `SVA_RDC_CLK, ~`SVA_RST)
 
-  // HMAC key path uses relaxed (entry-too-small) check: mismatch fires only
-  // when the stored entry is smaller than what the mode requires.
-  `CALIPTRA_ASSERT(KV_hmac_len_mismatch_iff_mode_differs,
-      `HMAC_PATH.hmac_key_kv_read.length_mismatch |->
-      `HMAC_PATH.kv_key_data_present &&
-      (`HMAC_PATH.init_reg || `HMAC_PATH.next_reg) &&
-      (`HMAC_PATH.hmac_key_kv_read.stored_last_dword < `HMAC_PATH.hmac_expected_key_size),
+  // The comparator must reach the FW-visible error register. Qualified against
+  // the higher-priority arms of the error_code mux so the check is exact.
+  // Expressed with $past() rather than |=> for Verilator compatibility.
+`define KV_LEN_ERR_REACHES_REG(NAME, CLIENT)                                           \
+  `CALIPTRA_ASSERT(KV_``NAME``_len_mismatch_latches_err,                               \
+      $past(CLIENT.length_mismatch && !CLIENT.zeroize && !CLIENT.fsm_error &&          \
+            !(CLIENT.validated_read_en && !CLIENT.read_allow) &&                       \
+            !(CLIENT.write_en && CLIENT.kv_resp.error) &&                              \
+            !(CLIENT.write_en && |CLIENT.write_offset &&                               \
+              (int'(CLIENT.error_code) != KV_ERRC_SUCCESS)), 1) |->                               \
+      (int'(CLIENT.error_code) == KV_ERRC_LEN_MISMATCH),                                       \
       `SVA_RDC_CLK, ~`SVA_RST)
 
-  // When mismatch fires, key regs clear via hwclr with a fixed 2-cycle
-  // pipeline (mismatch cycle N → error_code registers cycle N+1 →
-  // hwclr cycle N+1 → key_reg zero cycle N+2).
-  // Note: expressed via $past(..., 2) instead of `|-> ##2` because Verilator
-  // does not support "implication with sequence expression" on the RHS.
-  // Logically equivalent: if length_mismatch fired 2 cycles ago, the key
-  // register must be zero now.
+  // Non-AES clients gate kv_ready on error_code, which is what refuses the op.
+  // AES takes the aes_kv_ready_gen arm (no zeroize support) and instead relies
+  // on error_intr + engine-side op gating, so it is deliberately excluded here.
+`define KV_LEN_OP_BLOCKED(NAME, CLIENT)                                                \
+  `CALIPTRA_ASSERT(KV_``NAME``_not_ready_on_len_err,                                   \
+      (int'(CLIENT.error_code) == KV_ERRC_LEN_MISMATCH) |-> !CLIENT.kv_ready,                  \
+      `SVA_RDC_CLK, ~`SVA_RST)
+
+  `KV_LEN_COVERS(hmac_key,   `HMAC_PATH.hmac_key_kv_read)
+  `KV_LEN_COVERS(ecc_privkey,`ECC_PATH.ecc_privkey_kv_read)
+  `KV_LEN_COVERS(ecc_seed,   `ECC_PATH.ecc_seed_kv_read)
+  `KV_LEN_COVERS(aes_key,    `AES_CLP_PATH.aes_key_kv_read)
+  `KV_LEN_COVERS(mldsa_seed, `ABR_PATH.kv_mldsa_seed_read_inst)
+  `KV_LEN_COVERS(mlkem_seed, `ABR_PATH.kv_mlkem_seed_read_inst)
+  `KV_LEN_COVERS(mlkem_msg,  `ABR_PATH.kv_mlkem_msg_read_inst)
+  `KV_LEN_COVERS(dma_mek,    `AXI_DMA_CTRL_PATH.dma_data_kv_read)
+
+  `KV_LEN_STORED_MATCHES_ENTRY(hmac_key,   `HMAC_PATH.hmac_key_kv_read)
+  `KV_LEN_STORED_MATCHES_ENTRY(ecc_privkey,`ECC_PATH.ecc_privkey_kv_read)
+  `KV_LEN_STORED_MATCHES_ENTRY(ecc_seed,   `ECC_PATH.ecc_seed_kv_read)
+  `KV_LEN_STORED_MATCHES_ENTRY(aes_key,    `AES_CLP_PATH.aes_key_kv_read)
+  `KV_LEN_STORED_MATCHES_ENTRY(mldsa_seed, `ABR_PATH.kv_mldsa_seed_read_inst)
+  `KV_LEN_STORED_MATCHES_ENTRY(mlkem_seed, `ABR_PATH.kv_mlkem_seed_read_inst)
+  `KV_LEN_STORED_MATCHES_ENTRY(mlkem_msg,  `ABR_PATH.kv_mlkem_msg_read_inst)
+  `KV_LEN_STORED_MATCHES_ENTRY(dma_mek,    `AXI_DMA_CTRL_PATH.dma_data_kv_read)
+
+  `KV_LEN_ERR_REACHES_REG(hmac_key,   `HMAC_PATH.hmac_key_kv_read)
+  `KV_LEN_ERR_REACHES_REG(ecc_privkey,`ECC_PATH.ecc_privkey_kv_read)
+  `KV_LEN_ERR_REACHES_REG(ecc_seed,   `ECC_PATH.ecc_seed_kv_read)
+  `KV_LEN_ERR_REACHES_REG(aes_key,    `AES_CLP_PATH.aes_key_kv_read)
+  `KV_LEN_ERR_REACHES_REG(mldsa_seed, `ABR_PATH.kv_mldsa_seed_read_inst)
+  `KV_LEN_ERR_REACHES_REG(mlkem_seed, `ABR_PATH.kv_mlkem_seed_read_inst)
+  `KV_LEN_ERR_REACHES_REG(mlkem_msg,  `ABR_PATH.kv_mlkem_msg_read_inst)
+  `KV_LEN_ERR_REACHES_REG(dma_mek,    `AXI_DMA_CTRL_PATH.dma_data_kv_read)
+
+  `KV_LEN_OP_BLOCKED(hmac_key,   `HMAC_PATH.hmac_key_kv_read)
+  `KV_LEN_OP_BLOCKED(ecc_privkey,`ECC_PATH.ecc_privkey_kv_read)
+  `KV_LEN_OP_BLOCKED(ecc_seed,   `ECC_PATH.ecc_seed_kv_read)
+  `KV_LEN_OP_BLOCKED(mldsa_seed, `ABR_PATH.kv_mldsa_seed_read_inst)
+  `KV_LEN_OP_BLOCKED(mlkem_seed, `ABR_PATH.kv_mlkem_seed_read_inst)
+  `KV_LEN_OP_BLOCKED(mlkem_msg,  `ABR_PATH.kv_mlkem_msg_read_inst)
+  `KV_LEN_OP_BLOCKED(dma_mek,    `AXI_DMA_CTRL_PATH.dma_data_kv_read)
+
+  // -----------------------------------------------------------------
+  // Deferred-check consumers: cross the check against the runtime size
+  // -----------------------------------------------------------------
+  // HMAC and AES use LEN_CHECK_AT_KEY_USE=1 precisely because the expected
+  // size is programmed AFTER the KV read completes. An aggregate mismatch
+  // cover does not prove the check tracks the mode/key_len register, so each
+  // programmable size gets its own match and mismatch bin.
+
+  KV_hmac_key_len_mismatch_mode384_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `HMAC_PATH.hmac_key_kv_read.length_mismatch && (`HMAC_PATH.mode_reg != hmac_param_pkg::HMAC512_MODE));
+  KV_hmac_key_len_mismatch_mode512_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `HMAC_PATH.hmac_key_kv_read.length_mismatch && (`HMAC_PATH.mode_reg == hmac_param_pkg::HMAC512_MODE));
+  KV_hmac_key_len_match_mode384_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `HMAC_PATH.hmac_key_kv_read.len_check_gen.length_check_trigger &&
+      !`HMAC_PATH.hmac_key_kv_read.length_mismatch && (`HMAC_PATH.mode_reg != hmac_param_pkg::HMAC512_MODE));
+  KV_hmac_key_len_match_mode512_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `HMAC_PATH.hmac_key_kv_read.len_check_gen.length_check_trigger &&
+      !`HMAC_PATH.hmac_key_kv_read.length_mismatch && (`HMAC_PATH.mode_reg == hmac_param_pkg::HMAC512_MODE));
+
+  KV_aes_key_len_mismatch_128_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `AES_CLP_PATH.aes_key_kv_read.length_mismatch &&
+      (`AES_CLP_PATH.aes_expected_key_size == KV_ENTRY_SIZE_W'(aes_pkg::AES128_KV_LAST_DWORD)));
+  KV_aes_key_len_mismatch_192_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `AES_CLP_PATH.aes_key_kv_read.length_mismatch &&
+      (`AES_CLP_PATH.aes_expected_key_size == KV_ENTRY_SIZE_W'(aes_pkg::AES192_KV_LAST_DWORD)));
+  KV_aes_key_len_mismatch_256_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `AES_CLP_PATH.aes_key_kv_read.length_mismatch &&
+      (`AES_CLP_PATH.aes_expected_key_size == KV_ENTRY_SIZE_W'(aes_pkg::AES256_KV_LAST_DWORD)));
+  KV_aes_key_len_match_128_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `AES_CLP_PATH.aes_key_kv_read.len_check_gen.length_check_trigger &&
+      !`AES_CLP_PATH.aes_key_kv_read.length_mismatch &&
+      (`AES_CLP_PATH.aes_expected_key_size == KV_ENTRY_SIZE_W'(aes_pkg::AES128_KV_LAST_DWORD)));
+  KV_aes_key_len_match_192_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `AES_CLP_PATH.aes_key_kv_read.len_check_gen.length_check_trigger &&
+      !`AES_CLP_PATH.aes_key_kv_read.length_mismatch &&
+      (`AES_CLP_PATH.aes_expected_key_size == KV_ENTRY_SIZE_W'(aes_pkg::AES192_KV_LAST_DWORD)));
+  KV_aes_key_len_match_256_C: cover property (
+      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
+      `AES_CLP_PATH.aes_key_kv_read.len_check_gen.length_check_trigger &&
+      !`AES_CLP_PATH.aes_key_kv_read.length_mismatch &&
+      (`AES_CLP_PATH.aes_expected_key_size == KV_ENTRY_SIZE_W'(aes_pkg::AES256_KV_LAST_DWORD)));
+
+  // -----------------------------------------------------------------
+  // Consumer-side clear-down on mismatch
+  // -----------------------------------------------------------------
+  // mismatch cycle N -> error_code registers cycle N+1 -> hwclr cycle N+1 ->
+  // consumer key register zero cycle N+2. Expressed via $past(..., 2) instead
+  // of |-> ##2 because Verilator does not support an implication with a
+  // sequence expression on the RHS.
   `CALIPTRA_ASSERT(KV_hmac_key_cleared_on_mismatch,
       $past(`HMAC_PATH.hmac_key_kv_read.length_mismatch, 2) |-> (`HMAC_PATH.key_reg == '0),
       `SVA_RDC_CLK, ~`SVA_RST)
@@ -1557,71 +1710,4 @@ module caliptra_top_sva
   `CALIPTRA_ASSERT(KV_ecc_len_mismatch_clears_seed,
       $past(`ECC_PATH.ecc_seed_kv_read.length_mismatch, 2) |-> (`ECC_PATH.seed_reg == '0),
       `SVA_RDC_CLK, ~`SVA_RST)
-
-  // Covers: each consumer exercises both match and mismatch.
-  KV_hmac_len_match_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      (`HMAC_PATH.init_reg || `HMAC_PATH.next_reg) && `HMAC_PATH.kv_key_data_present && !`HMAC_PATH.hmac_key_kv_read.length_mismatch);
-  KV_hmac_len_mismatch_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `HMAC_PATH.hmac_key_kv_read.length_mismatch);
-  KV_ecc_privkey_len_match_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      |`ECC_PATH.cmd_reg && `ECC_PATH.kv_key_data_present && !`ECC_PATH.ecc_privkey_kv_read.length_mismatch);
-  KV_ecc_privkey_len_mismatch_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `ECC_PATH.ecc_privkey_kv_read.length_mismatch);
-  KV_ecc_seed_len_match_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      |`ECC_PATH.cmd_reg && `ECC_PATH.kv_seed_data_present && !`ECC_PATH.ecc_seed_kv_read.length_mismatch);
-  KV_ecc_seed_len_mismatch_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `ECC_PATH.ecc_seed_kv_read.length_mismatch);
-
-  // AES key path — length check deferred to key-use (LEN_CHECK_AT_KEY_USE=1).
-  // check_key_size pulses on kv_key_done | keymgr_key.valid.
-  KV_aes_len_match_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `CPTRA_TOP_PATH.aes_inst.aes_key_kv_read.check_key_size &&
-      !`CPTRA_TOP_PATH.aes_inst.aes_key_kv_read.length_mismatch);
-  KV_aes_len_mismatch_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `CPTRA_TOP_PATH.aes_inst.aes_key_kv_read.length_mismatch);
-
-  // MLDSA seed path
-  KV_mldsa_seed_len_match_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `ABR_PATH.kv_mldsa_seed_read_inst.read_done &&
-      !`ABR_PATH.kv_mldsa_seed_read_inst.length_mismatch);
-  KV_mldsa_seed_len_mismatch_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `ABR_PATH.kv_mldsa_seed_read_inst.length_mismatch);
-
-  // MLKEM seed path
-  KV_mlkem_seed_len_match_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `ABR_PATH.kv_mlkem_seed_read_inst.read_done &&
-      !`ABR_PATH.kv_mlkem_seed_read_inst.length_mismatch);
-  KV_mlkem_seed_len_mismatch_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `ABR_PATH.kv_mlkem_seed_read_inst.length_mismatch);
-
-  // MLKEM msg path
-  KV_mlkem_msg_len_match_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `ABR_PATH.kv_mlkem_msg_read_inst.read_done &&
-      !`ABR_PATH.kv_mlkem_msg_read_inst.length_mismatch);
-  KV_mlkem_msg_len_mismatch_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `ABR_PATH.kv_mlkem_msg_read_inst.length_mismatch);
-
-  // DMA key-release path (MEK)
-  KV_dma_len_match_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `AXI_DMA_CTRL_PATH.dma_data_kv_read.read_done &&
-      !`AXI_DMA_CTRL_PATH.dma_data_kv_read.length_mismatch);
-  KV_dma_len_mismatch_C: cover property (
-      @(posedge `SVA_RDC_CLK) disable iff (~`SVA_RST)
-      `AXI_DMA_CTRL_PATH.dma_data_kv_read.length_mismatch);
-
 endmodule

--- a/src/keyvault/rtl/kv_read_client.sv
+++ b/src/keyvault/rtl/kv_read_client.sv
@@ -54,7 +54,6 @@ module kv_read_client
     input  logic [KV_ENTRY_SIZE_W-1:0] expected_key_size
 );
 
-logic [KV_ENTRY_SIZE_W-1:0] stored_last_dword;
 logic length_mismatch;
 
 logic validated_read_en;
@@ -146,26 +145,51 @@ generate
     end
 endgenerate
 
-// Latch the addressed KV entry's stored last_dword during the read.
-// Sourced from the readmux (kv_resp.entry_last_dword) — independent of the
-// consumer's own DATA_WIDTH, so a consumer whose read window does not reach
-// the entry's true end still sees the correct stored size.
-always_ff @(posedge clk or negedge rst_b) begin
-    if (!rst_b)              stored_last_dword <= '0;
-    else if (zeroize)        stored_last_dword <= '0;
-    else if (write_en)       stored_last_dword <= kv_resp.entry_last_dword;
-end
+// Length-mismatch detection.
+//
+// Structurally elaborated only for consumers that request the check
+// (LEN_CHECK != 0) and only for the trigger the consumer selected. Coverage
+// rationale: a parameter-gated `always_comb` would leave permanently
+// unreachable condition/branch bins in every non-checking instance and an
+// unreachable arm of the trigger select in *every* instance, which then get
+// papered over with coverage exclusions. Generating the logic away instead
+// means every remaining line/cond/branch bin in this file is genuinely
+// reachable in the instance that owns it.
+generate
+    if (LEN_CHECK != 0) begin : len_check_gen
+        logic [KV_ENTRY_SIZE_W-1:0] stored_last_dword;
+        logic                       length_check_trigger;
 
-logic length_check_trigger;
-always_comb length_check_trigger = (LEN_CHECK_AT_KEY_USE != 0) ? check_key_size
-                                                              : read_done;
+        // Latch the addressed KV entry's stored last_dword during the read.
+        // Sourced from the readmux (kv_resp.entry_last_dword) — independent of
+        // the consumer's own DATA_WIDTH, so a consumer whose read window does
+        // not reach the entry's true end still sees the correct stored size.
+        always_ff @(posedge clk or negedge rst_b) begin
+            if (!rst_b)        stored_last_dword <= '0;
+            else if (zeroize)  stored_last_dword <= '0;
+            else if (write_en) stored_last_dword <= kv_resp.entry_last_dword;
+        end
 
-// Length-mismatch: consumer requires a KV entry of at least `expected_key_size`
-// dwords. A larger entry is accepted. A smaller entry triggers the
-// error and refuses the op. Once error_code latches KV_RD_LEN_MISMATCH the
-// mux self-holds until rst_b/zeroize (same discipline as KV_READ_FAIL).
-always_comb length_mismatch = (LEN_CHECK != 0) && length_check_trigger &&
-                              (stored_last_dword < expected_key_size);
+        if (LEN_CHECK_AT_KEY_USE != 0) begin : at_key_use_gen
+            // Consumer's expected length is only known when the engine commits
+            // to using the key (HMAC mode_reg / AES key_len are programmable
+            // after the KV read completes).
+            always_comb length_check_trigger = check_key_size;
+        end else begin : at_read_done_gen
+            always_comb length_check_trigger = read_done;
+        end
+
+        // Consumer requires a KV entry of at least `expected_key_size` dwords.
+        // A larger entry is accepted (safe prefix read). A smaller entry raises
+        // the error and refuses the op. Once error_code latches
+        // KV_RD_LEN_MISMATCH the mux self-holds until rst_b/zeroize (same
+        // discipline as KV_READ_FAIL).
+        always_comb length_mismatch = length_check_trigger &&
+                                      (stored_last_dword < expected_key_size);
+    end else begin : no_len_check_gen
+        always_comb length_mismatch = 1'b0;
+    end
+endgenerate
 
 `CALIPTRA_ASSERT_KNOWN(READ_METRICS_X,  read_metrics, clk, !rst_b)
 


### PR DESCRIPTION
Follow-up to #1353. That PR added the KV read-side key-length-mismatch
check and SVA for it. This PR makes the coverage for it per-consumer and
removes the structural pressure to exclude any of it.

### Why

Nothing is excluded today — there are no `.el` files, `vcs_cov_excl_files`
is empty, and the Makefile flow runs `-cm line+cond+fsm+tgl+branch+assert`.
The problem was not missing numbers, it was numbers that look better than
they are.

**1. VCS merges the eight checking instances into one condition group.**
Measured on a `caliptra_top_tb` coverage run:

```
Cond Coverage for Module : \RTL.kv_read_client
  ( DATA_WIDTH=384,...,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=0
  + DATA_WIDTH=512,...,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=1
  + DATA_WIDTH=256,...,AES=1,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=1
  + DATA_WIDTH=256,...,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=0
  + DATA_WIDTH=512,...,LEN_CHECK=1,LEN_CHECK_AT_KEY_USE=0 )

  EXPRESSION (length_check_trigger && (stored_last_dword < expected_key_size))
  -1- -2- Status
   0   1  Covered
   1   0  Not Covered
   1   1  Covered
```

One `smoke_test_kv_len_mismatch_hmac` run marks the mismatch bin covered
for HMAC, ECC (x2), AES, ABR (x3) and DMA simultaneously. The existing SVA
leaned on exactly this, checking HMAC as "representative of all
kv_read_client instances".

**2. `LEN_CHECK=0` instances carried unreachable bins.** The check was a
parameter-gated `always_comb`, so `sha512_block_kv_read` and
`hmac_block_kv_read` had permanently dead terms, and the
`LEN_CHECK_AT_KEY_USE` ternary had a dead arm in *every* instance. Those
are the bins that eventually get a blanket exclusion — which would then
also hide real holes in the check.

### What changed

- **`kv_read_client.sv`** — length-check logic moved into a `generate`,
  elaborated only for `LEN_CHECK != 0` and only for the selected trigger.
  Every remaining bin is reachable in the instance that owns it, so no
  exclusion file is needed. No functional change.
- **`caliptra_top_sva.sv`** — macro-driven bin set applied uniformly to
  every checking consumer: comparator fired, `error_code` latched, and the
  accept paths (match / exact boundary / larger entry). HMAC crossed
  against `mode_reg`, AES against `key_len`, since those two program the
  expected size after the read completes. 50 covers, 26 assertions.
  Error codes compared via `localparam int` mirrors to avoid `DTIE` (the
  enum is elaborated into both `RTL.` and `TB.` scopes).
- **Spec** — records which consumers skip the check and why, the measured
  merging, and that the cover properties rather than condition coverage
  are the sign-off evidence.

### Validation

- `pb fe build --tb integration_lib::caliptra_top_tb` — 0 errors, 0 warnings.
- `smoke_test_kv_len_mismatch_{hmac,ecc,aes,abr,dma}` — all PASSED, no new
  assertion firings.
- `smoke_test_kv_hmac_flow`, `smoke_test_kv_ecc_flow1`,
  `smoke_test_aes_kv_rand`, `smoke_test_kv_mldsa`, `smoke_test_dma_aes_kv`
  — all PASSED.
- Coverage run + `urg`: all 50 covers confirmed present as
  `caliptra_top_tb.sva.KV_*_len_*_C`. `caliptra_top_sva` sits outside the
  `+tree ...caliptra_top_dut` cm_hier scope, but that `begin` block lists
  only `line+tgl+fsm+cond+branch`, so `assert` is unscoped and collected
  design-wide. Left the cfg alone and documented the invariant.

The five directed tests are already in the nightly random regression at
weight 100 with `generations: 2000`, so the accept-path and AES-192 bins
fill from existing seeds without new tests.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>