### PR TITLE
[RDL] Fix CSRNG write semantics

### DIFF
--- a/.github/scripts/pr_rdl_check.sh
+++ b/.github/scripts/pr_rdl_check.sh
@@ -49,8 +49,10 @@ done
 patn=$(echo "${gen_rtl_list[@]}" | sed 's, ,\\\|,g')
 
 # Find file modifications
-rdl_mod_count=$(git diff --merge-base "${merge_dest}" --name-only | grep -c -e '\.rdl$\|tools\/templates\/rdl\|reg_gen.sh\|reg_gen.py\|reg_doc_gen.sh\|reg_doc_gen.py' -e "${patn}" || exit 0)
+rdl_mod_count=$(git diff --merge-base "${merge_dest}" --name-only | grep -c -e '\.rdl$\|tools\/templates\/rdl\|reg_gen.sh\|reg_gen.py\|reg_json.py\|reg_doc_gen.sh\|reg_doc_gen.py\|tools\/scripts\/tests\/test_reg_json.py' -e "${patn}" || exit 0)
 if [[ "${rdl_mod_count}" -gt 0 ]]; then
+    python3 "${CALIPTRA_ROOT}/tools/scripts/tests/test_reg_json.py"
+
     # Run the HTML Doc generator script (to update the REG macro header files)
     # and the individual reg generator script but then remove the docs directories
     bash "${CALIPTRA_ROOT}/tools/scripts/reg_gen.sh"

