### PR TITLE
[ENV] Add CODEOWNERS file: cherry-pick: PR1237 to patch v2.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+#############################################
+#    Caliptra RTL Code Owners               #
+#############################################
+
+# compilespecs.yml and compile.yml are used in Microsoft
+# internal build processes; edits must be approved by Microsoft
+# reps
+compilespecs.yml @Nitsirks @mojtaba-bisheh @upadhyayulakiran @ekarabu @clayton8 @calebofearth
+compile.yml @Nitsirks @mojtaba-bisheh @upadhyayulakiran @ekarabu @clayton8 @calebofearth

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,6 @@
 # reps
 compilespecs.yml @Nitsirks @mojtaba-bisheh @upadhyayulakiran @ekarabu @clayton8 @calebofearth
 compile.yml @Nitsirks @mojtaba-bisheh @upadhyayulakiran @ekarabu @clayton8 @calebofearth
+
+# CAVP verification guide is owned by its author
+docs/CaliptraCAVP_guide.md @ravithakurAMD

--- a/.github/scripts/license_header_check.sh
+++ b/.github/scripts/license_header_check.sh
@@ -78,7 +78,7 @@ exclude_dir='{uvmf*,.git,cmark,caliptra_reg_html,caliptra_top_reg_html,sha256,sh
 exclude_suffix='*.{tcl,txt,js,htm,html,json,vf,yml,woff,rsp,rdl,bashrc,waiver,cfg,hex,rc,exe,pdf,png,hvp,svg,log}'
 exclude_regs='*_reg*.{sv,rdl}'
 exclude_csr='*_csr*.*'
-exclude_file='{sglint_waivers,pr_hash,pr_timestamp,.git,.git-comodules,.gitignore,.gitmodules,spyglass_lint.policy,ascent.ctl,clp_mapfile,readme.md,README.md,SECURITY.md,CONTRIBUTING.md,c_sample.c,test_dilithium5,riscv_rev_info,caliptra_tlul_rev_info,aes_rev_info}'
+exclude_file='{sglint_waivers,pr_hash,pr_timestamp,.git,.git-comodules,.gitignore,.gitmodules,spyglass_lint.policy,ascent.ctl,clp_mapfile,readme.md,README.md,SECURITY.md,CONTRIBUTING.md,CODEOWNERS,c_sample.c,test_dilithium5,riscv_rev_info,caliptra_tlul_rev_info,aes_rev_info}'
 apache_patn='Licensed under the Apache License\|Apache License, Version 2\.0 (the \"License\")'
 
 # Recursive find through repository with some major exclusions

--- a/.github/workflows/pre-run-check.yml
+++ b/.github/workflows/pre-run-check.yml
@@ -21,70 +21,7 @@ on:
         description: "Control parameter indicating if Verilator tests should be run or skipped"
         value: ${{ jobs.evaluate_if_run.outputs.run_vltr }}
 
-env:
-  MSFT_ACTORS: ( "Nitsirks" "calebofearth" "mojtaba-bisheh" "anjpar" "upadhyayulakiran" "nileshbpat" "ekarabu" "marnovandermaas" "andrea-caforio" "h-filali" "clayton8" )
-
 jobs:
-  # Fail if any compile.yml has been modified
-  # (Microsoft employees use these to run an internal tool)
-  # Don't run this job for manual runs
-  compile_yml_check:
-    name: compile.yml Check
-    runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Checkout RTL repo
-        uses: actions/checkout@v4
-        with:
-            fetch-depth: 0
-            submodules: 'true'
-      - name: Compare against target
-        env:
-            PR_OPENER:   ${{ github.event.pull_request.user.login }}
-            SOURCE_BR:   ${{ github.event.pull_request.head.ref }}
-            SOURCE_FORK: ${{ github.event.pull_request.head.repo.fork }}
-            SOURCE_OWN:  ${{ github.event.pull_request.head.repo.owner.login }}
-            SOURCE_URL:  ${{ github.event.pull_request.head.repo.clone_url }}
-            TARGET_BR:   ${{ github.event.pull_request.base.ref }}
-        run: |
-            local_msft_actors=${{ env.MSFT_ACTORS }}
-            for msft_actor in "${local_msft_actors[@]}"; do
-              if [[ "${PR_OPENER}" == "${msft_actor}" ]]; then
-                echo "Skipping check on compile.yml modifications for detected Microsoft contributor: ${msft_actor}"
-                exit 0
-              fi
-            done
-            echo "git fetch origin $TARGET_BR"
-            if ! git fetch origin $TARGET_BR; then
-              echo "git fetch failed\!"
-              exit 1
-            fi
-            if [[ "${SOURCE_FORK}" == "true" ]]; then
-              echo "pull request is from a fork: ${SOURCE_FORK}"
-              echo "fork repository owner is ${SOURCE_OWN}"
-              echo "adding remote '${SOURCE_OWN}' at url '${SOURCE_URL}'"
-              git remote add -f ${SOURCE_OWN} ${SOURCE_URL}
-              SOURCE_REMOTE=${SOURCE_OWN}
-            else
-              SOURCE_REMOTE=origin
-            fi
-            echo "git fetch ${SOURCE_REMOTE} $SOURCE_BR"
-            if ! git fetch ${SOURCE_REMOTE} $SOURCE_BR; then
-              echo "git fetch failed\!"
-              exit 1
-            fi
-            echo "target ref for [origin/${TARGET_BR}] is $(git log -n1 --pretty=tformat:'%H' origin/${TARGET_BR} 2> /dev/null)"
-            echo "source ref for [${SOURCE_REMOTE}/${SOURCE_BR}] is $(git log -n1 --pretty=tformat:'%H' ${SOURCE_REMOTE}/${SOURCE_BR} 2> /dev/null)"
-            echo "Comparing $SOURCE_REMOTE/$SOURCE_BR against merge target origin/$TARGET_BR to look for compile.yml"
-            compiles=$(git diff --name-only $(git log -n1 --pretty=tformat:'%H' "origin/$TARGET_BR")...$(git log -n1 --pretty=tformat:'%H' "${SOURCE_REMOTE}/${SOURCE_BR}"))
-            if [[ $(grep -c compile.yml <<< "$compiles") -gt 0 ]]; then
-                echo "compile.yml should not be modified for pull requests! Found:"
-                echo "$compiles"
-                exit 1
-            else
-                echo "Found no modifications to compile.yml"
-            fi
-
   # Build the comparison hash file
   hash_check:
     name: Hash Check


### PR DESCRIPTION
Cherry-pick of #1237 (`1f44cb32`) onto `patch_v2.1`, plus a CODEOWNERS entry for the CAVP guide.

Add CODEOWNERS file, remove the compile.yml check from the PR validation workflow, and move that authority to codeowners for review.

Changes:
- Add `.github/CODEOWNERS` guarding `compilespecs.yml` / `compile.yml`
- Remove the `compile_yml_check` job (and the now-unused `MSFT_ACTORS` env) from `.github/workflows/pre-run-check.yml`
- Exclude `CODEOWNERS` from the license header check
- Add @ravithakurAMD as codeowner for `docs/CaliptraCAVP_guide.md` only (file lands via #1362)

Conflicts resolved: `.github/workflow_metadata/pr_hash` and `pr_timestamp` kept at the branch's existing values (pipeline-generated stamps).