--- a/src/csrng/data/csrng.rdl
+++ b/src/csrng/data/csrng.rdl
@@ -24,22 +24,18 @@ addrmap csrng {
     reg {
         field {
             sw = rw;
-            onwrite = woclr;
             desc = "Enable interrupt when cs_cmd_req_done is set.";
         } CS_CMD_REQ_DONE[0:0];
         field {
             sw = rw;
-            onwrite = woclr;
             desc = "Enable interrupt when cs_entropy_req is set.";
         } CS_ENTROPY_REQ[1:1];
         field {
             sw = rw;
-            onwrite = woclr;
             desc = "Enable interrupt when cs_hw_inst_exc is set.";
         } CS_HW_INST_EXC[2:2];
         field {
             sw = rw;
-            onwrite = woclr;
             desc = "Enable interrupt when cs_fatal_err is set.";
         } CS_FATAL_ERR[3:3];
     } INTERRUPT_ENABLE @ 0x4;
@@ -76,7 +72,7 @@ addrmap csrng {
             desc = "When true, all writeable registers can be modified.
             When false, they become read-only.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } REGWEN[0:0] = 0x1;
     } REGWEN @ 0x10;
     reg {
@@ -231,7 +227,7 @@ addrmap csrng {
             desc = "INT_STATE_READ_ENABLE register configuration enable bit.
             If this is cleared to 0, the INT_STATE_READ_ENABLE register cannot be written anymore.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } INT_STATE_READ_ENABLE_REGWEN[0:0] = 0x1;
     } INT_STATE_READ_ENABLE_REGWEN @ 0x3C;
     reg {
@@ -283,7 +279,7 @@ addrmap csrng {
             to the SW instance, check the !!SW_CMD_STS register). Writing a zero to this register
             resets the status bits.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } HW_EXC_STS[15:0];
     } HW_EXC_STS @ 0x4C;
     reg {
@@ -292,41 +288,41 @@ addrmap csrng {
             a value other than kMultiBitBool4True or kMultiBitBool4False.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } ENABLE_FIELD_ALERT[0:0];
         field {
             desc = "This bit is set when the SW_APP_ENABLE field in the !!CTRL register is set to
             a value other than kMultiBitBool4True or kMultiBitBool4False.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } SW_APP_ENABLE_FIELD_ALERT[1:1];
         field {
             desc = "This bit is set when the READ_INT_STATE field in the !!CTRL register is set to
             a value other than kMultiBitBool4True or kMultiBitBool4False.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } READ_INT_STATE_FIELD_ALERT[2:2];
         field {
             desc = "This bit is set when the FIPS_FORCE_ENABLE field in the !!CTRL register is set to a value other than kMultiBitBool4True or kMultiBitBool4False.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } FIPS_FORCE_ENABLE_FIELD_ALERT[3:3];
         field {
             desc = "This bit is set when the FLAG0 field in the Application Command is set to
             a value other than kMultiBitBool4True or kMultiBitBool4False.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } ACMD_FLAG0_FIELD_ALERT[4:4];
         field {
             desc = "This bit is set when the software application port genbits bus value is equal
             to the prior valid value on the bus, indicating a possible attack.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } CS_BUS_CMP_ALERT[12:12];
         field {
             desc = "This bit is set when an unsupported/illegal CSRNG command is received by the
@@ -334,7 +330,7 @@ addrmap csrng {
             The invalid command is ignored and CSRNG continues to operate.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } CMD_STAGE_INVALID_ACMD_ALERT[13:13];
         field {
             desc = "This bit is set when an out of order command is received by the main state machine.
@@ -344,7 +340,7 @@ addrmap csrng {
             The invalid command is ignored and CSRNG continues to operate.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } CMD_STAGE_INVALID_CMD_SEQ_ALERT[14:14];
         field {
             desc = "This bit is set when the maximum number of generate requests between reseeds is
@@ -352,7 +348,7 @@ addrmap csrng {
             The invalid generate command is ignored and CSRNG continues to operate.
             Writing a zero resets this status bit.";
             sw = rw;
-            onwrite = woclr;
+            onwrite = wzc;
         } CMD_STAGE_RESEED_CNT_ALERT[15:15];
     } RECOV_ALERT_STS @ 0x50;
     reg {

--- a/tools/scripts/reg_json.py
+++ b/tools/scripts/reg_json.py
@@ -110,9 +110,6 @@ class JsonImporter(RDLImporter):
     if access_type == 'rw0c':
       self.assign_property(comp_def, 'sw', AccessType['rw'])
       self.assign_property(comp_def, 'onwrite', OnWriteType['wzc'])
-    if access_type == 'rw0c':
-      self.assign_property(comp_def, 'sw', AccessType['rw'])
-      self.assign_property(comp_def, 'onwrite', OnWriteType['woclr'])
     elif access_type == 'rw':
       self.assign_property(comp_def, 'sw', AccessType['rw'])
     elif access_type == 'ro':
@@ -265,7 +262,6 @@ class JsonImporter(RDLImporter):
       elif addr == 0x4:
         field_desc = 'Enable interrupt when %s is set.' % field_name
         self.assign_property(field_def, 'sw', AccessType['rw'])
-        self.assign_property(field_def, 'onwrite', OnWriteType['woclr'])
       elif addr == 0x8:
         field_desc = 'Write 1 to force %s to 1.' % field_name
         self.assign_property(field_def, 'sw', AccessType['w'])

--- a/tools/scripts/tests/test_reg_json.py
+++ b/tools/scripts/tests/test_reg_json.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from systemrdl import RDLCompiler, RDLListener, RDLWalker
+from systemrdl.node import FieldNode
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reg_json import JsonImporter  # noqa: E402
+
+
+class FieldPropertyListener(RDLListener):
+
+  def __init__(self):
+    self.fields = {}
+
+  def enter_Field(self, node: FieldNode) -> None:
+    key = (node.parent.inst_name, node.inst_name)
+    self.fields[key] = {
+        'sw': self._property_name(node, 'sw'),
+        'onwrite': self._property_name(node, 'onwrite'),
+    }
+
+  @staticmethod
+  def _property_name(node: FieldNode, name: str):
+    value = node.get_property(name)
+    return None if value is None else value.name
+
+
+class JsonImporterAccessTest(unittest.TestCase):
+
+  def test_access_properties(self):
+    register_description = {
+        'name': 'access_probe',
+        'interrupt_list': [{'name': 'irq', 'desc': 'Interrupt.'}],
+        'alert_list': [{'name': 'alert', 'desc': 'Alert.'}],
+        'registers': [
+            {
+                'name': 'ORDINARY_RW',
+                'desc': 'Ordinary read/write.',
+                'swaccess': 'rw',
+                'hwaccess': 'hro',
+                'fields': [{'name': 'VALUE', 'bits': '0', 'desc': 'Value.'}],
+            },
+            {
+                'name': 'WRITE_ZERO_CLEAR',
+                'desc': 'Write zero to clear.',
+                'swaccess': 'rw0c',
+                'hwaccess': 'hrw',
+                'fields': [{'name': 'VALUE', 'bits': '0', 'desc': 'Value.'}],
+            },
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as directory:
+      input_path = Path(directory) / 'access_probe.json'
+      input_path.write_text(json.dumps(register_description), encoding='utf-8')
+
+      compiler = RDLCompiler()
+      JsonImporter(compiler).import_file(str(input_path))
+      root = compiler.elaborate()
+
+    listener = FieldPropertyListener()
+    RDLWalker().walk(root, listener)
+
+    self.assertEqual(
+        listener.fields,
+        {
+            ('INTERRUPT_STATE', 'IRQ'): {'sw': 'rw', 'onwrite': 'woclr'},
+            ('INTERRUPT_ENABLE', 'IRQ'): {'sw': 'rw', 'onwrite': None},
+            ('INTERRUPT_TEST', 'IRQ'): {'sw': 'w', 'onwrite': None},
+            ('ALERT_TEST', 'ALERT'): {'sw': 'w', 'onwrite': None},
+            ('ORDINARY_RW', 'VALUE'): {'sw': 'rw', 'onwrite': None},
+            ('WRITE_ZERO_CLEAR', 'VALUE'): {'sw': 'rw', 'onwrite': 'wzc'},
+        },
+    )
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
- Correct the JSON importer so `rw0c` fields map to SystemRDL `wzc` instead of being overwritten with `woclr`.
- Keep interrupt-enable fields as ordinary read/write while preserving write-one-to-clear interrupt-state behavior.
- Regenerate `csrng.rdl` from the checked-in JSON source so its write semantics match the existing RTL implementation.
- Add a focused importer regression and run it from the existing RDL pull-request gate.

Validation:
- Focused `test_reg_json.py` regression
- Full `pr_rdl_check.sh` regeneration gate
- Deterministic CSRNG RDL semantic-delta check
- Pinned `caliptra-sw` register-generation compatibility at `e7dc50f2282a965281eed349fadb61c2690193ba`

Related to #1308.